### PR TITLE
Multi-sensor pointcloud fusion for local mapping and critical zone checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,11 @@ The package includes modules for mapping, control, trajectory planning, and visi
 
 - Implements efficient local mapping and occupancy grid generation algorithms, with configuration support for various scan models and grid resolution settings.
 - Supports **GPU-accelerated** mapping for real-time performance.
+- Fuses point clouds from **multiple 3D sensors** into a single occupancy grid with per-sensor free-space carving.
 
 ### Utilities Module
 
-- Provides collision checking utilities and critical zone detection to ensure safe navigation, including both CPU and GPU implementations.
+- Provides collision checking utilities and critical zone detection to ensure safe navigation, including both CPU and GPU implementations. Critical zone checking fuses point clouds from **multiple 3D sensors** into one safety decision (minimum factor across sensors).
 - Logger utilities for runtime diagnostics.
 - Linear state-space Kalman filter implementation for state estimation (C++).
 - Spline interpolation utilities for path control.

--- a/src/kompass_core/datatypes/scan_model.py
+++ b/src/kompass_core/datatypes/scan_model.py
@@ -33,8 +33,12 @@ class ScanModelConfig(BaseAttrs):
         Thickness (in meters) beyond the measured range where a cell is assumed to be occupied (e.g., for modeling walls or obstacles).
     max_height : float
         Maximum Z-axis height (in meters) of a point to be considered valid for occupancy updates.
+        For point cloud input this band is applied on the BODY-frame z (each sensor's mount
+        transform is applied to the point first), so it is shared by all sensors — typically
+        ``0 .. robot_height``. For laser scan input the band is not applicable (planar data).
     min_height : float
         Minimum Z-axis height (in meters) of a point to be considered valid for occupancy updates.
+        BODY-frame for point cloud input, see ``max_height``.
     """
 
     p_prior: float = field(

--- a/src/kompass_core/mapping/__init__.py
+++ b/src/kompass_core/mapping/__init__.py
@@ -1,6 +1,9 @@
+from kompass_cpp.types import SensorConfig
+
 from .local_mapper import LocalMapper, MapConfig
 
 __all__ = [
     "LocalMapper",
     "MapConfig",
+    "SensorConfig",
 ]

--- a/src/kompass_core/mapping/local_mapper.py
+++ b/src/kompass_core/mapping/local_mapper.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional, Sequence, Union
 from attrs import define, field, validators
 import math
 import numpy as np
@@ -7,6 +7,7 @@ from ..datatypes.pose import PoseData
 from kompass_cpp.mapping import (
     OCCUPANCY_TYPE,
 )
+from kompass_cpp.types import SensorConfig
 
 from ..utils.geometry import transform_point_from_local_to_global, get_relative_pose
 
@@ -75,7 +76,7 @@ class MapConfig(BaseAttrs):
     padding: float = field(
         default=0.0, validator=base_validators.in_range(min_value=0.0, max_value=10.0)
     )
-    baysian_update: bool = field(default=False)
+    bayesian_update: bool = field(default=False)
     max_num_threads: int = field(default=1, validator=validators.ge(1))
 
     filter_limit: float = field(
@@ -117,6 +118,8 @@ class LocalMapper:
         config: MapConfig,
         scan_model_config: ScanModelConfig,
         pose_laser_scanner_in_robot: Optional[PoseData] = None,
+        *,
+        sensors: Optional[Sequence[Union[PoseData, SensorConfig]]] = None,
     ):
         """Initialize a LocalMapper
 
@@ -124,6 +127,15 @@ class LocalMapper:
         :type config: MapConfig
         :param scan_model_config: LaserScan or PointCloud model config
         :type scan_model_config: ScanModelConfig
+        :param pose_laser_scanner_in_robot: Single-sensor mount pose
+            (mutually exclusive with ``sensors``)
+        :type pose_laser_scanner_in_robot: Optional[PoseData]
+        :param sensors: Multi-sensor mode: one mount per sensor, as PoseData
+            or kompass_cpp.types.SensorConfig (the latter also carries the
+            cloud field encoding). Point clouds are then fused with
+            ``update_from_pointclouds``, one cloud per sensor, positional
+            pairing
+        :type sensors: Optional[Sequence[Union[PoseData, SensorConfig]]]
         """
 
         self.config = config
@@ -148,12 +160,25 @@ class LocalMapper:
 
         self.scan_model = scan_model_config
 
+        # multi sensor config (pointclouds)
+        if sensors is not None:
+            if pose_laser_scanner_in_robot is not None:
+                raise ValueError(
+                    "Pass either 'pose_laser_scanner_in_robot' (single sensor) "
+                    "or 'sensors' (multi-sensor), not both"
+                )
+            if len(sensors) == 0:
+                raise ValueError("'sensors' requires at least one entry")
+            if config.bayesian_update:
+                raise ValueError(
+                    "bayesian_update is not supported with the multi-sensor "
+                    "pipeline ('sensors='); use the single-sensor "
+                    "'pose_laser_scanner_in_robot' argument instead"
+                )
+        self._sensors = list(sensors) if sensors is not None else None
+
         self.pose_laserscanner_in_robot = (
             pose_laser_scanner_in_robot if pose_laser_scanner_in_robot else PoseData()
-        )
-
-        self.laserscan_orientation_in_robot = 2 * np.arctan(
-            self.pose_laserscanner_in_robot.qz / self.pose_laserscanner_in_robot.qw
         )
 
         self.grid_data = GridData(
@@ -185,6 +210,33 @@ class LocalMapper:
         """
         return self.grid_data.occupancy_prob
 
+    @property
+    def num_sensors(self) -> int:
+        """Number of configured sensors"""
+        return len(self._sensors) if self._sensors is not None else 1
+
+    def _sensor_configs(self) -> List[SensorConfig]:
+        """Builds the per-sensor mount configs passed to the cpp mapper.
+
+        The full mount quaternion is forwarded (roll/pitch honored on the
+        pointcloud path; the laserscan path consumes the mount as planar).
+        """
+
+        def _to_config(sensor) -> SensorConfig:
+            if isinstance(sensor, SensorConfig):
+                return sensor
+            return SensorConfig(
+                position=sensor.get_position(),
+                rotation=np.array(
+                    [sensor.qx, sensor.qy, sensor.qz, sensor.qw],
+                    dtype=np.float32,
+                ),
+            )
+
+        if self._sensors is not None:
+            return [_to_config(sensor) for sensor in self._sensors]
+        return [_to_config(self.pose_laserscanner_in_robot)]
+
     def _initialize_mapper(self, scan_size: int) -> None:
         """Initialize cpp local mapper"""
         try:
@@ -194,11 +246,9 @@ class LocalMapper:
                 grid_height=self.grid_height,
                 grid_width=self.grid_width,
                 resolution=self.config.resolution,
-                laserscan_position=self.pose_laserscanner_in_robot.get_position(),
-                laserscan_orientation=self.laserscan_orientation_in_robot,
+                sensor_configs=self._sensor_configs(),
                 is_pointcloud=self.is_pointcloud,
                 scan_size=scan_size,
-                angle_step=self.scan_model.angle_step,
                 max_height=self.scan_model.max_height,
                 min_height=self.scan_model.min_height,
                 range_max=self.scan_model.range_max,
@@ -207,15 +257,18 @@ class LocalMapper:
         except ImportError:
             from kompass_cpp.mapping import LocalMapper as LocalMapperCpp
 
+            # angle_step only used to derive scan_size for pointclouds, not used
+            # in cpp ctor
+            scan_model_params = self.scan_model.asdict()
+            scan_model_params.pop("angle_step", None)
             self.local_mapper = LocalMapperCpp(
                 grid_height=self.grid_height,
                 grid_width=self.grid_width,
                 resolution=self.config.resolution,
-                laserscan_position=self.pose_laserscanner_in_robot.get_position(),
-                laserscan_orientation=self.laserscan_orientation_in_robot,
+                sensor_configs=self._sensor_configs(),
                 is_pointcloud=self.is_pointcloud,
                 scan_size=scan_size,
-                **self.scan_model.asdict(),
+                **scan_model_params,
                 max_points_per_line=self.config.max_points_per_line,
                 max_num_threads=self.config.max_num_threads,
             )
@@ -261,6 +314,11 @@ class LocalMapper:
         :param angles: Angle of each range measurement (rad)
         :type angles: np.ndarray
         """
+        if self.num_sensors > 1:
+            raise NotImplementedError(
+                "Multi-sensor LaserScan fusion is not supported; configure "
+                "multiple sensors with point cloud input"
+            )
         if not self.processed:
             self.is_pointcloud = False
             self._initialize_mapper(ranges.size)
@@ -320,15 +378,19 @@ class LocalMapper:
         :param z_offset: Byte offset of the 'z' field within a point
         :type z_offset: int
         """
+        if self.num_sensors > 1:
+            raise RuntimeError(
+                "This mapper is configured with multiple sensors; use "
+                "update_from_pointclouds instead"
+            )
         if not self.processed:
             self.is_pointcloud = True
             # NOTE: `angle_step` is the canonical knob on the Python side; the
             # bin count is derived from it with a ceil so every angle in
-            # [0, 2π) lands in a valid bin. The C++ ctor then enforces
-            # the inverse relation `angle_step = 2π / scan_size` so the
-            # conversion kernel (which bins by `scan_size`) and the
-            # ray-cast kernel (which reads `initializedAngles[i] =
-            # i * angle_step`) can't drift apart.
+            # [0, 2π) lands in a valid bin. The cpp mapping kernels derive their
+            # step as `2π / scan_size`, so the two can't drift apart by construction.
+            # The effective step is therefore marginally finer than the requested
+            # one whenever 2π isn't an exact multiple of it.
             self._initialize_mapper(math.ceil(2 * np.pi / self.scan_model.angle_step))
 
         self._move_grid_to(robot_pose)
@@ -344,6 +406,44 @@ class LocalMapper:
             z_offset=z_offset,
         )
 
+    def update_from_pointclouds(
+        self,
+        robot_pose: PoseData,
+        *,
+        clouds: Sequence,
+    ):
+        """
+        Update the local map by fusing one point cloud per configured sensor
+
+        ``clouds[i]`` pairs with the i-th configured sensor (positional
+        pairing). Each element is a dict and ``None`` means the sensor
+        contributed no data this tick.
+
+        :param robot_pose: Current robot position
+        :type robot_pose: PoseData
+        :param clouds: One cloud (or None) per configured sensor
+        :type clouds: Sequence
+        """
+        if self._sensors is None:
+            raise RuntimeError(
+                "update_from_pointclouds requires the mapper to be "
+                "constructed with 'sensors='"
+            )
+        if len(clouds) != self.num_sensors:
+            raise ValueError(
+                f"Expected {self.num_sensors} clouds (one per configured "
+                f"sensor), got {len(clouds)}"
+            )
+        if not self.processed:
+            self.is_pointcloud = True
+            # NOTE: (see update_from_pointcloud), cpp kernels derive their bin
+            # step from scan_size
+            scan_size = math.ceil(2 * np.pi / self.scan_model.angle_step)
+            self._initialize_mapper(scan_size)
+
+        self._move_grid_to(robot_pose)
+        self._update_grid(clouds=list(clouds))
+
     def _move_grid_to(self, robot_pose: PoseData) -> None:
         """Re-center the grid around a new robot pose
 
@@ -357,7 +457,7 @@ class LocalMapper:
 
         # Get transformation between the previous robot state (pose and grid)
         # w.r.t the current state.
-        if self.config.baysian_update and self.processed:
+        if self.config.bayesian_update and self.processed:
             self._calculate_grid_shift(robot_pose)
 
     def _update_grid(self, **scan) -> None:
@@ -367,9 +467,9 @@ class LocalMapper:
             overload: ``angles``/``ranges`` for a laser scan, or the raw buffer
             and its layout for a point cloud
         """
-        if self.config.baysian_update:
-            scan_occupancy, scan_occupancy_prob = self.local_mapper.scan_to_grid_baysian(
-                **scan
+        if self.config.bayesian_update:
+            scan_occupancy, scan_occupancy_prob = (
+                self.local_mapper.scan_to_grid_bayesian(**scan)
             )
 
             # Update grids in place, copy into preallocated storage
@@ -391,9 +491,7 @@ class LocalMapper:
 
         else:
             # Update grid in place
-            np.copyto(
-                self.grid_data.occupancy, self.local_mapper.scan_to_grid(**scan)
-            )
+            np.copyto(self.grid_data.occupancy, self.local_mapper.scan_to_grid(**scan))
 
         # flag to enable fetching the mapping data
         self.processed = True

--- a/src/kompass_cpp/benchmarks/README.md
+++ b/src/kompass_cpp/benchmarks/README.md
@@ -14,13 +14,16 @@ We benchmark three critical components of the navigation stack:
     - **Stress Factor:** Massive parallel trajectory rollout and reduction.
 
 2.  **Local Mapper (Occupancy Grid)**
-    - **Workload:** Raycasts a dense LiDAR scan (3,600 points) into a $400 \times 400$ grid ($20m \times 20m$ @ $5cm$ resolution).
+    - **Scenario A (LaserScan):** Raycasts a dense LiDAR scan (3,600 points) into a $400 \times 400$ grid ($20m \times 20m$ @ $5cm$ resolution).
+    - **Scenario B (PointCloud, GPU builds):** Converts a raw 100,000-point cloud on device (byte buffer → per-angle-bin pseudo-laserscan) and raycasts it into the same grid.
+    - **Scenario C (Multi-sensor fusion, GPU builds):** Two 50,000-point clouds from a front + back mount fused into one grid through the batched entry — same total points as Scenario B, plus the second sensor's raycast pass (per-sensor free-space carving requires one pass per origin).
     - **Metric:** Time to update occupancy probabilities for the entire grid.
     - **Stress Factor:** Random memory access patterns and ray traversal.
 
 3.  **Critical Zone Checker (Safety System)**
     - **Scenario A (PointCloud):** Checks a dense 3D point cloud (100,000 points) against the robot's safety footprint.
-    - **Scenario B (LaserScan):** Checks a high-res 2D laser scan (3,600 rays) where points fall within the "slowdown" zone to force worst-case evaluation logic. This component is light-weight and highly optimized on the CPU, so performance gains are expected to be marginal. Use of the GPU is not default behaviour and left to the user.
+    - **Scenario B (Multi-sensor fusion):** Two 50,000-point clouds from a front + back mount through the batched entry (minimum factor across sensors) — same total points as Scenario A, one extra kernel submit.
+    - **Scenario C (LaserScan):** Checks a high-res 2D laser scan (3,600 rays) where points fall within the "slowdown" zone to force worst-case evaluation logic. This component is light-weight and highly optimized on the CPU, so performance gains are expected to be marginal. Use of the GPU is not default behaviour and left to the user.
     - **Metric:** Latency to return a safety factor $[0.0, 1.0]$.
     - **Stress Factor:** High-throughput collision checking.
 

--- a/src/kompass_cpp/benchmarks/benchmark_runner.cpp
+++ b/src/kompass_cpp/benchmarks/benchmark_runner.cpp
@@ -201,17 +201,17 @@ int main(int argc, char *argv[]) {
     // and large enough for the longest ray here (range 3-7 m / res 0.05 m
     // = 60-140 cells) to reach its endpoint so OCCUPIED cells actually
     // get stamped
-    Mapping::LocalMapperGPU mapper(height, width, res, {0.0, 0.0, 0.0}, 0.0,
-                                   false, /*scan_size*/ 3600, 0.01, 2.0, 0.0,
-                                   20.0, /*max_points_per_line*/ 256);
+    Mapping::LocalMapperGPU mapper(height, width, res, {SensorConfig{}},
+                                   false, /*scan_size*/ 3600, 2.0, 0.0, 20.0,
+                                   /*max_points_per_line*/ 256);
     auto workload = [&]() { mapper.scanToGrid(angles, ranges); };
 #else
     float limit = width * res * std::sqrt(2);
     int maxPointsPerLine = static_cast<int>((limit / res) * 1.5);
-    Mapping::LocalMapper mapper(height, width, res, {0.0, 0.0, 0.0}, 0.0, false,
-                                0, 0.6, 0.9, 0.1, 0.1, 20.0, 0.2, 0.01, 2.0,
-                                0.0, maxPointsPerLine, 10);
-    auto workload = [&]() { mapper.scanToGridBaysian(angles, ranges); };
+    Mapping::LocalMapper mapper(height, width, res, {SensorConfig{}}, false,
+                                0, 0.6, 0.9, 0.1, 0.1, 20.0, 0.2, 2.0, 0.0,
+                                maxPointsPerLine, 10);
+    auto workload = [&]() { mapper.scanToGridBayesian(angles, ranges); };
 #endif
 
     results.push_back(measure_performance("Mapper_Dense_400x400", workload));
@@ -231,7 +231,6 @@ int main(int argc, char *argv[]) {
     const int width = 400;
     const float res = 0.05f;
     const int scan_size = 3600;  // matches the laserscan benchmark
-    const float angle_step = static_cast<float>(2.0 * M_PI / scan_size);
     const int max_points_per_line = 256;  // warp-multiple WG size, see TEST 2
 
     // Z-filter matches the critical-zone pointcloud benchmark so in-zone
@@ -240,10 +239,9 @@ int main(int argc, char *argv[]) {
     const float max_h = 2.0f;
     const float range_max = 20.0f;
 
-    Mapping::LocalMapperGPU mapper(height, width, res, {0.0, 0.0, 0.0}, 0.0,
-                                   /*isPointCloud*/ true, scan_size, angle_step,
-                                   max_h, min_h, range_max,
-                                   max_points_per_line);
+    Mapping::LocalMapperGPU mapper(height, width, res, {SensorConfig{}},
+                                   /*isPointCloud*/ true, scan_size, max_h,
+                                   min_h, range_max, max_points_per_line);
 
     auto cloud_bytes = generate_heavy_pointcloud_bytes(100000);
     const int point_step = sizeof(PointXYZ);

--- a/src/kompass_cpp/benchmarks/benchmark_runner.cpp
+++ b/src/kompass_cpp/benchmarks/benchmark_runner.cpp
@@ -262,6 +262,51 @@ int main(int argc, char *argv[]) {
     results.push_back(
         measure_performance("Mapper_PointCloud_100k", workload));
   }
+
+  // -------------------------------------------------------------------------
+  // TEST 2c: MAPPING (Multi-sensor fusion, 2 x 50k clouds, GPU-only)
+  //
+  // Same total point count as Mapper_PointCloud_100k, split across a
+  // front + back mount and fused through the batched scanToGrid: expected
+  // cost is ~the single-cloud benchmark plus one extra kernel pair.
+  // -------------------------------------------------------------------------
+  {
+    const int height = 400;
+    const int width = 400;
+    const float res = 0.05f;
+    const int scan_size = 3600;           // matches the laserscan benchmark
+    const int max_points_per_line = 256;  // warp-multiple WG size, see TEST 2
+    const float min_h = 0.1f;
+    const float max_h = 2.0f;
+    const float range_max = 20.0f;
+
+    Mapping::LocalMapperGPU mapper(
+        height, width, res,
+        {SensorConfig::fromYaw({0.2f, 0.0f, 0.2f}, 0.0f),
+         SensorConfig::fromYaw({-0.2f, 0.0f, 0.2f},
+                               static_cast<float>(M_PI))},
+        /*isPointCloud*/ true, scan_size, max_h, min_h, range_max,
+        max_points_per_line);
+
+    auto front_bytes = generate_heavy_pointcloud_bytes(50000);
+    auto back_bytes = generate_heavy_pointcloud_bytes(50000);
+    const int point_step = sizeof(PointXYZ);
+    const int x_off = offsetof(PointXYZ, x);
+    const int y_off = offsetof(PointXYZ, y);
+    const int z_off = offsetof(PointXYZ, z);
+    auto view = [&](const std::vector<uint8_t> &bytes) {
+      const int n = static_cast<int>(bytes.size() / point_step);
+      return PointCloudView{bytes, point_step, n * point_step, 1, n,
+                            x_off, y_off, z_off};
+    };
+    const std::vector<PointCloudView> clouds{view(front_bytes),
+                                             view(back_bytes)};
+
+    auto workload = [&]() { mapper.scanToGrid(clouds); };
+
+    results.push_back(
+        measure_performance("Mapper_MultiCloud_2x50k", workload));
+  }
 #endif
 
   // -------------------------------------------------------------------------
@@ -304,6 +349,52 @@ int main(int argc, char *argv[]) {
     };
 
     results.push_back(measure_performance("CriticalZone_100k_Cloud", workload));
+  }
+
+  // -------------------------------------------------------------------------
+  // TEST 3b: CRITICAL ZONE (Multi-sensor fusion, 2 x 50k clouds)
+  //
+  // Same total point count as CriticalZone_100k_Cloud, split across a
+  // front + back mount and fused through the batched check (min across
+  // sensors). Runs on both platforms like TEST 3.
+  // -------------------------------------------------------------------------
+  {
+    auto shape = CollisionChecker::ShapeType::CYLINDER;
+    std::vector<float> robotDim{0.51, 2.0};
+    float crit_angle = 160.0, crit_dist = 0.3, slow_dist = 0.6;
+    std::vector<SensorConfig> sensors{
+        SensorConfig::fromYaw({0.2f, 0.0f, 0.2f}, 0.0f),
+        SensorConfig::fromYaw({-0.2f, 0.0f, 0.2f},
+                              static_cast<float>(M_PI))};
+
+    auto front_bytes = generate_heavy_pointcloud_bytes(50000);
+    auto back_bytes = generate_heavy_pointcloud_bytes(50000);
+    const int point_step = sizeof(PointXYZ);
+    const int x_off = offsetof(PointXYZ, x);
+    const int y_off = offsetof(PointXYZ, y);
+    const int z_off = offsetof(PointXYZ, z);
+    auto view = [&](const std::vector<uint8_t> &bytes) {
+      const int n = static_cast<int>(bytes.size() / point_step);
+      return PointCloudView{bytes, point_step, n * point_step, 1, n,
+                            x_off, y_off, z_off};
+    };
+    const std::vector<PointCloudView> clouds{view(front_bytes),
+                                             view(back_bytes)};
+
+#ifdef GPU
+    CriticalZoneCheckerGPU checker(CriticalZoneChecker::InputType::POINTCLOUD,
+                                   shape, robotDim, sensors, crit_angle,
+                                   crit_dist, slow_dist, 0.1, 2.0, 20.0);
+#else
+    CriticalZoneChecker checker(CriticalZoneChecker::InputType::POINTCLOUD,
+                                shape, robotDim, sensors, crit_angle,
+                                crit_dist, slow_dist, 0.1, 2.0, 20.0);
+#endif
+
+    auto workload = [&]() { checker.check(clouds, true); };
+
+    results.push_back(
+        measure_performance("CriticalZone_2x50k_Cloud", workload));
   }
 
   // -------------------------------------------------------------------------

--- a/src/kompass_cpp/benchmarks/benchmark_runner.cpp
+++ b/src/kompass_cpp/benchmarks/benchmark_runner.cpp
@@ -273,12 +273,6 @@ int main(int argc, char *argv[]) {
     Eigen::Vector3f sensorPos{0.22, 0.0, 0.4};
     Eigen::Vector4f sensorRot{0, 0, 0.99, 0.0};
     float crit_angle = 160.0, crit_dist = 0.3, slow_dist = 0.6;
-    std::vector<double> dummy_angles;
-    dummy_angles.reserve(360);
-    double angle_step = 2.0 * M_PI / 360.0;
-    for (int i = 0; i < 360; ++i) {
-      dummy_angles.push_back(i * angle_step);
-    }
     auto cloud_bytes = generate_heavy_pointcloud_bytes(100000); // 100k points
 
     int point_step = sizeof(PointXYZ);
@@ -292,14 +286,16 @@ int main(int argc, char *argv[]) {
 
 #ifdef GPU
     CriticalZoneCheckerGPU checker(CriticalZoneChecker::InputType::POINTCLOUD,
-                                   shape, robotDim, sensorPos, sensorRot,
-                                   crit_angle, crit_dist, slow_dist,
-                                   dummy_angles, 0.1, 2.0, 20.0);
+                                   shape, robotDim,
+                                   {SensorConfig{sensorPos, sensorRot}},
+                                   crit_angle, crit_dist, slow_dist, 0.1, 2.0,
+                                   20.0);
 #else
     CriticalZoneChecker checker(CriticalZoneChecker::InputType::POINTCLOUD,
-                                shape, robotDim, sensorPos, sensorRot,
-                                crit_angle, crit_dist, slow_dist, dummy_angles,
-                                0.1, 2.0, 20.0);
+                                shape, robotDim,
+                                {SensorConfig{sensorPos, sensorRot}},
+                                crit_angle, crit_dist, slow_dist, 0.1, 2.0,
+                                20.0);
 #endif
 
     auto workload = [&]() {
@@ -364,13 +360,13 @@ int main(int argc, char *argv[]) {
 #ifdef GPU
     CriticalZoneCheckerGPU checker(CriticalZoneChecker::InputType::LASERSCAN,
                                    CollisionChecker::ShapeType::CYLINDER,
-                                   robotDim, sensorPos, sensorRot, 160.0, 0.3,
-                                   0.6, angles, 0.1, 2.0, 20.0);
+                                   robotDim, {SensorConfig{sensorPos, sensorRot}},
+                                   160.0, 0.3, 0.6, 0.1, 2.0, 20.0, angles);
 #else
     CriticalZoneChecker checker(CriticalZoneChecker::InputType::LASERSCAN,
                                 CollisionChecker::ShapeType::CYLINDER, robotDim,
-                                sensorPos, sensorRot, 160.0, 0.3, 0.6, angles,
-                                0.1, 2.0, 20.0);
+                                {SensorConfig{sensorPos, sensorRot}}, 160.0,
+                                0.3, 0.6, 0.1, 2.0, 20.0, angles);
 #endif
 
     auto workload = [&]() { checker.check(ranges, true); };

--- a/src/kompass_cpp/bindings/bindings.h
+++ b/src/kompass_cpp/bindings/bindings.h
@@ -1,9 +1,13 @@
 #pragma once
 
+#include "datatypes/sensors.h"
 #include "datatypes/span.h"
 #include <nanobind/eigen/dense.h>
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 namespace py = nanobind;
 
@@ -31,7 +35,70 @@ inline Kompass::ByteSpan toSpan(const ByteArray &a) {
   return Kompass::ByteSpan(a.data(), a.size());
 }
 
-// Nx3 cartesian points (row-major so a numpy (N, 3) float32 array maps
-// zero-copy); float64 or non-contiguous input converts with one copy
-using RowMatrixX3f =
-    Eigen::Matrix<float, Eigen::Dynamic, 3, Eigen::RowMajor>;
+// Extracts one PointCloudView from a Python cloud element. An element is a dict
+// (extra keys are ignored), or None, which yields an empty view. The element's
+// byte buffer crosses zero-copy. Its owner handle is appended to
+// `keepalive`, which must outlive the C++ call the views are passed to. Must be
+// called with the GIL held.
+inline Kompass::PointCloudView
+extractCloudView(py::handle element, const size_t index,
+                 std::vector<ByteArray> &keepalive) {
+  if (!element.is_valid() || element.is_none()) {
+    return Kompass::PointCloudView{};
+  }
+  auto fail = [index](const std::string &message) {
+    throw std::invalid_argument("clouds[" + std::to_string(index) +
+                                "]: " + message);
+  };
+  if (!py::isinstance<py::dict>(element)) {
+    fail("expected a dict (e.g. PointCloudData.asdict()) or None");
+  }
+  py::dict cloud = py::borrow<py::dict>(element);
+
+  auto field = [&](const char *name) -> py::object {
+    if (!cloud.contains(name)) {
+      fail("missing field '" + std::string(name) + "'");
+    }
+    return cloud[name];
+  };
+  auto int_field = [&](const char *name) -> int {
+    int value = 0;
+    if (!py::try_cast<int>(field(name), value)) {
+      fail("field '" + std::string(name) + "' must be an integer");
+    }
+    return value;
+  };
+
+  ByteArray data;
+  if (!py::try_cast<ByteArray>(field("data"), data)) {
+    fail("'data' must be a contiguous uint8 buffer (numpy uint8 array or "
+         "bytes)");
+  }
+
+  Kompass::PointCloudView view;
+  view.point_step = int_field("point_step");
+  view.row_step = int_field("row_step");
+  view.height = int_field("height");
+  view.width = int_field("width");
+  view.x_offset = int_field("x_offset");
+  view.y_offset = int_field("y_offset");
+  view.z_offset = int_field("z_offset");
+  keepalive.push_back(data);
+  view.data = toSpan(keepalive.back());
+  return view;
+}
+
+// Extracts a whole batch. clouds[i] pairs with the mapper/checker's i-th
+// configured sensor (positional). Must be called with the GIL held; the
+// returned views stay valid for as long as `keepalive` lives
+inline std::vector<Kompass::PointCloudView>
+extractCloudViews(py::sequence clouds, std::vector<ByteArray> &keepalive) {
+  const size_t count = py::len(clouds);
+  std::vector<Kompass::PointCloudView> views;
+  views.reserve(count);
+  keepalive.reserve(count);
+  for (size_t i = 0; i < count; ++i) {
+    views.push_back(extractCloudView(clouds[i], i, keepalive));
+  }
+  return views;
+}

--- a/src/kompass_cpp/bindings/bindings_control.cpp
+++ b/src/kompass_cpp/bindings/bindings_control.cpp
@@ -16,6 +16,10 @@
 
 using namespace Kompass;
 
+// Nx3 cartesian points (row-major so a numpy (N, 3) float32 array maps
+// zero-copy); float64 or non-contiguous input converts with one copy
+using RowMatrixX3f = Eigen::Matrix<float, Eigen::Dynamic, 3, Eigen::RowMajor>;
+
 // Control bindings submodule
 void bindings_control(py::module_ &m) {
   auto m_control = m.def_submodule("control", "Control module");

--- a/src/kompass_cpp/bindings/bindings_gpu.cpp
+++ b/src/kompass_cpp/bindings/bindings_gpu.cpp
@@ -40,7 +40,23 @@ void bindings_mapping_gpu(py::module_ &m) {
           py::arg("data"), py::arg("point_step"), py::arg("row_step"),
           py::arg("height"), py::arg("width"), py::arg("x_offset"),
           py::arg("y_offset"), py::arg("z_offset"),
-          py::rv_policy::reference_internal);
+          py::rv_policy::reference_internal)
+
+      .def(
+          "scan_to_grid",
+          [](Mapping::LocalMapperGPU &self,
+             py::sequence clouds) -> Eigen::MatrixXi & {
+            std::vector<ByteArray> keepalive;
+            auto views = extractCloudViews(clouds, keepalive);
+            py::gil_scoped_release release;
+            return self.scanToGrid(views);
+          },
+          "Fuse N point clouds into one occupancy grid (zero-copy input). "
+          "clouds[i] pairs with sensor_configs[i]; each element is a dict "
+          "(e.g. PointCloudData.asdict()) carrying data/point_step/row_step/"
+          "height/width/x_offset/y_offset/z_offset (extra keys ignored); "
+          "None entries are skipped.",
+          py::arg("clouds"), py::rv_policy::reference_internal);
 }
 
 // Utils bindings submodule

--- a/src/kompass_cpp/bindings/bindings_gpu.cpp
+++ b/src/kompass_cpp/bindings/bindings_gpu.cpp
@@ -1,7 +1,6 @@
 #include "bindings.h"
 #include "mapping/local_mapper_gpu.h"
 #include "utils/critical_zone_check_gpu.h"
-#include "utils/pointcloud.h"
 #include <nanobind/stl/vector.h>
 
 using namespace Kompass;
@@ -9,13 +8,17 @@ using namespace Kompass;
 // Mapping bindings submodule
 void bindings_mapping_gpu(py::module_ &m) {
   py::class_<Mapping::LocalMapperGPU>(m, "LocalMapperGPU")
-      .def(py::init<const int, const int, float, const Eigen::Vector3f &, float,
-                    bool, int, float, float, float, float, int>(),
+      .def(py::init<const int, const int, float,
+                    const std::vector<SensorConfig> &, bool, int, float, float,
+                    float, int>(),
            py::arg("grid_height"), py::arg("grid_width"), py::arg("resolution"),
-           py::arg("laserscan_position"), py::arg("laserscan_orientation"),
-           py::arg("is_pointcloud"), py::arg("scan_size"),
-           py::arg("angle_step"), py::arg("max_height"), py::arg("min_height"),
-           py::arg("range_max"), py::arg("max_points_per_line") = 32)
+           py::arg("sensor_configs"), py::arg("is_pointcloud"),
+           py::arg("scan_size"), py::arg("max_height"), py::arg("min_height"),
+           py::arg("range_max"), py::arg("max_points_per_line") = 32,
+           "One SensorConfig per sensor. Laserscan input requires exactly one "
+           "sensor (mount consumed as planar); pointcloud input accepts N "
+           "sensors fused into one grid, with max/min height as a BODY-frame "
+           "band shared by all sensors.")
 
       .def("scan_to_grid",
            py::overload_cast<Eigen::Ref<const Eigen::VectorXf>,
@@ -68,8 +71,8 @@ void bindings_utils_gpu(py::module_ &m) {
              int row_step, int height, int width, int x_offset, int y_offset,
              int z_offset, bool forward) {
             py::gil_scoped_release release;
-            return self.check(toSpan(data), point_step, row_step, height,
-                              width, x_offset, y_offset, z_offset, forward);
+            return self.check(toSpan(data), point_step, row_step, height, width,
+                              x_offset, y_offset, z_offset, forward);
           },
           py::arg("data"), py::arg("point_step"), py::arg("row_step"),
           py::arg("height"), py::arg("width"), py::arg("x_offset"),

--- a/src/kompass_cpp/bindings/bindings_gpu.cpp
+++ b/src/kompass_cpp/bindings/bindings_gpu.cpp
@@ -64,17 +64,20 @@ void bindings_utils_gpu(py::module_ &m) {
 
   py::class_<CriticalZoneCheckerGPU>(m, "CriticalZoneCheckerGPU")
       .def(py::init<CriticalZoneChecker::InputType, CollisionChecker::ShapeType,
-                    const std::vector<float> &, const Eigen::Vector3f &,
-                    const Eigen::Vector4f &, const float, const float,
-                    const float, const std::vector<double> &, const float,
-                    const float, const float, const PointFieldType>(),
+                    const std::vector<float> &,
+                    const std::vector<SensorConfig> &, const float, const float,
+                    const float, const float, const float, const float,
+                    const std::vector<double> &>(),
            py::arg("input_type"), py::arg("robot_shape"),
-           py::arg("robot_dimensions"), py::arg("sensor_position_body"),
-           py::arg("sensor_rotation_body"), py::arg("critical_angle"),
-           py::arg("critical_distance"), py::arg("slowdown_distance"),
-           py::arg("scan_angles"), py::arg("min_height"), py::arg("max_height"),
-           py::arg("range_max"),
-           py::arg("cloud_field_type") = PointFieldType::FLOAT32)
+           py::arg("robot_dimensions"), py::arg("sensor_configs"),
+           py::arg("critical_angle"), py::arg("critical_distance"),
+           py::arg("slowdown_distance"), py::arg("min_height"),
+           py::arg("max_height"), py::arg("range_max"),
+           py::arg("scan_angles") = std::vector<double>(),
+           "One SensorConfig per sensor. Laserscan input requires exactly one "
+           "sensor and non-empty scan_angles; pointcloud input accepts N "
+           "sensors (min factor wins) with min/max height as a BODY-frame "
+           "band shared by all sensors.")
 
       .def("check",
            py::overload_cast<Eigen::Ref<const Eigen::VectorXf>, const bool>(
@@ -92,5 +95,24 @@ void bindings_utils_gpu(py::module_ &m) {
           },
           py::arg("data"), py::arg("point_step"), py::arg("row_step"),
           py::arg("height"), py::arg("width"), py::arg("x_offset"),
-          py::arg("y_offset"), py::arg("z_offset"), py::arg("forward"));
+          py::arg("y_offset"), py::arg("z_offset"), py::arg("forward"))
+
+      .def(
+          "check",
+          [](CriticalZoneCheckerGPU &self, py::sequence clouds, bool forward) {
+            std::vector<ByteArray> keepalive;
+            auto views = extractCloudViews(clouds, keepalive);
+            py::gil_scoped_release release;
+            return self.check(views, forward);
+          },
+          "Check N point clouds on the GPU (zero-copy input) and return the "
+          "minimum safety factor. clouds[i] pairs with sensor_configs[i]; "
+          "each element is a dict (e.g. PointCloudData.asdict()) carrying "
+          "data/point_step/row_step/height/width/x_offset/y_offset/z_offset "
+          "(extra keys ignored); None entries are skipped.",
+          py::arg("clouds"), py::arg("forward"))
+
+      .def_prop_ro("num_sensors", [](const CriticalZoneCheckerGPU &self) {
+        return self.numSensors();
+      });
 }

--- a/src/kompass_cpp/bindings/bindings_mapping.cpp
+++ b/src/kompass_cpp/bindings/bindings_mapping.cpp
@@ -60,6 +60,22 @@ void bindings_mapping(py::module_ &m) {
           py::arg("y_offset"), py::arg("z_offset"),
           py::rv_policy::reference_internal)
 
+      .def(
+          "scan_to_grid",
+          [](Mapping::LocalMapper &self,
+             py::sequence clouds) -> Eigen::MatrixXi & {
+            std::vector<ByteArray> keepalive;
+            auto views = extractCloudViews(clouds, keepalive);
+            py::gil_scoped_release release;
+            return self.scanToGrid(views);
+          },
+          "Fuse N point clouds into one occupancy grid (zero-copy input). "
+          "clouds[i] pairs with sensor_configs[i]; each element is a dict "
+          "(e.g. PointCloudData.asdict()) carrying data/point_step/row_step/"
+          "height/width/x_offset/y_offset/z_offset (extra keys ignored); "
+          "None entries are skipped.",
+          py::arg("clouds"), py::rv_policy::reference_internal)
+
       .def("scan_to_grid_bayesian",
            py::overload_cast<Eigen::Ref<const Eigen::VectorXf>,
                              Eigen::Ref<const Eigen::VectorXf>>(

--- a/src/kompass_cpp/bindings/bindings_mapping.cpp
+++ b/src/kompass_cpp/bindings/bindings_mapping.cpp
@@ -6,7 +6,6 @@
 
 using namespace Kompass;
 
-
 // Mapping bindings submodule
 void bindings_mapping(py::module_ &m) {
   auto m_mapping = m.def_submodule("mapping", "Local Mapping module");
@@ -16,24 +15,27 @@ void bindings_mapping(py::module_ &m) {
       .value("OCCUPIED", Mapping::OccupancyType::OCCUPIED);
 
   py::class_<Mapping::LocalMapper>(m_mapping, "LocalMapper")
-      .def(py::init<const int, const int, float, const Eigen::Vector3f &, float,
-                    bool, int, float, float, float, float, int, int>(),
+      .def(py::init<const int, const int, float,
+                    const std::vector<SensorConfig> &, bool, int, float, float,
+                    float, int, int>(),
            py::arg("grid_height"), py::arg("grid_width"), py::arg("resolution"),
-           py::arg("laserscan_position"), py::arg("laserscan_orientation"),
-           py::arg("is_pointcloud"), py::arg("scan_size"),
-           py::arg("angle_step"), py::arg("max_height"), py::arg("min_height"),
+           py::arg("sensor_configs"), py::arg("is_pointcloud"),
+           py::arg("scan_size"), py::arg("max_height"), py::arg("min_height"),
            py::arg("range_max"), py::arg("max_points_per_line") = 32,
-           py::arg("max_num_threads") = 1)
+           py::arg("max_num_threads") = 1,
+           "One SensorConfig per sensor. Laserscan input requires exactly one "
+           "sensor (mount consumed as planar); pointcloud input accepts N "
+           "sensors fused into one grid, with max/min height as a BODY-frame "
+           "band shared by all sensors.")
 
-      .def(py::init<const int, const int, float, const Eigen::Vector3f &, float,
-                    bool, int, float, float, float, float, float, float, float,
-                    float, float, int, int>(),
+      .def(py::init<const int, const int, float,
+                    const std::vector<SensorConfig> &, bool, int, float, float,
+                    float, float, float, float, float, float, int, int>(),
            py::arg("grid_height"), py::arg("grid_width"), py::arg("resolution"),
-           py::arg("laserscan_position"), py::arg("laserscan_orientation"),
-           py::arg("is_pointcloud"), py::arg("scan_size"), py::arg("p_prior"),
-           py::arg("p_occupied"), py::arg("p_empty"), py::arg("range_sure"),
-           py::arg("range_max"), py::arg("wall_size"), py::arg("angle_step"),
-           py::arg("max_height"), py::arg("min_height"),
+           py::arg("sensor_configs"), py::arg("is_pointcloud"),
+           py::arg("scan_size"), py::arg("p_prior"), py::arg("p_occupied"),
+           py::arg("p_empty"), py::arg("range_sure"), py::arg("range_max"),
+           py::arg("wall_size"), py::arg("max_height"), py::arg("min_height"),
            py::arg("max_points_per_line"), py::arg("max_num_threads") = 1)
 
       .def("scan_to_grid",
@@ -58,25 +60,25 @@ void bindings_mapping(py::module_ &m) {
           py::arg("y_offset"), py::arg("z_offset"),
           py::rv_policy::reference_internal)
 
-      .def("scan_to_grid_baysian",
+      .def("scan_to_grid_bayesian",
            py::overload_cast<Eigen::Ref<const Eigen::VectorXf>,
                              Eigen::Ref<const Eigen::VectorXf>>(
-               &Mapping::LocalMapper::scanToGridBaysian),
-           "Convert laser scan data to occupancy grid, with baysian update",
+               &Mapping::LocalMapper::scanToGridBayesian),
+           "Convert laser scan data to occupancy grid, with bayesian update",
            py::arg("angles"), py::arg("ranges"),
            py::rv_policy::reference_internal)
 
       .def(
-          "scan_to_grid_baysian",
+          "scan_to_grid_bayesian",
           [](Mapping::LocalMapper &self, ByteArray data, int point_step,
              int row_step, int height, int width, int x_offset, int y_offset,
              int z_offset) {
             py::gil_scoped_release release;
-            return self.scanToGridBaysian(toSpan(data), point_step, row_step,
-                                          height, width, x_offset, y_offset,
-                                          z_offset);
+            return self.scanToGridBayesian(toSpan(data), point_step, row_step,
+                                           height, width, x_offset, y_offset,
+                                           z_offset);
           },
-          "Convert raw point cloud data to occupancy grid, with baysian "
+          "Convert raw point cloud data to occupancy grid, with bayesian "
           "update (zero-copy input)",
           py::arg("data"), py::arg("point_step"), py::arg("row_step"),
           py::arg("height"), py::arg("width"), py::arg("x_offset"),

--- a/src/kompass_cpp/bindings/bindings_types.cpp
+++ b/src/kompass_cpp/bindings/bindings_types.cpp
@@ -202,8 +202,7 @@ void bindings_types(py::module_ &m) {
             }
             throw std::runtime_error("Invalid robot geometry type");
           },
-          py::arg("shape_type"),
-          "Number of parameters the geometry requires");
+          py::arg("shape_type"), "Number of parameters the geometry requires");
 
   // For pointcloud data type
   py::enum_<PointFieldType>(m_types, "PointFieldType")
@@ -228,6 +227,34 @@ void bindings_types(py::module_ &m) {
           py::arg("value"),
           "Creates a PointFieldType from its integer ID (1-8).");
 
+  // Per-sensor mount configuration (used by mapper and critical zone checker)
+  py::class_<SensorConfig>(m_types, "SensorConfig")
+      .def(
+          "__init__",
+          [](SensorConfig *self, const Eigen::Vector3f &position,
+             const Eigen::Vector4f &rotation,
+             const PointFieldType cloud_field_type) {
+            new (self) SensorConfig{position, rotation, cloud_field_type};
+          },
+          py::arg("position") = Eigen::Vector3f(0.0f, 0.0f, 0.0f),
+          py::arg("rotation") = Eigen::Vector4f(0.0f, 0.0f, 0.0f, 1.0f),
+          py::arg("cloud_field_type") = PointFieldType::FLOAT32,
+          "Sensor mount pose in the body frame (position + quaternion "
+          "x, y, z, w) and the encoding of the sensor's point fields.")
+      .def_rw("position", &SensorConfig::position)
+      .def_rw("rotation", &SensorConfig::rotation)
+      .def_rw("cloud_field_type", &SensorConfig::cloud_field_type)
+      .def("__repr__", [](const SensorConfig &config) {
+        return "SensorConfig(position=[" + std::to_string(config.position.x()) +
+               ", " + std::to_string(config.position.y()) + ", " +
+               std::to_string(config.position.z()) + "], rotation=[" +
+               std::to_string(config.rotation.x()) + ", " +
+               std::to_string(config.rotation.y()) + ", " +
+               std::to_string(config.rotation.z()) + ", " +
+               std::to_string(config.rotation.w()) + "], cloud_field_type=" +
+               std::to_string(static_cast<int>(config.cloud_field_type)) + ")";
+      });
+
   // For critical zone checking
   py::enum_<CriticalZoneChecker::InputType>(m_types, "SensorInputType")
       .value("LASERSCAN", CriticalZoneChecker::InputType::LASERSCAN)
@@ -244,10 +271,11 @@ void bindings_types(py::module_ &m) {
   py::class_<PointsOfInterest>(m_types, "PointsOfInterest")
       .def(py::init<>())
       .def(py::init<const PointsOfInterest &>())
-      .def(py::init<const std::vector<Eigen::Vector2i> &, const Eigen::Vector2i &,
-                    const float, const std::string &>(),
-           py::arg("points"), py::arg("img_size") = Eigen::Vector2i(640, 480),
-           py::arg("timestamp") = 0.0, py::arg("label") = "")
+      .def(
+          py::init<const std::vector<Eigen::Vector2i> &,
+                   const Eigen::Vector2i &, const float, const std::string &>(),
+          py::arg("points"), py::arg("img_size") = Eigen::Vector2i(640, 480),
+          py::arg("timestamp") = 0.0, py::arg("label") = "")
       .def_rw("points_2d", &PointsOfInterest::Points2D)
       .def_rw("timestamp", &PointsOfInterest::timestamp)
       .def_rw("label", &PointsOfInterest::label)

--- a/src/kompass_cpp/bindings/bindings_types.cpp
+++ b/src/kompass_cpp/bindings/bindings_types.cpp
@@ -11,7 +11,6 @@
 #include "datatypes/trajectory.h"
 #include "utils/collision_check.h"
 #include "utils/critical_zone_check.h"
-#include "utils/pointcloud.h"
 
 using namespace Kompass;
 

--- a/src/kompass_cpp/bindings/bindings_utils.cpp
+++ b/src/kompass_cpp/bindings/bindings_utils.cpp
@@ -103,7 +103,8 @@ void bindings_utils(py::module_ &m) {
       [](ByteArray data, int point_step, int row_step, int height, int width,
          int x_offset, int y_offset, int z_offset, double max_range,
          double min_z, double max_z, double angle_step,
-         const Eigen::Vector3f &position, const Eigen::Vector4f &rotation) {
+         const Eigen::Vector3f &position, const Eigen::Vector4f &rotation,
+         PointFieldType cloud_field_type) {
         Eigen::VectorXf ranges_out;
         Eigen::VectorXf angles_out;
         {
@@ -111,8 +112,8 @@ void bindings_utils(py::module_ &m) {
           pointCloudToLaserScanFromRaw(
               PointCloudView{toSpan(data), point_step, row_step, height, width,
                              x_offset, y_offset, z_offset},
-              getTransformation(rotation, position), max_range, min_z, max_z,
-              angle_step, ranges_out, angles_out);
+              cloud_field_type, getTransformation(rotation, position),
+              max_range, min_z, max_z, angle_step, ranges_out, angles_out);
         }
         return std::make_tuple(std::move(ranges_out), std::move(angles_out));
       },
@@ -122,11 +123,13 @@ void bindings_utils(py::module_ &m) {
       py::arg("min_z"), py::arg("max_z"), py::arg("angle_step"),
       py::arg("position") = Eigen::Vector3f(0.0f, 0.0f, 0.0f),
       py::arg("rotation") = Eigen::Vector4f(0.0f, 0.0f, 0.0f, 1.0f),
+      py::arg("cloud_field_type") = PointFieldType::FLOAT32,
       "Converts raw PointCloud2 to ranges and angles using a specific angular "
       "step. An optional sensor mount pose (position + quaternion x,y,z,w) "
       "rotates points into body orientation and gates min_z/max_z on the "
       "body-frame height; the default identity mount reproduces the plain "
-      "sensor-frame conversion.");
+      "sensor-frame conversion. cloud_field_type selects the x/y/z field "
+      "encoding (default FLOAT32).");
 
   // Overload using num_bins (Returns: ranges as a float32 numpy array)
   m_utils.def(
@@ -134,15 +137,16 @@ void bindings_utils(py::module_ &m) {
       [](ByteArray data, int point_step, int row_step, int height, int width,
          int x_offset, int y_offset, int z_offset, double max_range,
          double min_z, double max_z, int num_bins,
-         const Eigen::Vector3f &position, const Eigen::Vector4f &rotation) {
+         const Eigen::Vector3f &position, const Eigen::Vector4f &rotation,
+         PointFieldType cloud_field_type) {
         Eigen::VectorXf ranges_out;
         {
           py::gil_scoped_release release;
           pointCloudToLaserScanFromRaw(
               PointCloudView{toSpan(data), point_step, row_step, height, width,
                              x_offset, y_offset, z_offset},
-              getTransformation(rotation, position), max_range, min_z, max_z,
-              num_bins, ranges_out);
+              cloud_field_type, getTransformation(rotation, position),
+              max_range, min_z, max_z, num_bins, ranges_out);
         }
         return ranges_out;
       },
@@ -152,11 +156,13 @@ void bindings_utils(py::module_ &m) {
       py::arg("min_z"), py::arg("max_z"), py::arg("num_bins"),
       py::arg("position") = Eigen::Vector3f(0.0f, 0.0f, 0.0f),
       py::arg("rotation") = Eigen::Vector4f(0.0f, 0.0f, 0.0f, 1.0f),
+      py::arg("cloud_field_type") = PointFieldType::FLOAT32,
       "Converts raw PointCloud2 to ranges only, using a fixed number of bins. "
       "An optional sensor mount pose (position + quaternion x,y,z,w) rotates "
       "points into body orientation and gates min_z/max_z on the body-frame "
       "height; the default identity mount reproduces the plain sensor-frame "
-      "conversion.");
+      "conversion. cloud_field_type selects the x/y/z field encoding "
+      "(default FLOAT32).");
 
   m_utils.def(
       "read_pcd", &read_pcd_py, py::arg("filename"),

--- a/src/kompass_cpp/bindings/bindings_utils.cpp
+++ b/src/kompass_cpp/bindings/bindings_utils.cpp
@@ -44,16 +44,20 @@ void bindings_utils(py::module_ &m) {
 
   py::class_<CriticalZoneChecker>(m_utils, "CriticalZoneChecker")
       .def(py::init<CriticalZoneChecker::InputType, CollisionChecker::ShapeType,
-                    const std::vector<float> &, const Eigen::Vector3f &,
-                    const Eigen::Vector4f &, const float, const float,
-                    const float, const std::vector<double> &, const float,
-                    const float, const float>(),
+                    const std::vector<float> &,
+                    const std::vector<SensorConfig> &, const float, const float,
+                    const float, const float, const float, const float,
+                    const std::vector<double> &>(),
            py::arg("input_type"), py::arg("robot_shape"),
-           py::arg("robot_dimensions"), py::arg("sensor_position_body"),
-           py::arg("sensor_rotation_body"), py::arg("critical_angle"),
-           py::arg("critical_distance"), py::arg("slowdown_distance"),
-           py::arg("scan_angles"), py::arg("min_height"), py::arg("max_height"),
-           py::arg("range_max"))
+           py::arg("robot_dimensions"), py::arg("sensor_configs"),
+           py::arg("critical_angle"), py::arg("critical_distance"),
+           py::arg("slowdown_distance"), py::arg("min_height"),
+           py::arg("max_height"), py::arg("range_max"),
+           py::arg("scan_angles") = std::vector<double>(),
+           "One SensorConfig per sensor. Laserscan input requires exactly one "
+           "sensor and non-empty scan_angles; pointcloud input accepts N "
+           "sensors (min factor wins) with min/max height as a BODY-frame "
+           "band shared by all sensors.")
 
       .def("check",
            py::overload_cast<Eigen::Ref<const Eigen::VectorXf>, const bool>(
@@ -71,7 +75,26 @@ void bindings_utils(py::module_ &m) {
           },
           py::arg("data"), py::arg("point_step"), py::arg("row_step"),
           py::arg("height"), py::arg("width"), py::arg("x_offset"),
-          py::arg("y_offset"), py::arg("z_offset"), py::arg("forward"));
+          py::arg("y_offset"), py::arg("z_offset"), py::arg("forward"))
+
+      .def(
+          "check",
+          [](CriticalZoneChecker &self, py::sequence clouds, bool forward) {
+            std::vector<ByteArray> keepalive;
+            auto views = extractCloudViews(clouds, keepalive);
+            py::gil_scoped_release release;
+            return self.check(views, forward);
+          },
+          "Check N point clouds (zero-copy input) and return the minimum "
+          "safety factor. clouds[i] pairs with sensor_configs[i]; each "
+          "element is a dict (e.g. PointCloudData.asdict()) carrying "
+          "data/point_step/row_step/height/width/x_offset/y_offset/z_offset "
+          "(extra keys ignored); None entries are skipped.",
+          py::arg("clouds"), py::arg("forward"))
+
+      .def_prop_ro("num_sensors", [](const CriticalZoneChecker &self) {
+        return self.numSensors();
+      });
 
   // Overload using angle_step (Returns: tuple(ranges, angles) as float32
   // numpy arrays)

--- a/src/kompass_cpp/bindings/bindings_utils.cpp
+++ b/src/kompass_cpp/bindings/bindings_utils.cpp
@@ -79,15 +79,17 @@ void bindings_utils(py::module_ &m) {
       "pointcloud_to_laserscan_from_raw",
       [](ByteArray data, int point_step, int row_step, int height, int width,
          int x_offset, int y_offset, int z_offset, double max_range,
-         double min_z, double max_z, double angle_step) {
+         double min_z, double max_z, double angle_step,
+         const Eigen::Vector3f &position, const Eigen::Vector4f &rotation) {
         Eigen::VectorXf ranges_out;
         Eigen::VectorXf angles_out;
         {
           py::gil_scoped_release release;
-          pointCloudToLaserScanFromRaw(toSpan(data), point_step, row_step,
-                                       height, width, x_offset, y_offset,
-                                       z_offset, max_range, min_z, max_z,
-                                       angle_step, ranges_out, angles_out);
+          pointCloudToLaserScanFromRaw(
+              PointCloudView{toSpan(data), point_step, row_step, height, width,
+                             x_offset, y_offset, z_offset},
+              getTransformation(rotation, position), max_range, min_z, max_z,
+              angle_step, ranges_out, angles_out);
         }
         return std::make_tuple(std::move(ranges_out), std::move(angles_out));
       },
@@ -95,22 +97,29 @@ void bindings_utils(py::module_ &m) {
       py::arg("height"), py::arg("width"), py::arg("x_offset"),
       py::arg("y_offset"), py::arg("z_offset"), py::arg("max_range"),
       py::arg("min_z"), py::arg("max_z"), py::arg("angle_step"),
+      py::arg("position") = Eigen::Vector3f(0.0f, 0.0f, 0.0f),
+      py::arg("rotation") = Eigen::Vector4f(0.0f, 0.0f, 0.0f, 1.0f),
       "Converts raw PointCloud2 to ranges and angles using a specific angular "
-      "step.");
+      "step. An optional sensor mount pose (position + quaternion x,y,z,w) "
+      "rotates points into body orientation and gates min_z/max_z on the "
+      "body-frame height; the default identity mount reproduces the plain "
+      "sensor-frame conversion.");
 
   // Overload using num_bins (Returns: ranges as a float32 numpy array)
   m_utils.def(
       "pointcloud_to_laserscan_from_raw",
       [](ByteArray data, int point_step, int row_step, int height, int width,
          int x_offset, int y_offset, int z_offset, double max_range,
-         double min_z, double max_z, int num_bins) {
+         double min_z, double max_z, int num_bins,
+         const Eigen::Vector3f &position, const Eigen::Vector4f &rotation) {
         Eigen::VectorXf ranges_out;
         {
           py::gil_scoped_release release;
-          pointCloudToLaserScanFromRaw(toSpan(data), point_step, row_step,
-                                       height, width, x_offset, y_offset,
-                                       z_offset, max_range, min_z, max_z,
-                                       num_bins, ranges_out);
+          pointCloudToLaserScanFromRaw(
+              PointCloudView{toSpan(data), point_step, row_step, height, width,
+                             x_offset, y_offset, z_offset},
+              getTransformation(rotation, position), max_range, min_z, max_z,
+              num_bins, ranges_out);
         }
         return ranges_out;
       },
@@ -118,7 +127,13 @@ void bindings_utils(py::module_ &m) {
       py::arg("height"), py::arg("width"), py::arg("x_offset"),
       py::arg("y_offset"), py::arg("z_offset"), py::arg("max_range"),
       py::arg("min_z"), py::arg("max_z"), py::arg("num_bins"),
-      "Converts raw PointCloud2 to ranges only, using a fixed number of bins.");
+      py::arg("position") = Eigen::Vector3f(0.0f, 0.0f, 0.0f),
+      py::arg("rotation") = Eigen::Vector4f(0.0f, 0.0f, 0.0f, 1.0f),
+      "Converts raw PointCloud2 to ranges only, using a fixed number of bins. "
+      "An optional sensor mount pose (position + quaternion x,y,z,w) rotates "
+      "points into body orientation and gates min_z/max_z on the body-frame "
+      "height; the default identity mount reproduces the plain sensor-frame "
+      "conversion.");
 
   m_utils.def(
       "read_pcd", &read_pcd_py, py::arg("filename"),

--- a/src/kompass_cpp/kompass_cpp/include/datatypes/sensors.h
+++ b/src/kompass_cpp/kompass_cpp/include/datatypes/sensors.h
@@ -40,6 +40,48 @@ inline int elementSizeOf(const PointFieldType type) {
   }
 }
 
+// Helper: Loads bytes safely handling potential misalignment
+inline float load_and_cast_val(const uint8_t *ptr, size_t offset,
+                               PointFieldType type) {
+  const uint8_t *addr = ptr + offset;
+
+  // Generic lambda to load unaligned data safely
+  auto load_safe = [&](auto dummy_type) {
+    using T = decltype(dummy_type);
+    T val;
+    // Copy byte-by-byte (compiler optimizes this to a register load)
+    // use uint8_t* to match the source pointer type
+    for (size_t i = 0; i < sizeof(T); ++i) {
+      reinterpret_cast<uint8_t *>(&val)[i] = addr[i];
+    }
+    return static_cast<float>(val);
+  };
+
+  switch (type) {
+  case PointFieldType::INT8:
+    // INT8 is always aligned (1 byte)
+    return static_cast<float>(*reinterpret_cast<const int8_t *>(addr));
+  case PointFieldType::UINT8:
+    // UINT8 is always aligned (1 byte)
+    return static_cast<float>(*addr);
+  case PointFieldType::INT16:
+    return load_safe(int16_t{});
+  case PointFieldType::UINT16:
+    return load_safe(uint16_t{});
+  case PointFieldType::INT32:
+    return load_safe(int32_t{});
+  case PointFieldType::UINT32:
+    return load_safe(uint32_t{});
+  case PointFieldType::FLOAT32:
+    return load_safe(float{});
+  case PointFieldType::FLOAT64:
+    return load_safe(double{});
+
+  default:
+    return 0.0f;
+  }
+}
+
 namespace Kompass {
 
 /**

--- a/src/kompass_cpp/kompass_cpp/include/datatypes/sensors.h
+++ b/src/kompass_cpp/kompass_cpp/include/datatypes/sensors.h
@@ -4,6 +4,8 @@
 #include "utils/transformation.h"
 #include <Eigen/Dense>
 #include <cmath>
+#include <stdexcept>
+#include <string>
 
 // Point field encoding of a PointCloud2-style byte buffer. Values match the
 // sensor_msgs/PointField datatype codes.
@@ -87,6 +89,33 @@ struct PointCloudView {
 
   /// An empty view means this sensor contributed no data this tick
   bool empty() const { return data.empty() || width * height == 0; }
+
+  /// Negative field offsets mean malformed PointCloud2 metadata
+  bool offsetsValid() const {
+    return x_offset >= 0 && y_offset >= 0 && z_offset >= 0;
+  }
 };
+
+/**
+ * Shared prologue of every batched cloud call. The batch must hold exactly one
+ * view per configured sensor (positional pairing), and every non-empty view
+ * must carry valid offsets.
+ */
+inline void validateClouds(Span<PointCloudView> clouds,
+                           const size_t num_sensors) {
+  if (clouds.size() != num_sensors) {
+    throw std::invalid_argument("expected " + std::to_string(num_sensors) +
+                                " clouds (one per configured sensor), got " +
+                                std::to_string(clouds.size()));
+  }
+  for (size_t i = 0; i < clouds.size(); ++i) {
+    if (!clouds[i].empty() && !clouds[i].offsetsValid()) {
+      throw std::invalid_argument(
+          "clouds[" + std::to_string(i) +
+          "]: point field offsets (x/y/z) must be non-negative: malformed "
+          "point cloud metadata");
+    }
+  }
+}
 
 } // namespace Kompass

--- a/src/kompass_cpp/kompass_cpp/include/datatypes/sensors.h
+++ b/src/kompass_cpp/kompass_cpp/include/datatypes/sensors.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include "datatypes/span.h"
+#include "utils/transformation.h"
+#include <Eigen/Dense>
+#include <cmath>
+
+// Point field encoding of a PointCloud2-style byte buffer. Values match the
+// sensor_msgs/PointField datatype codes.
+enum class PointFieldType : int {
+  INT8 = 1,
+  UINT8 = 2,
+  INT16 = 3,
+  UINT16 = 4,
+  INT32 = 5,
+  UINT32 = 6,
+  FLOAT32 = 7,
+  FLOAT64 = 8
+};
+
+// Size in bytes of one element of the given field type
+inline int elementSizeOf(const PointFieldType type) {
+  switch (type) {
+  case PointFieldType::INT8:
+  case PointFieldType::UINT8:
+    return 1;
+  case PointFieldType::INT16:
+  case PointFieldType::UINT16:
+    return 2;
+  case PointFieldType::INT32:
+  case PointFieldType::UINT32:
+  case PointFieldType::FLOAT32:
+    return 4;
+  case PointFieldType::FLOAT64:
+    return 8;
+  default:
+    return 4;
+  }
+}
+
+namespace Kompass {
+
+/**
+ * Per-sensor mount configuration, shared by the local mapper and the critical
+ * zone checker. Covers pointcloud sensors.
+ */
+struct SensorConfig {
+  /// Mount translation in the body frame
+  Eigen::Vector3f position{0.0f, 0.0f, 0.0f};
+  /// Mount rotation in the body frame, quaternion coefficients (x, y, z, w)
+  Eigen::Vector4f rotation{0.0f, 0.0f, 0.0f, 1.0f};
+  /// Encoding of the x/y/z fields in this sensor's byte buffer
+  PointFieldType cloud_field_type{PointFieldType::FLOAT32};
+
+  /// sensor -> body isometry built from position/rotation
+  Eigen::Isometry3f tfBody() const {
+    return getTransformation(rotation, position);
+  }
+
+  /// Convenience for planar (yaw-only) mounts
+  static SensorConfig
+  fromYaw(const Eigen::Vector3f &position, const float yaw,
+          const PointFieldType field_type = PointFieldType::FLOAT32) {
+    SensorConfig config;
+    config.position = position;
+    config.rotation = {0.0f, 0.0f, std::sin(yaw / 2.0f), std::cos(yaw / 2.0f)};
+    config.cloud_field_type = field_type;
+    return config;
+  }
+};
+
+/**
+ * Non-owning view of one PointCloud2-style byte buffer plus its layout
+ * metadata. Zero-copy `data` refers to caller-owned memory that must stay
+ * alive for the duration of the call it is passed to. In batched calls,
+ * clouds pair with sensors positionally. clouds[i] belongs to sensors[i].
+ */
+struct PointCloudView {
+  ByteSpan data{};
+  int point_step{0};
+  int row_step{0};
+  int height{0};
+  int width{0};
+  int x_offset{-1};
+  int y_offset{-1};
+  int z_offset{-1};
+
+  /// An empty view means this sensor contributed no data this tick
+  bool empty() const { return data.empty() || width * height == 0; }
+};
+
+} // namespace Kompass

--- a/src/kompass_cpp/kompass_cpp/include/mapping/local_mapper.h
+++ b/src/kompass_cpp/kompass_cpp/include/mapping/local_mapper.h
@@ -179,12 +179,14 @@ public:
 
 protected:
   // Transforms a point from grid coordinate (i,j) to the local coordinates
-  // frame of the grid (around the central cell) (x,y,z)
+  // frame of the grid (around the central cell) (x,y,z).
+  // NOTE: (INVARIANT) this must stay the exact inverse of localToGrid below
+  // (cell = central + p/res  <=>  p = (cell - central)*res).
   Eigen::Vector3f gridToLocal(const Eigen::Vector2i &pointTargetInGrid,
                               float height = 0.0) {
     Eigen::Vector3f poseB;
-    poseB(0) = (m_centralPoint(0) - pointTargetInGrid(0)) * m_resolution;
-    poseB(1) = (m_centralPoint(1) - pointTargetInGrid(1)) * m_resolution;
+    poseB(0) = (pointTargetInGrid(0) - m_centralPoint(0)) * m_resolution;
+    poseB(1) = (pointTargetInGrid(1) - m_centralPoint(1)) * m_resolution;
     poseB(2) = height;
 
     return poseB;

--- a/src/kompass_cpp/kompass_cpp/include/mapping/local_mapper.h
+++ b/src/kompass_cpp/kompass_cpp/include/mapping/local_mapper.h
@@ -1,10 +1,14 @@
 #pragma once
 
+#include "datatypes/sensors.h"
 #include "datatypes/span.h"
 #include "utils/threadpool.h"
 #include <Eigen/Dense>
+#include <cmath>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
+#include <vector>
 
 namespace Kompass {
 namespace Mapping {
@@ -14,100 +18,52 @@ enum class OccupancyType { UNEXPLORED = -1, EMPTY = 0, OCCUPIED = 100 };
 
 class LocalMapper {
 public:
-  // Constructor with basic parameters
+  /**
+   * Constructor with basic parameters.
+   *
+   * @param sensors One SensorConfig per sensor. Laserscan input
+   * requires exactly one sensor and consumes its mount as planar
+   * (position x/y + yaw extracted from the quaternion). Pointcloud input
+   * accepts N sensors fused into one grid, each with its full 3D mount applied.
+   *
+   * NOTE for pointcloud input `maxHeight`/`minHeight` are a BODY-frame
+   * height band shared by all sensors (typically 0 .. robot_height).
+   */
   LocalMapper(const int gridHeight, const int gridWidth, const float resolution,
-              const Eigen::Vector3f &laserscanPosition,
-              const float laserscanOrientation, const bool isPointCloud,
-              const int scanSize, const float angleStep, const float maxHeight,
-              const float minHeight, const float rangeMax,
-              const int maxPointsPerLine, const int maxNumThreads = 1)
+              const std::vector<SensorConfig> &sensors, const bool isPointCloud,
+              const int scanSize, const float maxHeight, const float minHeight,
+              const float rangeMax, const int maxPointsPerLine,
+              const int maxNumThreads = 1)
       : m_gridHeight(gridHeight), m_gridWidth(gridWidth),
-        m_resolution(resolution), m_laserscanOrientation(laserscanOrientation),
-        m_pPrior(0.5f), m_pEmpty(0.4f), m_pOccupied(0.6f), m_rangeSure(1.0f),
-        m_rangeMax(rangeMax), m_wallSize(0.2f), m_angleStep(angleStep),
-        m_maxHeight(maxHeight), m_minHeight(minHeight),
+        m_resolution(resolution), m_pPrior(0.5f), m_pEmpty(0.4f),
+        m_pOccupied(0.6f), m_rangeSure(1.0f), m_rangeMax(rangeMax),
+        m_wallSize(0.2f), m_maxHeight(maxHeight), m_minHeight(minHeight),
         m_maxPointsPerLine(maxPointsPerLine),
         m_centralPoint(std::round(gridHeight / 2) - 1,
                        std::round(gridWidth / 2) - 1),
-        m_laserscanPosition(laserscanPosition), m_scanSize(scanSize),
+        m_scanSize(scanSize), m_isPointCloud(isPointCloud),
         m_maxNumThreads(maxNumThreads) {
-    m_startPoint = localToGrid(
-        Eigen::Vector2f(laserscanPosition(0), laserscanPosition(1)));
-    gridData = Eigen::MatrixXi(gridHeight, gridWidth);
-    gridDataProb = Eigen::MatrixXf(gridHeight, gridWidth);
-    previousGridDataProb = Eigen::MatrixXf(gridHeight, gridWidth);
-    m_transformScratch = Eigen::MatrixXf(gridHeight, gridWidth);
-    // initialize previous grid data
-    previousGridDataProb.fill(m_pPrior);
-    if (m_maxNumThreads > 1) {
-      m_pool = std::make_unique<ThreadPool>(m_maxNumThreads);
-    }
-
-    // initialize ranges and angles if working with pointcloud
-    if (isPointCloud) {
-      // NOTE: Enforce scan_size / angle_step consistency. The pointcloud →
-      // laserscan step (CPU `pointCloudToLaserScanFromRaw` num_bins
-      // overload, and its GPU counterpart) buckets by a bin width of
-      // `2π / scan_size`. Downstream the ray-cast step consumes
-      // `initializedAngles[i] = i · angle_step`. If the caller passed an
-      // `angle_step` that doesn't match `2π / scan_size` the two steps
-      // drift by a fraction of a bin per ray (silent rotation). We
-      // override `angle_step` here so both halves see the same grid.
-      const double derived_step =
-          (2.0 * M_PI) / static_cast<double>(scanSize);
-      initializedAngles.resize(scanSize);
-      initializedRanges.resize(scanSize);
-      for (int i = 0; i < scanSize; ++i) {
-        initializedAngles[i] = static_cast<float>(i * derived_step);
-      }
-    }
+    initMapper_(sensors);
   }
 
-  // Constructor with additional baysian parameters
+  // Constructor with additional bayesian parameters
   LocalMapper(const int gridHeight, const int gridWidth, const float resolution,
-              const Eigen::Vector3f &laserscanPosition,
-              const float laserscanOrientation, const bool isPointCloud,
+              const std::vector<SensorConfig> &sensors, const bool isPointCloud,
               const int scanSize, const float pPrior, const float pOccupied,
               const float pEmpty, const float rangeSure, const float rangeMax,
-              const float wallSize, const float angleStep,
-              const float maxHeight, const float minHeight,
-              const int maxPointsPerLine, const int maxNumThreads = 1)
+              const float wallSize, const float maxHeight,
+              const float minHeight, const int maxPointsPerLine,
+              const int maxNumThreads = 1)
       : m_gridHeight(gridHeight), m_gridWidth(gridWidth),
-        m_resolution(resolution), m_laserscanOrientation(laserscanOrientation),
-        m_pPrior(pPrior), m_pEmpty(pEmpty), m_pOccupied(pOccupied),
-        m_rangeSure(rangeSure), m_rangeMax(rangeMax), m_wallSize(wallSize),
-        m_angleStep(angleStep), m_maxHeight(maxHeight), m_minHeight(minHeight),
+        m_resolution(resolution), m_pPrior(pPrior), m_pEmpty(pEmpty),
+        m_pOccupied(pOccupied), m_rangeSure(rangeSure), m_rangeMax(rangeMax),
+        m_wallSize(wallSize), m_maxHeight(maxHeight), m_minHeight(minHeight),
         m_maxPointsPerLine(maxPointsPerLine),
         m_centralPoint(std::round(gridHeight / 2) - 1,
                        std::round(gridWidth / 2) - 1),
-        m_laserscanPosition(laserscanPosition), m_scanSize(scanSize),
+        m_scanSize(scanSize), m_isPointCloud(isPointCloud),
         m_maxNumThreads(maxNumThreads) {
-    m_startPoint = localToGrid(
-        Eigen::Vector2f(laserscanPosition(0), laserscanPosition(1)));
-    gridData = Eigen::MatrixXi(gridHeight, gridWidth);
-    gridDataProb = Eigen::MatrixXf(gridHeight, gridWidth);
-    previousGridDataProb = Eigen::MatrixXf(gridHeight, gridWidth);
-    m_transformScratch = Eigen::MatrixXf(gridHeight, gridWidth);
-    // initialize previous grid data
-    previousGridDataProb.fill(m_pPrior);
-    if (m_maxNumThreads > 1) {
-      m_pool = std::make_unique<ThreadPool>(m_maxNumThreads);
-    }
-    // initialize ranges and angles if working with pointcloud
-    if (isPointCloud) {
-      // NOTE: See the non-Bayesian ctor above for the rationale: the
-      // pointcloud → laserscan step buckets by `2π / scan_size`, so the
-      // ray-cast step's `initializedAngles[i] = i · angle_step` must
-      // use the same step or the two halves drift. Override here.
-      const double derived_step =
-          (2.0 * M_PI) / static_cast<double>(scanSize);
-      initializedAngles.resize(scanSize);
-      initializedRanges.resize(scanSize);
-      for (int i = 0; i < scanSize; ++i) {
-        initializedAngles[i] = static_cast<float>(i * derived_step);
-        initializedRanges[i] = rangeMax;
-      }
-    }
+    initMapper_(sensors);
   }
 
   // Default destructor
@@ -151,7 +107,7 @@ public:
 
   /**
    * Processes Laserscan data (angles and ranges) to project on a 2D grid
-   * using Bresenham line drawing for each Laserscan beam and baysian map
+   * using Bresenham line drawing for each Laserscan beam and bayesian map
    * updates
    *
    * @param angles        LaserScan angles in radians
@@ -159,7 +115,7 @@ public:
    * @returns gridDataProb Current probabilistic grid data
    */
   std::tuple<Eigen::MatrixXi &, Eigen::MatrixXf &>
-  scanToGridBaysian(Eigen::Ref<const Eigen::VectorXf> angles,
+  scanToGridBayesian(Eigen::Ref<const Eigen::VectorXf> angles,
                     Eigen::Ref<const Eigen::VectorXf> ranges);
 
   /**
@@ -177,8 +133,8 @@ public:
    * @return            A 2D occupancy grid as an Eigen::MatrixXi.
    */
   Eigen::MatrixXi &scanToGrid(ByteSpan data, int point_step, int row_step,
-                              int height, int width, int x_offset,
-                              int y_offset, int z_offset);
+                              int height, int width, int x_offset, int y_offset,
+                              int z_offset);
   /**
    * Projects 3D point cloud data onto a 2D grid using Bresenham line drawing,
    * with Bayesian updates to build a probabilistic occupancy grid.
@@ -197,8 +153,29 @@ public:
    *                      - Probabilistic occupancy grid (Eigen::MatrixXf&)
    */
   std::tuple<Eigen::MatrixXi &, Eigen::MatrixXf &>
-  scanToGridBaysian(ByteSpan data, int point_step, int row_step, int height,
+  scanToGridBayesian(ByteSpan data, int point_step, int row_step, int height,
                     int width, int x_offset, int y_offset, int z_offset);
+
+  /**
+   * Fuses N point clouds into one occupancy grid. clouds[i] pairs with the
+   * i-th configured sensor (positional). The grid is reset once, then each
+   * sensor's cloud is converted around its own mount pose and ray-cast from
+   * its own origin; cell writes are max-monotone
+   * (OCCUPIED > EMPTY > UNEXPLORED) so the per-sensor passes fuse
+   * order-independently. Empty views are skipped ("no data from this sensor
+   * this tick"); an all-empty batch returns an all-UNEXPLORED grid.
+   *
+   * @throws std::logic_error when the mapper was not constructed for
+   * pointcloud input.
+   * @throws std::invalid_argument on cloud count mismatch or negative field
+   * offsets (message names the offending cloud index).
+   */
+  Eigen::MatrixXi &scanToGrid(Span<PointCloudView> clouds);
+
+  // Convenience overload for containers / braced lists
+  Eigen::MatrixXi &scanToGrid(const std::vector<PointCloudView> &clouds) {
+    return scanToGrid(Span<PointCloudView>(clouds));
+  }
 
 protected:
   // Transforms a point from grid coordinate (i,j) to the local coordinates
@@ -229,11 +206,96 @@ protected:
     return gridPoint;
   }
 
-  // Update method for scanToGrid
-  void updateGrid_(const float angle, const float range);
+  // Per-sensor runtime state derived from a SensorConfig. The pointcloud
+  // path uses tf_body/origin_xy/start_point (rotation folded into the
+  // conversion, ray-cast orientation 0); the laserscan path uses
+  // origin_xy/yaw/start_point (planar consumption of the mount)
+  struct SensorRuntime {
+    Eigen::Isometry3f tf_body;   // sensor -> body mount
+    Eigen::Vector2f origin_xy;   // planar mount position (ray-cast origin)
+    float yaw;                   // planar heading extracted from the mount
+    Eigen::Vector2i start_point; // ray-cast origin cell
+  };
 
-  // Update method for scanToGridBaysian
-  void updateGridBaysian_(const float angle, const float range);
+  SensorRuntime makeSensorRuntime(const SensorConfig &config) {
+    SensorRuntime runtime;
+    runtime.tf_body = config.tfBody();
+    runtime.origin_xy = config.position.head<2>();
+    const Eigen::Matrix3f rot = runtime.tf_body.rotation();
+    runtime.yaw = std::atan2(rot(1, 0), rot(0, 0));
+    runtime.start_point = localToGrid(runtime.origin_xy);
+    return runtime;
+  }
+
+  // Shared constructor body
+  void initMapper_(const std::vector<SensorConfig> &sensors) {
+    gridData = Eigen::MatrixXi(m_gridHeight, m_gridWidth);
+    // Only for Bayesian calls
+    gridDataProb = Eigen::MatrixXf(m_gridHeight, m_gridWidth);
+    previousGridDataProb = Eigen::MatrixXf(m_gridHeight, m_gridWidth);
+    m_transformScratch = Eigen::MatrixXf(m_gridHeight, m_gridWidth);
+    previousGridDataProb.fill(m_pPrior);  // previous prob buffer
+    // initialize thread pool
+    if (m_maxNumThreads > 1) {
+      m_pool = std::make_unique<ThreadPool>(m_maxNumThreads);
+    }
+
+    if (sensors.empty()) {
+      throw std::invalid_argument(
+          "LocalMapper requires at least one sensor config");
+    }
+    if (!m_isPointCloud && sensors.size() != 1) {
+      throw std::invalid_argument(
+          "LocalMapper laserscan input supports exactly one sensor");
+    }
+    m_sensors.reserve(sensors.size());
+    for (const auto &sensor : sensors) {
+      m_sensors.push_back(makeSensorRuntime(sensor));
+    }
+
+    // initialize ranges and angles if working with pointcloud
+    if (m_isPointCloud) {
+      // NOTE: The pointcloud → laserscan step (CPU
+      // `pointCloudToLaserScanFromRaw` and its GPU counterpart) buckets by a
+      // bin width of `2π / scan_size`; the ray-cast step consumes
+      // `initializedAngles[i]` and must see the exact same step or the two
+      // halves drift by a fraction of a bin per ray (silent rotation)
+      const double derived_step =
+          (2.0 * M_PI) / static_cast<double>(m_scanSize);
+      initializedAngles.resize(m_scanSize);
+      initializedRanges.resize(m_scanSize);
+      for (int i = 0; i < m_scanSize; ++i) {
+        initializedAngles[i] = static_cast<float>(i * derived_step);
+        initializedRanges[i] = m_rangeMax;
+      }
+    }
+  }
+
+  // Casts one ray from the given origin and writes its EMPTY/OCCUPIED cells.
+  void updateGrid_(const float angle, const float range,
+                   const Eigen::Vector2f originXY, const float orientation,
+                   const Eigen::Vector2i startPoint);
+
+  // Bayesian variant of updateGrid_
+  void updateGridBayesian_(const float angle, const float range,
+                          const Eigen::Vector2f originXY,
+                          const float orientation,
+                          const Eigen::Vector2i startPoint);
+
+  // Rasterizes one whole scan from one origin into the grid. Does NOT reset the
+  // grid, so several rasterize passes (one per sensor) accumulate into the same
+  // grid
+  void rasterizeScan_(Eigen::Ref<const Eigen::VectorXf> angles,
+                      Eigen::Ref<const Eigen::VectorXf> ranges,
+                      const Eigen::Vector2f originXY, const float orientation,
+                      const Eigen::Vector2i startPoint);
+
+  // Bayesian variant of rasterizeScan_
+  void rasterizeScanBayesian_(Eigen::Ref<const Eigen::VectorXf> angles,
+                             Eigen::Ref<const Eigen::VectorXf> ranges,
+                             const Eigen::Vector2f originXY,
+                             const float orientation,
+                             const Eigen::Vector2i startPoint);
 
   /**
    * @brief Fill an area around a point on the grid with given padding.
@@ -251,26 +313,26 @@ protected:
   const int m_gridHeight;
   const int m_gridWidth;
   const float m_resolution;
-  const float m_laserscanOrientation;
   const float m_pPrior;
   const float m_pEmpty;
   const float m_pOccupied;
   const float m_rangeSure;
   const float m_rangeMax;
   const float m_wallSize;
-  const float m_angleStep;
   const float m_maxHeight;
   const float m_minHeight;
   const int m_maxPointsPerLine;
   const Eigen::Vector2i m_centralPoint;
-  const Eigen::Vector3f m_laserscanPosition;
   const int m_scanSize;
-  Eigen::Vector2i m_startPoint;
+  const bool m_isPointCloud;
   Eigen::MatrixXi gridData;
   Eigen::MatrixXf gridDataProb;
   Eigen::MatrixXf previousGridDataProb;
   Eigen::VectorXf initializedRanges; // only initialized for pointcloud data
   Eigen::VectorXf initializedAngles; // only initialized for pointcloud data
+  // Per-sensor runtimes, one per SensorConfig (laserscan input has exactly
+  // one; pointcloud input may have several)
+  std::vector<SensorRuntime> m_sensors;
 
   // Serializes grid writes across worker threads (one lock per ray)
   std::mutex m_gridMutex;

--- a/src/kompass_cpp/kompass_cpp/include/mapping/local_mapper.h
+++ b/src/kompass_cpp/kompass_cpp/include/mapping/local_mapper.h
@@ -217,12 +217,14 @@ protected:
     Eigen::Vector2f origin_xy;   // planar mount position (ray-cast origin)
     float yaw;                   // planar heading extracted from the mount
     Eigen::Vector2i start_point; // ray-cast origin cell
+    PointFieldType field_type;   // point field encoding (pointcloud decode)
   };
 
   SensorRuntime makeSensorRuntime(const SensorConfig &config) {
     SensorRuntime runtime;
     runtime.tf_body = config.tfBody();
     runtime.origin_xy = config.position.head<2>();
+    runtime.field_type = config.cloud_field_type;
     const Eigen::Matrix3f rot = runtime.tf_body.rotation();
     runtime.yaw = std::atan2(rot(1, 0), rot(0, 0));
     runtime.start_point = localToGrid(runtime.origin_xy);

--- a/src/kompass_cpp/kompass_cpp/include/mapping/local_mapper_gpu.h
+++ b/src/kompass_cpp/kompass_cpp/include/mapping/local_mapper_gpu.h
@@ -3,66 +3,41 @@
 #include "local_mapper.h"
 #include "utils/logger.h"
 #include <Eigen/Dense>
+#include <array>
 #include <sycl/sycl.hpp>
+#include <vector>
 
 namespace Kompass {
 namespace Mapping {
 
 class LocalMapperGPU : public LocalMapper {
 public:
-  // Constructor
+  /**
+   * Constructor.
+   *
+   * @param sensors One SensorConfig per sensor. Laserscan input
+   * (`isPointCloud == false`) requires exactly one sensor and consumes its
+   * mount as planar (position x/y + yaw extracted from the quaternion).
+   * Pointcloud input accepts N sensors fused into one grid, each with its
+   * full 3D mount applied.
+   *
+   * NOTE for pointcloud input `maxHeight`/`minHeight` are a BODY-frame
+   * height band shared by all sensors (typically 0 .. robot_height).
+   */
   LocalMapperGPU(const int gridHeight, const int gridWidth,
                  const float resolution,
-                 const Eigen::Vector3f &laserscanPosition,
-                 const float laserscanOrientation, const bool isPointCloud,
-                 const int scanSize, const float angleStep,
+                 const std::vector<SensorConfig> &sensors,
+                 const bool isPointCloud, const int scanSize,
                  const float maxHeight, const float minHeight,
                  const float rangeMax, const int maxPointsPerLine = 32)
-      : LocalMapper(gridHeight, gridWidth, resolution, laserscanPosition,
-                    laserscanOrientation, isPointCloud, scanSize, angleStep,
-                    maxHeight, minHeight, rangeMax, maxPointsPerLine) {
-    m_q = sycl::queue{sycl::default_selector_v,
-                      sycl::property::queue::in_order{}};
-    auto dev = m_q.get_device();
-    LOG_INFO("Running on :", dev.get_info<sycl::info::device::name>());
-
-    // Query the device's max work-group size for the pointcloud conversion
-    // kernel
-    m_max_wg_size = dev.get_info<sycl::info::device::max_work_group_size>();
-
-    // Buffers needed on both laserscan and pointcloud paths
-    m_devicePtrRanges = sycl::malloc_device<float>(scanSize, m_q);
-    // NOTE: Angles stay double on device. The ray-cast kernel feeds them to
-    // sin/cos, and on CPU only backend float trig measurably loses to
-    // double trig (glibc). The kernel already narrows the angle to float before
-    // trig, so double costs only the wider H->D copy and per-thread load and
-    // the fp64 throughput penalty is negligible
-    m_devicePtrAngles = sycl::malloc_device<double>(scanSize, m_q);
-    m_anglesWide.resize(scanSize);
-    m_devicePtrGrid = sycl::malloc_device<int>(m_gridHeight * m_gridWidth, m_q);
-    m_devicePtrDistances =
-        sycl::malloc_shared<float>(m_gridHeight * m_gridWidth, m_q);
-
-    // Precompute per-cell distance from the laserscan origin.
-    // Used by the ray-cast kernel to gate super-cover line fills.
-    Eigen::Vector3f destPointLocal;
-    for (size_t i = 0; i < m_gridHeight; ++i) {
-      for (size_t j = 0; j < m_gridWidth; ++j) {
-        destPointLocal = gridToLocal({i, j});
-        m_devicePtrDistances[i + j * m_gridWidth] =
-            (destPointLocal - m_laserscanPosition).norm();
-      }
-    }
-
+      : LocalMapper(gridHeight, gridWidth, resolution, sensors, isPointCloud,
+                    scanSize, maxHeight, minHeight, rangeMax,
+                    maxPointsPerLine) {
+    initCommon_();
     if (isPointCloud) {
-      // Angles are pre-populated by the base LocalMapper ctor with the
-      // `2π / scan_size` bin width the conversion kernel assumes; upload
-      // them once here and skip the per-call H→D copy. The laserscan
-      // path uploads angles per call instead.
-      m_anglesWide = initializedAngles.cast<double>();
-      m_q.memcpy(m_devicePtrAngles, m_anglesWide.data(),
-                 sizeof(double) * scanSize);
-      m_q.wait();
+      initPointCloudMode_(sensors);
+    } else {
+      initLaserscanMode_();
     }
   }
 
@@ -81,8 +56,16 @@ public:
     if (m_devicePtrDistances) {
       sycl::free(m_devicePtrDistances, m_q);
     }
-    if (m_devicePtrRawBytes) {
-      sycl::free(m_devicePtrRawBytes, m_q);
+    for (auto &dev : m_sensorDev) {
+      if (dev.ranges) {
+        sycl::free(dev.ranges, m_q);
+      }
+      if (dev.distances) {
+        sycl::free(dev.distances, m_q);
+      }
+      if (dev.rawBytes) {
+        sycl::free(dev.rawBytes, m_q);
+      }
     }
   }
 
@@ -93,13 +76,17 @@ public:
    * @param angles        LaserScan angles in radians
    * @param ranges         LaserScan ranges in meters
    * @param gridData      Current grid data
+   *
+   * @throws std::logic_error when the mapper was constructed for pointcloud
+   * input (a laserscan call would overwrite the pre-uploaded bin angles).
    */
   Eigen::MatrixXi &scanToGrid(Eigen::Ref<const Eigen::VectorXf> angles,
                               Eigen::Ref<const Eigen::VectorXf> ranges);
 
   /**
    * Uses a GPU to Projects 3D point cloud data onto a 2D grid using Bresenham
-   * line drawing.
+   * line drawing. Single-cloud adapter onto the batched entry below (the
+   * mapper must be configured with exactly one sensor).
    *
    * @param data        Flattened point cloud data (uint8), typically in XYZ
    * format.
@@ -116,23 +103,130 @@ public:
                               int height, int width, int x_offset, int y_offset,
                               int z_offset);
 
-private:
-  // Per-cell distance from laserscan origin. Precomputed at construction;
-  // read by the ray-cast kernel
-  float *m_devicePtrDistances;
+  /**
+   * Fuses N point clouds into one occupancy grid on the GPU. clouds[i] pairs
+   * with the i-th configured sensor (positional). The device grid is reset
+   * once, then each sensor's cloud runs its own conversion + ray-cast kernel
+   * pair. Empty views are skipped; an all-empty batch returns an all-UNEXPLORED
+   * grid.
+   *
+   * @throws std::logic_error when the mapper was not constructed for
+   * pointcloud input.
+   * @throws std::invalid_argument on cloud count mismatch or negative field
+   * offsets (message names the offending cloud index).
+   */
+  Eigen::MatrixXi &scanToGrid(Span<PointCloudView> clouds);
 
-  // Laserscan device buffers.
+  // Convenience overload for containers / braced lists
+  Eigen::MatrixXi &scanToGrid(const std::vector<PointCloudView> &clouds) {
+    return scanToGrid(Span<PointCloudView>(clouds));
+  }
+
+private:
+  // Device-side per-sensor state; one entry per configured sensor in
+  // pointcloud mode, empty in laserscan mode
+  struct SensorDeviceState {
+    // Raw PointCloud2 bytes. Grown lazily per call because the per-scan
+    // point count isn't known at ctor time; grow-only
+    uint8_t *rawBytes = nullptr;
+    size_t rawCapacity = 0;
+    // Conversion output: per-bin minimum planar range (scanSize floats)
+    float *ranges = nullptr;
+    // Per-cell planar distance from this sensor's origin; gates super-cover
+    // EMPTY fills in the ray-cast kernel
+    float *distances = nullptr;
+    // Rows 0..2 of the sensor->body isometry [R | t], row-major
+    std::array<float, 12> tf{};
+    Eigen::Vector2f originXY{0.0f, 0.0f};
+    Eigen::Vector2i startPoint{0, 0};
+    PointFieldType fieldType = PointFieldType::FLOAT32;
+    int elementSize = 4;
+  };
+
+  void initCommon_() {
+    m_q = sycl::queue{sycl::default_selector_v,
+                      sycl::property::queue::in_order{}};
+    auto dev = m_q.get_device();
+    LOG_INFO("Running on :", dev.get_info<sycl::info::device::name>());
+
+    // Query the device's max work-group size for the pointcloud conversion
+    // kernel
+    m_max_wg_size = dev.get_info<sycl::info::device::max_work_group_size>();
+
+    // NOTE: Angles stay double on device. The ray-cast kernel feeds them to
+    // sin/cos, and on CPU only backend float trig measurably loses to
+    // double trig (glibc). The kernel already narrows the angle to float
+    // before trig, so double costs only the wider H->D copy and per-thread
+    // load and the fp64 throughput penalty is negligible
+    m_devicePtrAngles =
+        sycl::malloc_device<double>(m_scanSize > 0 ? m_scanSize : 1, m_q);
+    m_anglesWide.resize(m_scanSize);
+    m_devicePtrGrid = sycl::malloc_device<int>(m_gridHeight * m_gridWidth, m_q);
+  }
+
+  /**
+   * Builds a per-cell distance table from the given planar origin, in the
+   * column-major layout the ray-cast kernel reads (`cell(i, j)` at flat
+   * index `i + j * gridHeight`). Distances are PLANAR (xy only): the ray
+   * ranges they gate against are planar too, so including a sensor's mount
+   * height would inflate every cell distance and suppress EMPTY fills near
+   * ray endpoints.
+   */
+  float *makeDistanceTable_(const Eigen::Vector2f &originXY) {
+    float *table = sycl::malloc_shared<float>(m_gridHeight * m_gridWidth, m_q);
+    for (int i = 0; i < m_gridHeight; ++i) {
+      for (int j = 0; j < m_gridWidth; ++j) {
+        const Eigen::Vector3f cell = gridToLocal({i, j});
+        table[i + j * m_gridHeight] = (cell.head<2>() - originXY).norm();
+      }
+    }
+    return table;
+  }
+
+  void initLaserscanMode_() {
+    m_devicePtrRanges = sycl::malloc_device<float>(m_scanSize, m_q);
+    m_devicePtrDistances = makeDistanceTable_(m_sensors[0].origin_xy);
+  }
+
+  // Builds the per-sensor device state from m_sensors (already populated by the
+  // base ctor) plus each sensor's field encoding
+  void initPointCloudMode_(const std::vector<SensorConfig> &sensors) {
+    m_sensorDev.reserve(m_sensors.size());
+    for (size_t s = 0; s < m_sensors.size(); ++s) {
+      SensorDeviceState dev;
+      const Eigen::Matrix4f tf = m_sensors[s].tf_body.matrix();
+      dev.tf = {tf(0, 0), tf(0, 1), tf(0, 2), tf(0, 3), tf(1, 0), tf(1, 1),
+                tf(1, 2), tf(1, 3), tf(2, 0), tf(2, 1), tf(2, 2), tf(2, 3)};
+      dev.originXY = m_sensors[s].origin_xy;
+      dev.startPoint = m_sensors[s].start_point;
+      dev.fieldType = sensors[s].cloud_field_type;
+      dev.elementSize = elementSizeOf(dev.fieldType);
+      dev.ranges = sycl::malloc_device<float>(m_scanSize, m_q);
+      dev.distances = makeDistanceTable_(m_sensors[s].origin_xy);
+      m_sensorDev.push_back(dev);
+    }
+
+    // Angles are pre-populated with the `2π / scan_size` bin width the
+    // conversion kernel assumes; upload them once here. All sensors share the
+    // bin space (bearings are body-oriented around each sensor's own origin)
+    m_anglesWide = initializedAngles.cast<double>();
+    m_q.memcpy(m_devicePtrAngles, m_anglesWide.data(),
+               sizeof(double) * m_scanSize);
+    m_q.wait();
+  }
+
+  // Laserscan-mode buffers (null in pointcloud mode)
+  float *m_devicePtrDistances = nullptr;
+  float *m_devicePtrRanges = nullptr;
+
+  // Shared buffers (both modes)
   double
       *m_devicePtrAngles; // uploaded per-call (laserscan) or once (pointcloud)
-  float *m_devicePtrRanges; // fed to the ray-cast kernel
+  int *m_devicePtrGrid;   // output grid
 
-  // Output grid.
-  int *m_devicePtrGrid;
-
-  // Pointcloud-only. Grown lazily on first use in `scanToGrid(bytes,...)`
-  // because the per-scan point count isn't known at ctor time.
-  uint8_t *m_devicePtrRawBytes = nullptr;
-  size_t m_rawCapacity = 0;
+  // Pointcloud mode. One device state per configured sensor; empty in
+  // laserscan mode
+  std::vector<SensorDeviceState> m_sensorDev;
 
   // Host-side widening staging buffer for the double device-angles
   Eigen::VectorXd m_anglesWide;

--- a/src/kompass_cpp/kompass_cpp/include/utils/critical_zone_check.h
+++ b/src/kompass_cpp/kompass_cpp/include/utils/critical_zone_check.h
@@ -1,13 +1,16 @@
 #pragma once
 
+#include "datatypes/sensors.h"
 #include "datatypes/span.h"
 #include "utils/collision_check.h"
 #include <Eigen/Core>
 #include <Eigen/Dense>
+#include <array>
+#include <vector>
 
 namespace Kompass {
 /**
- * @brief Emergency (Critical) Zone Checker using LaserScan data
+ * @brief Emergency (Critical) Zone Checker using LaserScan or PointCloud data
  *
  */
 class CriticalZoneChecker {
@@ -21,24 +24,34 @@ public:
   /**
    * @brief Construct a new CriticalZoneChecker object
    *
-   * * @param input_type           Selects LASERSCAN or POINTCLOUD mode.
-   * - LASERSCAN: Allocates and pre-computes angular indices.
-   * - POINTCLOUD: Allocates raw byte buffer for 3D data.
-   * @param robotShapeType    Type of the robot shape geometry
-   * @param robotDimensions   Corresponding geometry dimensions
-   * @param sensorPositionWRTbody         Position of the sensor w.r.t the robot
-   * body - Considered constant
-   * @param octreeRes         Resolution of the constructed OctTree
+   * @param input_type        Selects LASERSCAN or POINTCLOUD mode.
+   * - LASERSCAN: requires exactly one sensor and non-empty `scan_angles`;
+   * - POINTCLOUD: accepts N sensors (clouds are checked per sensor and the
+   *   minimum safety factor wins); `scan_angles` is unused.
+   * @param robot_shape_type  Type of the robot shape geometry
+   * @param robot_dimensions  Corresponding geometry dimensions
+   * @param sensors           One SensorConfig per sensor (mount pose in the
+   * body frame + the point field encoding for pointcloud input)
+   * @param critical_angle    Full angle of the safety cone (degrees)
+   * @param critical_distance Distance for emergency stop (m)
+   * @param slowdown_distance Distance for linear slowdown (m)
+   * @param min_height        Minimum accepted point height (m). For
+   * pointcloud input this is a BODY-frame band shared by all sensors
+   * (typically 0 .. robot_height): each sensor's mount transform is applied
+   * to the point before the gate
+   * @param max_height        Maximum accepted point height (m), body-frame
+   * for pointcloud input (see min_height)
+   * @param range_max         Maximum valid sensor range (m)
+   * @param scan_angles       (LASERSCAN only) scan angles in radians
    */
   CriticalZoneChecker(InputType input_type,
                       const CollisionChecker::ShapeType robot_shape_type,
                       const std::vector<float> &robot_dimensions,
-                      const Eigen::Vector3f &sensor_position_body,
-                      const Eigen::Vector4f &sensor_rotation_body,
+                      const std::vector<SensorConfig> &sensors,
                       const float critical_angle, const float critical_distance,
-                      const float slowdown_distance,
-                      const std::vector<double> &angles, const float min_height,
-                      const float max_height, const float range_max);
+                      const float slowdown_distance, const float min_height,
+                      const float max_height, const float range_max,
+                      const std::vector<double> &scan_angles = {});
 
   /**
    * @brief Destroy the CriticalZoneChecker object
@@ -56,11 +69,41 @@ public:
    * @param forward   True if the robot is moving forward, false otherwise
    * @return    Slowdown factor (0.0 - 1.0) if in the slowdown zone, 0.0 if in
    * the critical zone (stop), 1.0 otherwise
+   *
+   * @throws std::logic_error when the checker was constructed for pointcloud
+   * input.
    */
   float check(Eigen::Ref<const Eigen::VectorXf> ranges, const bool forward);
 
   /**
-   * Uses 3D point cloud data to check if robot is in slowdown or critical zone.
+   * @brief Checks N point clouds (one per configured sensor, positional
+   * pairing) and returns the minimum safety factor across all of them.
+   *
+   * Each surviving point is transformed with its sensor's full mount
+   * isometry, gated on BODY-frame height, filtered by the body-frame
+   * critical cone (forward or backward), and scored by its planar distance
+   * to the robot's bounding circle. Empty views are skipped; an all-empty batch
+   * returns 1.0 (no constraint).
+   *
+   * @param clouds    One view per configured sensor
+   * @param forward   True if the robot is moving forward, false otherwise
+   * @return    Slowdown factor (0.0 - 1.0); 0.0 = emergency stop
+   *
+   * @throws std::logic_error when the checker was not constructed for
+   * pointcloud input.
+   * @throws std::invalid_argument on cloud count mismatch or negative field
+   * offsets (message names the offending cloud index).
+   */
+  float check(Span<PointCloudView> clouds, const bool forward);
+
+  // Convenience overload for containers / braced lists
+  float check(const std::vector<PointCloudView> &clouds, const bool forward) {
+    return check(Span<PointCloudView>(clouds), forward);
+  }
+
+  /**
+   * Single-cloud adapter onto the batched check above (the checker must be
+   * configured with exactly one sensor).
    *
    * @param data        Flattened point cloud data (uint8), typically in XYZ
    * format.
@@ -71,13 +114,27 @@ public:
    * @param x_offset    Offset (in bytes) to the x-coordinate within a point.
    * @param y_offset    Offset (in bytes) to the y-coordinate within a point.
    * @param z_offset    Offset (in bytes) to the z-coordinate within a point.
-   * @return            A 2D occupancy grid as an Eigen::MatrixXi.
+   * @param forward     True if the robot is moving forward
+   * @return            Slowdown factor (0.0 - 1.0); 0.0 = emergency stop
    */
   float check(ByteSpan data, int point_step, int row_step, int height,
               int width, int x_offset, int y_offset, int z_offset,
               const bool forward);
 
+  /// Number of configured sensors
+  size_t numSensors() const { return sensors_.size(); }
+
 protected:
+  // Per-sensor runtime state derived once from a SensorConfig at
+  // construction; nothing here changes per tick
+  struct SensorRuntime {
+    Eigen::Isometry3f tf_body; // sensor -> body mount (laserscan per-beam)
+    // Rows 0..2 of tf_body [R | t], row-major
+    std::array<float, 12> tf;
+    PointFieldType field_type; // point field encoding (pointcloud decode)
+    int elem_size;             // sizeof one field element
+  };
+
   InputType input_type_;
   double robotHeight_{1.0}, robotRadius_;
   float min_height_, max_height_, range_max_;
@@ -86,12 +143,17 @@ protected:
   std::vector<float> cos_angles_;
   std::vector<size_t> indicies_forward_, indicies_backward_;
   float critical_distance_, slowdown_distance_;
-  // Reused output buffer for the pointcloud → laserscan conversion
-  // avoids a per-frame allocation
-  Eigen::VectorXf ranges_staging_;
 
-  Eigen::Isometry3f sensor_tf_body_ =
-      Eigen::Isometry3f::Identity(); // Sensor transformation with
-                                     // respect to the robot
+  // One runtime per configured sensor (laserscan input has exactly one)
+  std::vector<SensorRuntime> sensors_;
+
+  // Init time derived constants
+
+  // squared radius of the outermost ring that can matter (squared so the
+  // per-point rejection needs no sqrt)
+  float slow_limit_sq_;
+  // slowdown ramp's inverse width (turns the per-point division into a
+  // multiply)
+  float inv_dist_range_;
 };
 } // namespace Kompass

--- a/src/kompass_cpp/kompass_cpp/include/utils/critical_zone_check_gpu.h
+++ b/src/kompass_cpp/kompass_cpp/include/utils/critical_zone_check_gpu.h
@@ -103,27 +103,7 @@ public:
       m_devicePtrRawBytes = nullptr;
       max_wg_size_ = dev.get_info<sycl::info::device::max_work_group_size>();
       // set element size based on point field type
-      switch (m_pointFieldType) {
-      case PointFieldType::INT8:
-      case PointFieldType::UINT8:
-        m_elementSize = 1;
-        break;
-      case PointFieldType::INT16:
-      case PointFieldType::UINT16:
-        m_elementSize = 2;
-        break;
-      case PointFieldType::INT32:
-      case PointFieldType::UINT32:
-      case PointFieldType::FLOAT32:
-        m_elementSize = 4;
-        break;
-      case PointFieldType::FLOAT64:
-        m_elementSize = 8;
-        break;
-      default:
-        m_elementSize = 4;
-        break;
-      }
+      m_elementSize = elementSizeOf(m_pointFieldType);
     }
   }
 

--- a/src/kompass_cpp/kompass_cpp/include/utils/critical_zone_check_gpu.h
+++ b/src/kompass_cpp/kompass_cpp/include/utils/critical_zone_check_gpu.h
@@ -3,7 +3,6 @@
 #include "utils/collision_check.h"
 #include "utils/critical_zone_check.h"
 #include "utils/logger.h"
-#include "utils/pointcloud.h"
 #include <Eigen/Dense>
 #include <sycl/sycl.hpp>
 #include <vector>
@@ -18,39 +17,39 @@ class CriticalZoneCheckerGPU : public CriticalZoneChecker {
 public:
   /**
    * @brief Constructor for GPU-accelerated Safety Check
-   * * @param input_type           Selects LASERSCAN or POINTCLOUD mode.
-   * - LASERSCAN: Allocates and pre-computes angular indices.
-   * - POINTCLOUD: Allocates raw byte buffer for 3D data.
-   * @param robot_shape_type     Robot shape (CIRCLE, RECTANGLE, POLYGON).
-   * @param robot_dimensions     Dimensions specific to the shape.
-   * @param sensor_position_body Position of sensor in body frame (x, y, z).
-   * @param sensor_rotation_body Rotation of sensor (Quaternion x, y, z, w).
-   * @param critical_angle       Half-angle of the safety cone (radians).
-   * @param critical_distance    Distance for emergency stop.
-   * @param slowdown_distance    Distance for linear slowdown.
-   * @param angles               (LASERSCAN ONLY) Vector of angles for the scan.
-   * Pass empty {} for PointCloud.
-   * @param min_height           Min Z height to consider (for PointCloud).
-   * @param max_height           Max Z height to consider (for PointCloud).
-   * @param range_max            Maximum valid sensor range.
-   * @param cloud_field_type: Data type of fields (for PointCloud default:
-   * FLOAT32).
+   *
+   * @param input_type        Selects LASERSCAN or POINTCLOUD mode.
+   * - LASERSCAN: requires exactly one sensor and non-empty `scan_angles`;
+   * - POINTCLOUD: accepts N sensors; each check() submits one kernel per
+   *   cloud, all min-reducing into one shared result.
+   * @param robot_shape_type  Robot shape (CYLINDER, BOX, ...).
+   * @param robot_dimensions  Dimensions specific to the shape.
+   * @param sensors           One SensorConfig per sensor (mount pose in the
+   * body frame + the point field encoding for pointcloud input).
+   * @param critical_angle    Full angle of the safety cone (degrees).
+   * @param critical_distance Distance for emergency stop (m).
+   * @param slowdown_distance Distance for linear slowdown (m).
+   * @param min_height        Minimum accepted point height (m); BODY-frame
+   * band for pointcloud input, shared by all sensors.
+   * @param max_height        Maximum accepted point height (m); body-frame
+   * for pointcloud input.
+   * @param range_max         Maximum valid sensor range (m).
+   * @param scan_angles       (LASERSCAN only) scan angles in radians.
    */
-  CriticalZoneCheckerGPU(
-      InputType input_type, const CollisionChecker::ShapeType robot_shape_type,
-      const std::vector<float> &robot_dimensions,
-      const Eigen::Vector3f &sensor_position_body,
-      const Eigen::Vector4f &sensor_rotation_body, const float critical_angle,
-      const float critical_distance, const float slowdown_distance,
-      const std::vector<double> &angles, const float min_height,
-      const float max_height, const float range_max,
-      const PointFieldType cloud_field_type = PointFieldType::FLOAT32)
+  CriticalZoneCheckerGPU(InputType input_type,
+                         const CollisionChecker::ShapeType robot_shape_type,
+                         const std::vector<float> &robot_dimensions,
+                         const std::vector<SensorConfig> &sensors,
+                         const float critical_angle,
+                         const float critical_distance,
+                         const float slowdown_distance, const float min_height,
+                         const float max_height, const float range_max,
+                         const std::vector<double> &scan_angles = {})
       : CriticalZoneChecker(input_type, robot_shape_type, robot_dimensions,
-                            sensor_position_body, sensor_rotation_body,
-                            critical_angle, critical_distance,
-                            slowdown_distance, angles, min_height, max_height,
-                            range_max),
-        m_scanSize(angles.size()), m_pointFieldType(cloud_field_type) {
+                            sensors, critical_angle, critical_distance,
+                            slowdown_distance, min_height, max_height,
+                            range_max, scan_angles),
+        m_scanSize(scan_angles.size()) {
 
     // Initialize Queue
     m_q = sycl::queue{sycl::default_selector_v,
@@ -67,13 +66,6 @@ public:
     // Mode-Specific Allocation
     if (input_type_ == InputType::LASERSCAN) {
       // --- LaserScan Setup ---
-      // Only allocate these if we actually have angles
-      if (m_scanSize == 0) {
-        LOG_ERROR(
-            "InputType::LASERSCAN selected but 'angles' vector is empty!");
-        return;
-      }
-
       m_devicePtrRanges = sycl::malloc_device<float>(m_scanSize, m_q);
 
       // Load pre-computed Sin/Cos for fast transform
@@ -97,18 +89,16 @@ public:
       m_q.wait(); // Finish transfers
     } else {
       // --- PointCloud Setup ---
-      // Defer large buffer allocation to the first 'check' call
-      // to know the exact size.
-      m_rawCapacity = 0;
-      m_devicePtrRawBytes = nullptr;
       max_wg_size_ = dev.get_info<sycl::info::device::max_work_group_size>();
-      // set element size based on point field type
-      m_elementSize = elementSizeOf(m_pointFieldType);
+      // One device-buffer slot per sensor; grown lazily on first use.
+      m_sensorDev.resize(sensors_.size());
     }
   }
 
   // Destructor
   ~CriticalZoneCheckerGPU() {
+    m_q.wait(); // wait for the queue to finish before freeing memory
+
     // Free Shared Result
     if (m_result)
       sycl::free(m_result, m_q);
@@ -128,27 +118,51 @@ public:
     }
 
     // Free PointCloud Resources
-    if (m_devicePtrRawBytes) {
-      sycl::free(m_devicePtrRawBytes, m_q);
+    for (auto &devState : m_sensorDev) {
+      if (devState.rawBytes) {
+        sycl::free(devState.rawBytes, m_q);
+      }
     }
   }
 
   /**
    * @brief Process 2D LaserScan Data
    * Only valid if initialized with InputType::LASERSCAN
+   *
+   * @throws std::logic_error when the checker was constructed for pointcloud
+   * input.
    */
   float check(Eigen::Ref<const Eigen::VectorXf> ranges, const bool forward);
 
   /**
-   * @brief Process Raw 3D PointCloud Data
-   * Only valid if initialized with InputType::POINTCLOUD
+   * @brief Checks N point clouds (one per configured sensor, positional
+   * pairing) on the GPU and returns the minimum safety factor across all of
+   * them: one kernel per non-empty cloud, all atomically min-reducing into
+   * one shared result, with a single wait at the end. Empty views are
+   * skipped; an all-empty batch returns 1.0.
+   *
+   * @throws std::logic_error when the checker was not constructed for
+   * pointcloud input.
+   * @throws std::invalid_argument on cloud count mismatch or negative field
+   * offsets (message names the offending cloud index).
+   */
+  float check(Span<PointCloudView> clouds, const bool forward);
+
+  // Convenience overload for containers / braced lists
+  float check(const std::vector<PointCloudView> &clouds, const bool forward) {
+    return check(Span<PointCloudView>(clouds), forward);
+  }
+
+  /**
+   * @brief Process Raw 3D PointCloud Data. Single-cloud adapter onto the
+   * batched check above.
    */
   float check(ByteSpan data, int point_step, int row_step, int height,
               int width, int x_offset, int y_offset, int z_offset,
               const bool forward);
 
 private:
-  const size_t m_scanSize;
+  const size_t m_scanSize; // laserscan mode only
 
   // -- Shared --
   float *m_result = nullptr;
@@ -162,11 +176,15 @@ private:
   float *m_sin = nullptr;
 
   // -- PointCloud Specific --
+  // Per-sensor DEVICE BUFFERS only; one entry per configured sensor in
+  // pointcloud mode, empty in laserscan mode
+  struct SensorDeviceState {
+    // Raw PointCloud2 bytes. Grown lazily per call; grow-only
+    uint8_t *rawBytes = nullptr;
+    size_t rawCapacity = 0;
+  };
+  std::vector<SensorDeviceState> m_sensorDev;
   size_t max_wg_size_ = 0;
-  uint8_t *m_devicePtrRawBytes = nullptr;
-  size_t m_rawCapacity = 0;
-  PointFieldType m_pointFieldType; // intialized in init
-  int m_elementSize;               // initialized in init
 };
 
 } // namespace Kompass

--- a/src/kompass_cpp/kompass_cpp/include/utils/pointcloud.h
+++ b/src/kompass_cpp/kompass_cpp/include/utils/pointcloud.h
@@ -49,6 +49,8 @@ inline from_chars_result from_chars(const char *first, const char *last,
  * use the sensor's planar mount position as ray origin and orientation 0
  *
  * @param cloud          View of the raw buffer + layout metadata.
+ * @param field_type     Encoding of the x/y/z fields (dispatches
+ * load_and_cast_val, same as the GPU kernel).
  * @param sensor_tf_body Sensor mount pose in the body frame (full isometry:
  * roll/pitch/yaw honored).
  * @param max_range      Initial value and upper clipping range for distances.
@@ -59,13 +61,11 @@ inline from_chars_result from_chars(const char *first, const char *last,
  * @param num_bins       Number of uniform bins over [0, 2π).
  * @param ranges_out     Output vector of minimum distances per bin.
  *
- * @TODO: Coordinates are read as FLOAT32 at the given offsets. Unlike the GPU
- * kernel, this CPU path does not honor other PointFieldType field encodings.
- *
  * @throws std::invalid_argument on negative field offsets (corrupt metadata).
  */
 inline void
 pointCloudToLaserScanFromRaw(const Kompass::PointCloudView &cloud,
+                             const PointFieldType field_type,
                              const Eigen::Isometry3f &sensor_tf_body,
                              const double max_range, const double min_z_body,
                              const double max_z_body, const int num_bins,
@@ -95,6 +95,8 @@ pointCloudToLaserScanFromRaw(const Kompass::PointCloudView &cloud,
   const float max_range_sq =
       static_cast<float>(max_range) * static_cast<float>(max_range);
 
+  const int elem_size = elementSizeOf(field_type);
+
   // Iterate over raw points. The inner walk is bounded by the row's payload
   // (width points). Organized clouds may pad rows, and padding bytes must not
   // be decoded as points (same as GPU kernel)
@@ -106,16 +108,21 @@ pointCloudToLaserScanFromRaw(const Kompass::PointCloudView &cloud,
       std::size_t max_offset =
           point_start +
           std::max({cloud.x_offset, cloud.y_offset, cloud.z_offset}) +
-          sizeof(float);
+          elem_size;
       if (max_offset > cloud.data.size()) {
         LOG_WARNING("Point offset out of bounds");
         continue;
       }
 
-      float x, y, z;
-      std::memcpy(&x, &cloud.data[point_start + cloud.x_offset], sizeof(float));
-      std::memcpy(&y, &cloud.data[point_start + cloud.y_offset], sizeof(float));
-      std::memcpy(&z, &cloud.data[point_start + cloud.z_offset], sizeof(float));
+      const float x = load_and_cast_val(cloud.data.data(),
+                                        point_start + cloud.x_offset,
+                                        field_type);
+      const float y = load_and_cast_val(cloud.data.data(),
+                                        point_start + cloud.y_offset,
+                                        field_type);
+      const float z = load_and_cast_val(cloud.data.data(),
+                                        point_start + cloud.z_offset,
+                                        field_type);
 
       // Reject non-finite points (NaN padding in organized clouds)
       if (!std::isfinite(x) || !std::isfinite(y) || !std::isfinite(z)) {
@@ -178,7 +185,7 @@ pointCloudToLaserScanFromRaw(const Kompass::PointCloudView &cloud,
  * step (size and contents are both checked).
  */
 inline void pointCloudToLaserScanFromRaw(
-    const Kompass::PointCloudView &cloud,
+    const Kompass::PointCloudView &cloud, const PointFieldType field_type,
     const Eigen::Isometry3f &sensor_tf_body, const double max_range,
     const double min_z_body, const double max_z_body, const double angle_step,
     Eigen::VectorXf &ranges_out, Eigen::VectorXf &angles_out) {
@@ -197,8 +204,8 @@ inline void pointCloudToLaserScanFromRaw(
     }
   }
 
-  pointCloudToLaserScanFromRaw(cloud, sensor_tf_body, max_range, min_z_body,
-                               max_z_body, num_bins, ranges_out);
+  pointCloudToLaserScanFromRaw(cloud, field_type, sensor_tf_body, max_range,
+                               min_z_body, max_z_body, num_bins, ranges_out);
 }
 
 inline bool is_space(char c) {

--- a/src/kompass_cpp/kompass_cpp/include/utils/pointcloud.h
+++ b/src/kompass_cpp/kompass_cpp/include/utils/pointcloud.h
@@ -36,48 +36,6 @@ inline from_chars_result from_chars(const char *first, const char *last,
 } // namespace std
 #endif
 
-// Helper: Loads bytes safely handling potential misalignment
-inline float load_and_cast_val(const uint8_t *ptr, size_t offset,
-                               PointFieldType type) {
-  const uint8_t *addr = ptr + offset;
-
-  // Generic lambda to load unaligned data safely
-  auto load_safe = [&](auto dummy_type) {
-    using T = decltype(dummy_type);
-    T val;
-    // Copy byte-by-byte (compiler optimizes this to a register load)
-    // use uint8_t* to match the source pointer type
-    for (size_t i = 0; i < sizeof(T); ++i) {
-      reinterpret_cast<uint8_t *>(&val)[i] = addr[i];
-    }
-    return static_cast<float>(val);
-  };
-
-  switch (type) {
-  case PointFieldType::INT8:
-    // INT8 is always aligned (1 byte)
-    return static_cast<float>(*reinterpret_cast<const int8_t *>(addr));
-  case PointFieldType::UINT8:
-    // UINT8 is always aligned (1 byte)
-    return static_cast<float>(*addr);
-  case PointFieldType::INT16:
-    return load_safe(int16_t{});
-  case PointFieldType::UINT16:
-    return load_safe(uint16_t{});
-  case PointFieldType::INT32:
-    return load_safe(int32_t{});
-  case PointFieldType::UINT32:
-    return load_safe(uint32_t{});
-  case PointFieldType::FLOAT32:
-    return load_safe(float{});
-  case PointFieldType::FLOAT64:
-    return load_safe(double{});
-
-  default:
-    return 0.0f;
-  }
-}
-
 /**
  * @brief Converts raw PointCloud2-style byte data to a 2D LaserScan-like
  * pseudo-scan around the sensor origin, expressed in BODY orientation.
@@ -133,6 +91,10 @@ pointCloudToLaserScanFromRaw(const Kompass::PointCloudView &cloud,
   const float r20 = rot(2, 0), r21 = rot(2, 1), r22 = rot(2, 2);
   const float t_z = sensor_tf_body.translation().z();
 
+  // Points at/beyond max_range can never win a bin, calculate its sqr
+  const float max_range_sq =
+      static_cast<float>(max_range) * static_cast<float>(max_range);
+
   // Iterate over raw points. The inner walk is bounded by the row's payload
   // (width points). Organized clouds may pad rows, and padding bytes must not
   // be decoded as points (same as GPU kernel)
@@ -179,6 +141,10 @@ pointCloudToLaserScanFromRaw(const Kompass::PointCloudView &cloud,
       // No planar extent -> no bin (point straight above/below the sensor)
       const float range_sq = xr * xr + yr * yr;
       if (range_sq < 1e-6f) {
+        continue;
+      }
+      // Beyond max_range -> can never win the per-bin min
+      if (range_sq >= max_range_sq) {
         continue;
       }
 

--- a/src/kompass_cpp/kompass_cpp/include/utils/pointcloud.h
+++ b/src/kompass_cpp/kompass_cpp/include/utils/pointcloud.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "datatypes/sensors.h"
 #include "datatypes/span.h"
 #include "mapping/local_mapper.h"
 #include "utils/logger.h"
@@ -34,18 +35,6 @@ inline from_chars_result from_chars(const char *first, const char *last,
 }
 } // namespace std
 #endif
-
-// Point offset type
-enum class PointFieldType : int {
-  INT8 = 1,
-  UINT8 = 2,
-  INT16 = 3,
-  UINT16 = 4,
-  INT32 = 5,
-  UINT32 = 6,
-  FLOAT32 = 7,
-  FLOAT64 = 8
-};
 
 // Helper: Loads bytes safely handling potential misalignment
 inline float load_and_cast_val(const uint8_t *ptr, size_t offset,
@@ -90,64 +79,143 @@ inline float load_and_cast_val(const uint8_t *ptr, size_t offset,
 }
 
 /**
- * @brief Converts raw PointCloud2-style byte data to 2D LaserScan-like data.
+ * @brief Converts raw PointCloud2-style byte data to a 2D LaserScan-like
+ * pseudo-scan around the sensor origin, expressed in BODY orientation.
  *
- * This function extracts 3D points (x, y, z) directly from a raw byte buffer
- * and projects them onto a 2D laser scan by computing the angle and distance
- * for each point. It divides the full 360° field of view into bins using
- * angle_step, and assigns the closest point to each bin.
+ * Each point is read from the raw buffer, rotated by the mount rotation, and
+ * height-gated on its BODY-frame z (rotation applied plus the mount's z
+ * offset). Surviving points are binned by their bearing around the sensor
+ * origin in body orientation: bin angle = atan2 of the rotated planar
+ * coordinates, range = planar distance from the sensor origin. The closest
+ * point per bin wins. A consumer casting rays from this pseudo-scan should
+ * use the sensor's planar mount position as ray origin and orientation 0
  *
- * @param data         Raw point cloud data as a flattened byte array.
- * @param point_step   Number of bytes between successive points in a row.
- * @param row_step     Number of bytes between successive rows.
- * @param height       Number of rows in the point cloud.
- * @param width        Number of points per row. Bounds the per-row walk, so
- * trailing row padding (row_step > width * point_step) is not decoded as
- * points.
- * @param x_offset     Byte offset to the x-coordinate in a point.
- * @param y_offset     Byte offset to the y-coordinate in a point.
- * @param z_offset     Byte offset to the z-coordinate in a point.
- * @param max_range    Initial value and upper clipping range for distances.
- * @param min_z        Minimum acceptable Z value (inclusive).
- * @param max_z        Maximum acceptable Z value (inclusive). Pass
+ * @param cloud          View of the raw buffer + layout metadata.
+ * @param sensor_tf_body Sensor mount pose in the body frame (full isometry:
+ * roll/pitch/yaw honored).
+ * @param max_range      Initial value and upper clipping range for distances.
+ * @param min_z_body     Minimum acceptable BODY-frame z (inclusive).
+ * @param max_z_body     Maximum acceptable BODY-frame z (inclusive). Pass
  * `std::numeric_limits<double>::infinity()` for no upper bound. Note a
- * negative bound is a legitimate one, not a request to disable the gate: z is
- * a signed sensor-frame coordinate, so a sensor mounted above the volume of
- * interest gives a band that lies entirely below it.
- * @param angle_step   Angular resolution (in radians) of each bin.
- * @param ranges_out   Output vector of minimum distances per bin.
- * @param angles_out   Output vector of bin angles in radians [0, 2π).
+ * negative bound is a legitimate one, not a request to disable the gate.
+ * @param num_bins       Number of uniform bins over [0, 2π).
+ * @param ranges_out     Output vector of minimum distances per bin.
  *
  * @TODO: Coordinates are read as FLOAT32 at the given offsets. Unlike the GPU
  * kernel, this CPU path does not honor other PointFieldType field encodings.
  *
- * @TODO: The z gate is applied on the sensor's own z axis, so it can only
- * express a height band for a mount whose rotation preserves that axis --
- * i.e. yaw-only, which covers the usual case exactly. Under roll or pitch the
- * point's x/y leak into its body-frame height by an amount that grows with
- * range (15 deg of pitch skews z by ~0.78 m at 3 m), so no constant
- * (min_z, max_z) pair describes the intended band and callers cannot correct
- * for it on their side. Fixing it means gating on body-frame z: take the
- * third row of the sensor-to-body transform plus its z offset, and test
- * r0*x + r1*y + r2*z + tz against the band. The GPU kernel needs the same
- * change -- it already uploads rows 0 and 1 of that transform, so only row 2
- * and moving the filter after the dot product are missing. Deferred to a
- * later release: it changes the meaning of min_z/max_z for every caller.
- *
- * @throws std::out_of_range If point offsets access memory out of bounds.
+ * @throws std::invalid_argument on negative field offsets (corrupt metadata).
  */
-inline void pointCloudToLaserScanFromRaw(
-    Kompass::ByteSpan data, const int point_step, const int row_step, const int height,
-    const int width, const int x_offset, const int y_offset,
-    const int z_offset, const double max_range, const double min_z,
-    const double max_z, const double angle_step, Eigen::VectorXf &ranges_out,
-    Eigen::VectorXf &angles_out) {
+inline void
+pointCloudToLaserScanFromRaw(const Kompass::PointCloudView &cloud,
+                             const Eigen::Isometry3f &sensor_tf_body,
+                             const double max_range, const double min_z_body,
+                             const double max_z_body, const int num_bins,
+                             Eigen::VectorXf &ranges_out) {
   // Fail loudly for a negative off-set (corrupted metadata)
-  if (x_offset < 0 || y_offset < 0 || z_offset < 0) {
+  if (cloud.x_offset < 0 || cloud.y_offset < 0 || cloud.z_offset < 0) {
     throw std::invalid_argument(
         "Point field offsets (x/y/z) must be non-negative: malformed point "
         "cloud metadata");
   }
+  const double two_pi = 2.0 * M_PI;
+
+  // reinitialize ranges
+  ranges_out.resize(num_bins);
+  ranges_out.setConstant(static_cast<float>(max_range));
+
+  // Hoist the mount transform. Only the rotation enters x/y (bearing and
+  // radius stay relative to the sensor origin); the translation's z enters
+  // the body-frame height gate.
+  const Eigen::Matrix3f rot = sensor_tf_body.rotation();
+  const float r00 = rot(0, 0), r01 = rot(0, 1), r02 = rot(0, 2);
+  const float r10 = rot(1, 0), r11 = rot(1, 1), r12 = rot(1, 2);
+  const float r20 = rot(2, 0), r21 = rot(2, 1), r22 = rot(2, 2);
+  const float t_z = sensor_tf_body.translation().z();
+
+  // Iterate over raw points. The inner walk is bounded by the row's payload
+  // (width points). Organized clouds may pad rows, and padding bytes must not
+  // be decoded as points (same as GPU kernel)
+  const int row_bytes = cloud.width * cloud.point_step;
+  for (int row = 0; row < cloud.height; ++row) {
+    for (int col = 0; col < row_bytes; col += cloud.point_step) {
+      std::size_t point_start = row * cloud.row_step + col;
+
+      std::size_t max_offset =
+          point_start +
+          std::max({cloud.x_offset, cloud.y_offset, cloud.z_offset}) +
+          sizeof(float);
+      if (max_offset > cloud.data.size()) {
+        LOG_WARNING("Point offset out of bounds");
+        continue;
+      }
+
+      float x, y, z;
+      std::memcpy(&x, &cloud.data[point_start + cloud.x_offset], sizeof(float));
+      std::memcpy(&y, &cloud.data[point_start + cloud.y_offset], sizeof(float));
+      std::memcpy(&z, &cloud.data[point_start + cloud.z_offset], sizeof(float));
+
+      // Reject non-finite points (NaN padding in organized clouds)
+      if (!std::isfinite(x) || !std::isfinite(y) || !std::isfinite(z)) {
+        continue;
+      }
+
+      // A point at the sensor origin carries no bearing. Reject in the SENSOR
+      // frame, before rotation, so it can never end up mapped to the mount
+      // position (inside the robot) downstream.
+      if (x * x + y * y + z * z < 1e-6f) {
+        continue;
+      }
+
+      // Rotate into body orientation and gate on body-frame height
+      const float xr = r00 * x + r01 * y + r02 * z;
+      const float yr = r10 * x + r11 * y + r12 * z;
+      const float zb = r20 * x + r21 * y + r22 * z + t_z;
+
+      if (zb < min_z_body || zb > max_z_body) {
+        continue;
+      }
+
+      // No planar extent -> no bin (point straight above/below the sensor)
+      const float range_sq = xr * xr + yr * yr;
+      if (range_sq < 1e-6f) {
+        continue;
+      }
+
+      double angle = std::atan2(yr, xr);
+      if (angle < 0.0) {
+        angle += two_pi;
+      }
+
+      int bin = static_cast<int>((angle / two_pi) * num_bins);
+      bin = std::clamp(bin, 0, num_bins - 1); // Clamp just in case
+
+      const float distance = static_cast<float>(std::sqrt(range_sq));
+      if (distance < ranges_out[bin]) {
+        ranges_out[bin] = distance;
+      }
+    }
+  }
+}
+
+/**
+ * @brief angle_step variant of the conversion above, also producing the bin
+ * angle labels.
+ *
+ * Derives `num_bins = ceil(2π / angle_step)` and delegates to the num_bins
+ * conversion, so bins are uniform at 2π/num_bins. Marginally narrower than
+ * the requested step when 2π is not an exact multiple of it. Labels are the
+ * requested `i * angle_step` (bin starts).
+ *
+ * @param angles_out   Output vector of bin angles in radians [0, 2π). Only
+ * refilled when the caller's buffer doesn't already hold labels for this
+ * step (size and contents are both checked).
+ */
+inline void pointCloudToLaserScanFromRaw(
+    const Kompass::PointCloudView &cloud,
+    const Eigen::Isometry3f &sensor_tf_body, const double max_range,
+    const double min_z_body, const double max_z_body, const double angle_step,
+    Eigen::VectorXf &ranges_out, Eigen::VectorXf &angles_out) {
   const double two_pi = 2.0 * M_PI;
   const int num_bins = static_cast<int>(std::ceil(two_pi / angle_step));
 
@@ -162,163 +230,9 @@ inline void pointCloudToLaserScanFromRaw(
       angles_out[i] = static_cast<float>(i * angle_step);
     }
   }
-  ranges_out.resize(num_bins);
-  ranges_out.setConstant(static_cast<float>(max_range));
 
-  // Iterate over raw points. The inner walk is bounded by the row's payload
-  // (width points). Organized clouds may pad rows, and padding bytes must not
-  // be decoded as points (same as GPU kernel)
-  const int row_bytes = width * point_step;
-  for (int row = 0; row < height; ++row) {
-    for (int col = 0; col < row_bytes; col += point_step) {
-      std::size_t point_start = row * row_step + col;
-
-      std::size_t max_offset = point_start +
-                               std::max({x_offset, y_offset, z_offset}) +
-                               sizeof(float);
-      if (max_offset > data.size()) {
-        LOG_WARNING("Point offset out of bounds");
-        continue;
-      }
-
-      float x, y, z;
-      std::memcpy(&x, &data[point_start + x_offset], sizeof(float));
-      std::memcpy(&y, &data[point_start + y_offset], sizeof(float));
-      std::memcpy(&z, &data[point_start + z_offset], sizeof(float));
-
-      // Reject non-finite points (NaN padding in organized clouds)
-      if (!std::isfinite(x) || !std::isfinite(y) || !std::isfinite(z)) {
-        continue;
-      }
-
-      // filter (0,0,0) early with epsilon for checking float equality to 0.0f
-      float range_sq = x * x + y * y;
-      if (range_sq < 1e-6) {
-        continue;
-      }
-
-      // Z filtering. Applied as given, matching the GPU kernel: the sign of
-      // the bound carries no meaning of its own
-      if (z < min_z || z > max_z) {
-        continue;
-      }
-
-      double angle = std::atan2(y, x);
-      if (angle < 0.0) {
-        angle += two_pi;
-      }
-
-      int bin = static_cast<int>(angle / angle_step);
-      bin = std::clamp(bin, 0, num_bins - 1); // Clamp just in case
-
-      float distance = static_cast<float>(std::sqrt(range_sq));
-      if (distance < ranges_out[bin]) {
-        ranges_out[bin] = distance;
-      }
-    }
-  }
-}
-
-/**
- * @brief Converts raw PointCloud2-style byte data to 2D LaserScan-like data.
- *
- * This function extracts 3D points (x, y, z) directly from a raw byte buffer
- * and projects them onto a 2D laser scan by computing the angle and distance
- * for each point. It divides the full 360° field of view into bins and assigns
- * the closest point to each bin. FOR INTERNAL USE: with pre-initialized output
- * vectors.
- *
- * @param data         Raw point cloud data as a flattened byte array.
- * @param point_step   Number of bytes between successive points in a row.
- * @param row_step     Number of bytes between successive rows.
- * @param height       Number of rows in the point cloud.
- * @param width        Number of points per row. Bounds the per-row walk, so
- * trailing row padding (row_step > width * point_step) is not decoded as
- * points.
- * @param x_offset     Byte offset to the x-coordinate in a point.
- * @param y_offset     Byte offset to the y-coordinate in a point.
- * @param z_offset     Byte offset to the z-coordinate in a point.
- * @param max_range    Initial value and upper clipping range for distances.
- * @param min_z        Minimum acceptable Z value (inclusive).
- * @param max_z        Maximum acceptable Z value (inclusive). Pass
- * `std::numeric_limits<double>::infinity()` for no upper bound. Note a
- * negative bound is a legitimate one, not a request to disable the gate: z is
- * a signed sensor-frame coordinate, so a sensor mounted above the volume of
- * interest gives a band that lies entirely below it.
- * @param num_bins     Number of rays in the laserscan.
- * @param ranges_out   Output vector of minimum distances per bin.
- *
- * @throws std::out_of_range If point offsets access memory out of bounds.
- */
-inline void pointCloudToLaserScanFromRaw(
-    Kompass::ByteSpan data, const int point_step, const int row_step, const int height,
-    const int width, const int x_offset, const int y_offset,
-    const int z_offset, const double max_range, const double min_z,
-    const double max_z, const int num_bins, Eigen::VectorXf &ranges_out) {
-  // Fail loudly for a negative off-set (corrupted metadata)
-  if (x_offset < 0 || y_offset < 0 || z_offset < 0) {
-    throw std::invalid_argument(
-        "Point field offsets (x/y/z) must be non-negative: malformed point "
-        "cloud metadata");
-  }
-  const double two_pi = 2.0 * M_PI;
-
-  // reinitialize ranges
-  ranges_out.resize(num_bins);
-  ranges_out.setConstant(static_cast<float>(max_range));
-
-  // Iterate over raw points. The inner walk is bounded by the row's payload
-  // (width points). Organized clouds may pad rows, and padding bytes must not
-  // be decoded as points (same as GPU kernel)
-  const int row_bytes = width * point_step;
-  for (int row = 0; row < height; ++row) {
-    for (int col = 0; col < row_bytes; col += point_step) {
-      std::size_t point_start = row * row_step + col;
-
-      std::size_t max_offset = point_start +
-                               std::max({x_offset, y_offset, z_offset}) +
-                               sizeof(float);
-      if (max_offset > data.size()) {
-        LOG_WARNING("Point offset out of bounds");
-        continue;
-      }
-
-      float x, y, z;
-      std::memcpy(&x, &data[point_start + x_offset], sizeof(float));
-      std::memcpy(&y, &data[point_start + y_offset], sizeof(float));
-      std::memcpy(&z, &data[point_start + z_offset], sizeof(float));
-
-      // Reject non-finite points (NaN padding in organized clouds)
-      if (!std::isfinite(x) || !std::isfinite(y) || !std::isfinite(z)) {
-        continue;
-      }
-
-      // filter (0,0,0) early with epsilon for checking float equality to 0.0f
-      float range_sq = x * x + y * y;
-      if (range_sq < 1e-6) {
-        continue;
-      }
-
-      // Z filtering. Applied as given, matching the GPU kernel: the sign of
-      // the bound carries no meaning of its own
-      if (z < min_z || z > max_z) {
-        continue;
-      }
-
-      double angle = std::atan2(y, x);
-      if (angle < 0.0) {
-        angle += two_pi;
-      }
-
-      int bin = static_cast<int>((angle / two_pi) * num_bins);
-      bin = std::clamp(bin, 0, num_bins - 1); // Clamp just in case
-
-      float distance = static_cast<float>(std::sqrt(range_sq));
-      if (distance < ranges_out[bin]) {
-        ranges_out[bin] = distance;
-      }
-    }
-  }
+  pointCloudToLaserScanFromRaw(cloud, sensor_tf_body, max_range, min_z_body,
+                               max_z_body, num_bins, ranges_out);
 }
 
 inline bool is_space(char c) {

--- a/src/kompass_cpp/kompass_cpp/include/utils/trajectory_sampler.h
+++ b/src/kompass_cpp/kompass_cpp/include/utils/trajectory_sampler.h
@@ -5,6 +5,7 @@
 #include "datatypes/parameter.h"
 #include "datatypes/path.h"
 #include "datatypes/trajectory.h"
+#include "threadpool.h"
 #include <cmath>
 #include <memory>
 #include <vector>
@@ -156,6 +157,9 @@ protected:
   ControlLimitsParams ctrlimits;
   std::unique_ptr<CollisionChecker> collChecker;
   int maxNumThreads;
+  // Created once at construction when maxNumThreads > 1 and reused across
+  // calls
+  std::unique_ptr<ThreadPool> m_pool;
 
 private:
   double time_step_{0.0};

--- a/src/kompass_cpp/kompass_cpp/include/utils/trajectory_sampler.h
+++ b/src/kompass_cpp/kompass_cpp/include/utils/trajectory_sampler.h
@@ -5,7 +5,6 @@
 #include "datatypes/parameter.h"
 #include "datatypes/path.h"
 #include "datatypes/trajectory.h"
-#include <array>
 #include <cmath>
 #include <memory>
 #include <vector>

--- a/src/kompass_cpp/kompass_cpp/src/mapping/local_mapper.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/mapping/local_mapper.cpp
@@ -6,6 +6,7 @@
 #include <Eigen/SparseCore>
 #include <cstdio>
 #include <mutex>
+#include <string>
 #include <vector>
 
 namespace Kompass {
@@ -123,12 +124,13 @@ float LocalMapper::updateGridCellProbability(float distance, float currentRange,
   return pCurr;
 }
 
-void LocalMapper::updateGrid_(const float angle, const float range) {
+void LocalMapper::updateGrid_(const float angle, const float range,
+                              const Eigen::Vector2f originXY,
+                              const float orientation,
+                              const Eigen::Vector2i startPoint) {
 
-  float x =
-      m_laserscanPosition(0) + (range * cos(m_laserscanOrientation + angle));
-  float y =
-      m_laserscanPosition(1) + (range * sin(m_laserscanOrientation + angle));
+  float x = originXY(0) + (range * cos(orientation + angle));
+  float y = originXY(1) + (range * sin(orientation + angle));
 
   Eigen::Vector2i toPoint = localToGrid(Eigen::Vector2f(x, y));
   // Reused across rays on the same worker thread: one heap allocation per
@@ -137,7 +139,7 @@ void LocalMapper::updateGrid_(const float angle, const float range) {
   points.clear();
   points.reserve(m_maxPointsPerLine);
 
-  bresenhamEnhanced(m_startPoint, toPoint, points);
+  bresenhamEnhanced(startPoint, toPoint, points);
 
   // One lock per ray. The writes below are cheap cell stores, so holding
   // the lock across the line beats a lock per cell
@@ -159,12 +161,13 @@ void LocalMapper::updateGrid_(const float angle, const float range) {
   }
 }
 
-void LocalMapper::updateGridBaysian_(const float angle, const float range) {
+void LocalMapper::updateGridBayesian_(const float angle, const float range,
+                                      const Eigen::Vector2f originXY,
+                                      const float orientation,
+                                      const Eigen::Vector2i startPoint) {
 
-  float x =
-      m_laserscanPosition(0) + (range * cos(m_laserscanOrientation + angle));
-  float y =
-      m_laserscanPosition(1) + (range * sin(m_laserscanOrientation + angle));
+  float x = originXY(0) + (range * cos(orientation + angle));
+  float y = originXY(1) + (range * sin(orientation + angle));
 
   Eigen::Vector2i toPoint = localToGrid(Eigen::Vector2f(x, y));
   // Reused across rays on the same worker thread
@@ -173,7 +176,7 @@ void LocalMapper::updateGridBaysian_(const float angle, const float range) {
   points.clear();
   points.reserve(m_maxPointsPerLine);
 
-  bresenhamEnhanced(m_startPoint, toPoint, points);
+  bresenhamEnhanced(startPoint, toPoint, points);
 
   // Do probability math outside the lock
   newValues.resize(points.size());
@@ -181,7 +184,7 @@ void LocalMapper::updateGridBaysian_(const float angle, const float range) {
     const auto &pt = points[i];
     if (pt(0) >= 0 && pt(0) < m_gridHeight && pt(1) >= 0 &&
         pt(1) < m_gridWidth) {
-      float distance = (pt - m_startPoint).norm();
+      float distance = (pt - startPoint).norm();
       newValues[i] = updateGridCellProbability(
           distance, range, previousGridDataProb(pt(0), pt(1)));
     }
@@ -209,75 +212,160 @@ void LocalMapper::updateGridBaysian_(const float angle, const float range) {
   }
 }
 
-Eigen::MatrixXi &
-LocalMapper::scanToGrid(Eigen::Ref<const Eigen::VectorXf> angles,
-                        Eigen::Ref<const Eigen::VectorXf> ranges) {
-
-  gridData.fill(static_cast<int>(Mapping::OccupancyType::UNEXPLORED));
+void LocalMapper::rasterizeScan_(Eigen::Ref<const Eigen::VectorXf> angles,
+                                 Eigen::Ref<const Eigen::VectorXf> ranges,
+                                 const Eigen::Vector2f originXY,
+                                 const float orientation,
+                                 const Eigen::Vector2i startPoint) {
   if (m_pool) {
     static thread_local std::vector<std::future<void>> futures;
     futures.clear();
     futures.reserve(angles.size());
     for (Eigen::Index i = 0; i < angles.size(); ++i) {
       futures.emplace_back(m_pool->enqueue(&LocalMapper::updateGrid_, this,
-                                           angles[i], ranges[i]));
+                                           angles[i], ranges[i], originXY,
+                                           orientation, startPoint));
     }
     for (auto &f : futures) {
       f.wait();
     }
   } else {
     for (Eigen::Index i = 0; i < angles.size(); ++i) {
-      updateGrid_(angles[i], ranges[i]);
+      updateGrid_(angles[i], ranges[i], originXY, orientation, startPoint);
     }
   }
-  return gridData;
 }
 
-std::tuple<Eigen::MatrixXi &, Eigen::MatrixXf &>
-LocalMapper::scanToGridBaysian(Eigen::Ref<const Eigen::VectorXf> angles,
-                               Eigen::Ref<const Eigen::VectorXf> ranges) {
-
-  gridData.fill(static_cast<int>(Mapping::OccupancyType::UNEXPLORED));
-  gridDataProb.fill(m_pPrior);
+void LocalMapper::rasterizeScanBayesian_(
+    Eigen::Ref<const Eigen::VectorXf> angles,
+    Eigen::Ref<const Eigen::VectorXf> ranges, const Eigen::Vector2f originXY,
+    const float orientation, const Eigen::Vector2i startPoint) {
   if (m_pool) {
     static thread_local std::vector<std::future<void>> futures;
     futures.clear();
     futures.reserve(angles.size());
     for (Eigen::Index i = 0; i < angles.size(); ++i) {
-      futures.emplace_back(m_pool->enqueue(&LocalMapper::updateGridBaysian_,
-                                           this, angles[i], ranges[i]));
+      futures.emplace_back(m_pool->enqueue(&LocalMapper::updateGridBayesian_,
+                                           this, angles[i], ranges[i], originXY,
+                                           orientation, startPoint));
     }
     for (auto &f : futures) {
       f.wait();
     }
   } else {
     for (Eigen::Index i = 0; i < angles.size(); ++i) {
-      updateGridBaysian_(angles[i], ranges[i]);
+      updateGridBayesian_(angles[i], ranges[i], originXY, orientation,
+                          startPoint);
     }
   }
+}
+
+// Laserscan overload
+Eigen::MatrixXi &
+LocalMapper::scanToGrid(Eigen::Ref<const Eigen::VectorXf> angles,
+                        Eigen::Ref<const Eigen::VectorXf> ranges) {
+  if (m_isPointCloud) {
+    throw std::logic_error("scanToGrid(angles, ranges): mapper was "
+                           "constructed for pointcloud input");
+  }
+  gridData.fill(static_cast<int>(Mapping::OccupancyType::UNEXPLORED));
+  rasterizeScan_(angles, ranges, m_sensors[0].origin_xy, m_sensors[0].yaw,
+                 m_sensors[0].start_point);
+  return gridData;
+}
+
+// Laserscan Bayesian overload
+std::tuple<Eigen::MatrixXi &, Eigen::MatrixXf &>
+LocalMapper::scanToGridBayesian(Eigen::Ref<const Eigen::VectorXf> angles,
+                                Eigen::Ref<const Eigen::VectorXf> ranges) {
+  if (m_isPointCloud) {
+    throw std::logic_error("scanToGridBayesian(angles, ranges): mapper was "
+                           "constructed for pointcloud input");
+  }
+  gridData.fill(static_cast<int>(Mapping::OccupancyType::UNEXPLORED));
+  gridDataProb.fill(m_pPrior);
+  rasterizeScanBayesian_(angles, ranges, m_sensors[0].origin_xy,
+                         m_sensors[0].yaw, m_sensors[0].start_point);
   return std::tie(gridData, gridDataProb);
 }
 
+// Multi Pointcloud sensor overload
+Eigen::MatrixXi &LocalMapper::scanToGrid(Span<PointCloudView> clouds) {
+  if (!m_isPointCloud) {
+    throw std::logic_error(
+        "scanToGrid(clouds): mapper was not constructed for pointcloud input");
+  }
+  if (clouds.size() != m_sensors.size()) {
+    throw std::invalid_argument("scanToGrid(clouds): got " +
+                                std::to_string(clouds.size()) + " clouds for " +
+                                std::to_string(m_sensors.size()) + " sensors");
+  }
+  // Validate every cloud before touching the grid, so a bad batch cannot
+  // leave a half-fused result
+  for (size_t i = 0; i < clouds.size(); ++i) {
+    const auto &cloud = clouds[i];
+    if (!cloud.empty() &&
+        (cloud.x_offset < 0 || cloud.y_offset < 0 || cloud.z_offset < 0)) {
+      throw std::invalid_argument(
+          "clouds[" + std::to_string(i) +
+          "]: point field offsets (x/y/z) must be non-negative: malformed "
+          "point cloud metadata");
+    }
+  }
+
+  // initialize grid once
+  gridData.fill(static_cast<int>(Mapping::OccupancyType::UNEXPLORED));
+
+  for (size_t i = 0; i < clouds.size(); ++i) {
+    // Skip if cloud is empty
+    if (clouds[i].empty()) {
+      continue;
+    }
+    // Convert around this sensor's mount. Bearings come out in body
+    // orientation around the sensor origin, so the ray cast runs with
+    // orientation 0 from the sensor's own cell
+    pointCloudToLaserScanFromRaw(clouds[i], m_sensors[i].tf_body, m_rangeMax,
+                                 m_minHeight, m_maxHeight, m_scanSize,
+                                 initializedRanges);
+    rasterizeScan_(initializedAngles, initializedRanges, m_sensors[i].origin_xy,
+                   0.0f, m_sensors[i].start_point);
+  }
+  return gridData;
+}
+
+// Single sensor pointcloud convenience overload
 Eigen::MatrixXi &LocalMapper::scanToGrid(ByteSpan data, int point_step,
                                          int row_step, int height, int width,
                                          int x_offset, int y_offset,
                                          int z_offset) {
-  pointCloudToLaserScanFromRaw(
-      data, point_step, row_step, height, width, x_offset, y_offset, z_offset,
-      m_rangeMax, m_minHeight, m_maxHeight, m_scanSize, initializedRanges);
-  return scanToGrid(initializedAngles, initializedRanges);
+  const PointCloudView view{data,  point_step, row_step, height,
+                            width, x_offset,   y_offset, z_offset};
+  return scanToGrid(Span<PointCloudView>(&view, 1));
 }
 
+// Single sensor pointcloud Bayesian overload
 std::tuple<Eigen::MatrixXi &, Eigen::MatrixXf &>
-LocalMapper::scanToGridBaysian(ByteSpan data, int point_step, int row_step,
-                               int height, int width, int x_offset,
-                               int y_offset, int z_offset) {
-  // Bin by scan_size through the member buffers, exactly like the
-  // non-Bayesian path
-  pointCloudToLaserScanFromRaw(
-      data, point_step, row_step, height, width, x_offset, y_offset, z_offset,
-      m_rangeMax, m_minHeight, m_maxHeight, m_scanSize, initializedRanges);
-  return scanToGridBaysian(initializedAngles, initializedRanges);
+LocalMapper::scanToGridBayesian(ByteSpan data, int point_step, int row_step,
+                                int height, int width, int x_offset,
+                                int y_offset, int z_offset) {
+  // Bayesian fusion stays single-sensor
+  if (!m_isPointCloud || m_sensors.size() != 1) {
+    throw std::logic_error(
+        "scanToGridBayesian supports exactly one pointcloud sensor");
+  }
+  // Bin by scan_size through the member buffers. Bearings come out in body
+  // orientation around the sensor origin, so the ray cast runs with orientation 0
+  pointCloudToLaserScanFromRaw(PointCloudView{data, point_step, row_step,
+                                              height, width, x_offset, y_offset,
+                                              z_offset},
+                               m_sensors[0].tf_body, m_rangeMax, m_minHeight,
+                               m_maxHeight, m_scanSize, initializedRanges);
+  gridData.fill(static_cast<int>(Mapping::OccupancyType::UNEXPLORED));
+  gridDataProb.fill(m_pPrior);
+  rasterizeScanBayesian_(initializedAngles, initializedRanges,
+                         m_sensors[0].origin_xy, 0.0f,
+                         m_sensors[0].start_point);
+  return std::tie(gridData, gridDataProb);
 }
 } // namespace Mapping
 } // namespace Kompass

--- a/src/kompass_cpp/kompass_cpp/src/mapping/local_mapper.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/mapping/local_mapper.cpp
@@ -6,7 +6,6 @@
 #include <Eigen/SparseCore>
 #include <cstdio>
 #include <mutex>
-#include <string>
 #include <vector>
 
 namespace Kompass {
@@ -295,23 +294,7 @@ Eigen::MatrixXi &LocalMapper::scanToGrid(Span<PointCloudView> clouds) {
     throw std::logic_error(
         "scanToGrid(clouds): mapper was not constructed for pointcloud input");
   }
-  if (clouds.size() != m_sensors.size()) {
-    throw std::invalid_argument("scanToGrid(clouds): got " +
-                                std::to_string(clouds.size()) + " clouds for " +
-                                std::to_string(m_sensors.size()) + " sensors");
-  }
-  // Validate every cloud before touching the grid, so a bad batch cannot
-  // leave a half-fused result
-  for (size_t i = 0; i < clouds.size(); ++i) {
-    const auto &cloud = clouds[i];
-    if (!cloud.empty() &&
-        (cloud.x_offset < 0 || cloud.y_offset < 0 || cloud.z_offset < 0)) {
-      throw std::invalid_argument(
-          "clouds[" + std::to_string(i) +
-          "]: point field offsets (x/y/z) must be non-negative: malformed "
-          "point cloud metadata");
-    }
-  }
+  validateClouds(clouds, m_sensors.size());
 
   // initialize grid once
   gridData.fill(static_cast<int>(Mapping::OccupancyType::UNEXPLORED));

--- a/src/kompass_cpp/kompass_cpp/src/mapping/local_mapper.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/mapping/local_mapper.cpp
@@ -307,9 +307,9 @@ Eigen::MatrixXi &LocalMapper::scanToGrid(Span<PointCloudView> clouds) {
     // Convert around this sensor's mount. Bearings come out in body
     // orientation around the sensor origin, so the ray cast runs with
     // orientation 0 from the sensor's own cell
-    pointCloudToLaserScanFromRaw(clouds[i], m_sensors[i].tf_body, m_rangeMax,
-                                 m_minHeight, m_maxHeight, m_scanSize,
-                                 initializedRanges);
+    pointCloudToLaserScanFromRaw(clouds[i], m_sensors[i].field_type,
+                                 m_sensors[i].tf_body, m_rangeMax, m_minHeight,
+                                 m_maxHeight, m_scanSize, initializedRanges);
     rasterizeScan_(initializedAngles, initializedRanges, m_sensors[i].origin_xy,
                    0.0f, m_sensors[i].start_point);
   }
@@ -341,8 +341,9 @@ LocalMapper::scanToGridBayesian(ByteSpan data, int point_step, int row_step,
   pointCloudToLaserScanFromRaw(PointCloudView{data, point_step, row_step,
                                               height, width, x_offset, y_offset,
                                               z_offset},
-                               m_sensors[0].tf_body, m_rangeMax, m_minHeight,
-                               m_maxHeight, m_scanSize, initializedRanges);
+                               m_sensors[0].field_type, m_sensors[0].tf_body,
+                               m_rangeMax, m_minHeight, m_maxHeight, m_scanSize,
+                               initializedRanges);
   gridData.fill(static_cast<int>(Mapping::OccupancyType::UNEXPLORED));
   gridDataProb.fill(m_pPrior);
   rasterizeScanBayesian_(initializedAngles, initializedRanges,

--- a/src/kompass_cpp/kompass_cpp/src/mapping/local_mapper_gpu.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/mapping/local_mapper_gpu.cpp
@@ -3,7 +3,6 @@
 #include "utils/pointcloud.h"
 #include <cmath>
 #include <stdexcept>
-#include <string>
 #include <sycl/sycl.hpp>
 
 namespace Kompass {
@@ -381,23 +380,7 @@ Eigen::MatrixXi &LocalMapperGPU::scanToGrid(Span<PointCloudView> clouds) {
     throw std::logic_error(
         "scanToGrid(clouds): mapper was not constructed for pointcloud input");
   }
-  if (clouds.size() != m_sensorDev.size()) {
-    throw std::invalid_argument(
-        "scanToGrid(clouds): got " + std::to_string(clouds.size()) +
-        " clouds for " + std::to_string(m_sensorDev.size()) + " sensors");
-  }
-  // Validate every cloud before touching the device, so a bad batch cannot
-  // leave a half-fused result
-  for (size_t i = 0; i < clouds.size(); ++i) {
-    const auto &cloud = clouds[i];
-    if (!cloud.empty() &&
-        (cloud.x_offset < 0 || cloud.y_offset < 0 || cloud.z_offset < 0)) {
-      throw std::invalid_argument(
-          "clouds[" + std::to_string(i) +
-          "]: point field offsets (x/y/z) must be non-negative: malformed "
-          "point cloud metadata");
-    }
-  }
+  validateClouds(clouds, m_sensorDev.size());
 
   try {
     // Drain anything a previous throwing call may have left in flight

--- a/src/kompass_cpp/kompass_cpp/src/mapping/local_mapper_gpu.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/mapping/local_mapper_gpu.cpp
@@ -3,6 +3,7 @@
 #include "utils/pointcloud.h"
 #include <cmath>
 #include <stdexcept>
+#include <string>
 #include <sycl/sycl.hpp>
 
 namespace Kompass {
@@ -12,12 +13,15 @@ namespace {
 
 /**
  * @brief Convert a raw PointCloud2 byte buffer into a per-angle-bin
- *        laserscan on the GPU.
+ *        pseudo-laserscan on the GPU, around the sensor origin in BODY
+ *        orientation.
  *
  * One thread per input point. Each thread extracts (x, y, z) from the raw
- * buffer via load_and_cast_val, applies the Z and origin filters, computes
- * the angular bin as clamped `int((angle / 2π) * num_bins)`, and does an
- * atomic fetch_min into `device_ranges_out` for that bin.
+ * buffer via load_and_cast_val, rotates the point by the sensor mount
+ * rotation, gates it on BODY-frame z (rotation plus the mount's z offset),
+ * computes the angular bin from the rotated planar bearing as clamped
+ * `int((angle / 2π) * num_bins)`, and does an atomic fetch_min of the
+ * planar radius into `device_ranges_out` for that bin. .
  *
  * Caller owns every device allocation; this function only enqueues a fill
  * of `device_ranges_out` followed by the parallel_for. It does NOT wait
@@ -42,17 +46,17 @@ namespace {
  * @param x_offset          Byte offset of X within a point.
  * @param y_offset          Byte offset of Y within a point.
  * @param z_offset          Byte offset of Z within a point.
- * @param min_z             Minimum acceptable Z (inclusive). There is no
- *                          disable-sentinel for the lower bound: callers
- *                          that want a one-sided filter must pass a
- *                          suitably negative value (e.g. -FLT_MAX).
- * @param max_z             Maximum acceptable Z (inclusive). Applied as
- *                          given, matching the CPU
- *                          `pointCloudToLaserScanFromRaw`: the sign of the
- *                          bound carries no meaning of its own, so a
- *                          negative value is a real upper edge and not a
- *                          request to disable the gate. Callers wanting no
- *                          upper bound pass +FLT_MAX / infinity.
+ * @param tf_sensor_body    Rows 0..2 of the sensor→body isometry [R | t],
+ *                          row-major (12 floats). Identity reproduced the
+ yaw-only sensor frame conversion.
+ * @param min_z_body        Minimum acceptable BODY-frame z (inclusive).
+ *                          There is no disable-sentinel for the lower
+ *                          bound: callers that want a one-sided filter
+ *                          must pass a suitably negative value.
+ * @param max_z_body        Maximum acceptable BODY-frame z (inclusive).
+ *                          Applied as given. The sign of the bound carries no
+                            meaning of its own. Callers wanting no upper bound
+                            pass +FLT_MAX / infinity.
  * @param point_field_type  Dtype of the X/Y/Z fields (dispatches
  *                          load_and_cast_val).
  * @param element_size      sizeof(field) in bytes. Used for the
@@ -67,7 +71,8 @@ inline void submitPointCloudToLaserScanKernel(
     float *device_ranges_out, const int num_bins, const float max_range,
     const int point_step, const int row_step, const int width, const int height,
     const int x_offset, const int y_offset, const int z_offset,
-    const float min_z, const float max_z, const PointFieldType point_field_type,
+    const std::array<float, 12> &tf_sensor_body, const float min_z_body,
+    const float max_z_body, const PointFieldType point_field_type,
     const int element_size, const size_t wg_size) {
 
   // Fail loudly for a negative off-set (corrupted metadata)
@@ -102,14 +107,26 @@ inline void submitPointCloudToLaserScanKernel(
     const int x_off = x_offset;
     const int y_off = y_offset;
     const int z_off = z_offset;
-    const float f_min_z = min_z;
-    const float f_max_z = max_z;
+    const float f_min_z = min_z_body;
+    const float f_max_z = max_z_body;
     const int k_num_bins = num_bins;
     const float k_inv_two_pi_times_bins =
         static_cast<float>(k_num_bins) / static_cast<float>(2.0 * M_PI);
     const size_t k_total_bytes = total_bytes;
     const PointFieldType k_type = point_field_type;
     const int k_elem_size = element_size;
+
+    // Mount transform rows as kernel constants.
+    // NOTE: Only the rotation is used in x/y (bearing and radius stay relative
+    // to the sensor origin); the translation's z is used as body-frame height
+    // gate
+    const float r00 = tf_sensor_body[0], r01 = tf_sensor_body[1],
+                r02 = tf_sensor_body[2];
+    const float r10 = tf_sensor_body[4], r11 = tf_sensor_body[5],
+                r12 = tf_sensor_body[6];
+    const float r20 = tf_sensor_body[8], r21 = tf_sensor_body[9],
+                r22 = tf_sensor_body[10];
+    const float t_z = tf_sensor_body[11];
 
     const uint8_t *raw_bytes = device_raw_bytes;
     float *ranges_ptr = device_ranges_out;
@@ -138,31 +155,40 @@ inline void submitPointCloudToLaserScanKernel(
             return;
           }
 
-          // Early Z-filter. Both bounds are applied as given, matching the
-          // CPU path: a negative max_z is a real upper edge, not a
-          // disable-sentinel.
-          const float z =
-              load_and_cast_val(raw_bytes, byte_offset + z_off, k_type);
-          if (z < f_min_z || z > f_max_z)
-            return;
-
           const float x =
               load_and_cast_val(raw_bytes, byte_offset + x_off, k_type);
           const float y =
               load_and_cast_val(raw_bytes, byte_offset + y_off, k_type);
+          const float z =
+              load_and_cast_val(raw_bytes, byte_offset + z_off, k_type);
 
           // Reject non-finite points (NaN padding in organized clouds)
           if (!sycl::isfinite(x) || !sycl::isfinite(y) || !sycl::isfinite(z))
             return;
 
-          // Filter origin (±ε).
-          const float r2 = x * x + y * y;
+          // A point at the sensor origin carries no bearing. Reject in the
+          // SENSOR frame, before rotation, so it can never end up mapped to
+          // the mount position (inside the robot) downstream
+          if (x * x + y * y + z * z < 1e-6f)
+            return;
+
+          // Rotate into body orientation and gate on body-frame height.
+          // a negative max_z is a real upper edge, not a disable-sentinel
+          const float xr = r00 * x + r01 * y + r02 * z;
+          const float yr = r10 * x + r11 * y + r12 * z;
+          const float zb = r20 * x + r21 * y + r22 * z + t_z;
+          if (zb < f_min_z || zb > f_max_z)
+            return;
+
+          // No planar extent -> no bin (point straight above/below the
+          // sensor)
+          const float r2 = xr * xr + yr * yr;
           if (r2 < 1e-6f)
             return;
 
           // Angle + bin: normalize [0, 2π), bin = clamped
           // int((angle / 2π) * num_bins).
-          float angle = sycl::atan2(y, x);
+          float angle = sycl::atan2(yr, xr);
           if (angle < 0.0f)
             angle += static_cast<float>(2.0 * M_PI);
           int bin = static_cast<int>(angle * k_inv_two_pi_times_bins);
@@ -198,21 +224,23 @@ inline void submitPointCloudToLaserScanKernel(
  * @param devicePtrGrid        Output occupancy grid, `gridHeight * gridWidth`
  *                             ints, column-major. Must be pre-filled with
  *                             UNEXPLORED.
- * @param devicePtrDistances   Per-cell precomputed distance from the
- *                             laserscan origin, `gridHeight * gridWidth`
- *                             floats. Used to gate the super-cover line
- *                             fill so cells beyond the measured range
+ * @param devicePtrDistances   Per-cell precomputed PLANAR distance from the
+ *                             ray origin, `gridHeight * gridWidth` floats,
+ *                             column-major. Used to gate the super-cover
+ *                             line fill so cells beyond the measured range
  *                             aren't wrongly marked EMPTY.
  * @param devicePtrAngles      Per-ray angle in radians, `scanSize` doubles.
  * @param devicePtrRanges      Per-ray range in metres, `scanSize` floats.
  * @param gridHeight           Grid row count (= `rows`).
  * @param gridWidth            Grid column count (= `cols`).
  * @param resolution           Cell size in metres.
- * @param laserscanOrientation Sensor yaw offset added to every ray angle.
+ * @param laserscanOrientation Sensor yaw offset added to every ray angle
+ *                             (0 on the pointcloud path as the conversion
+ *                             already folded the mount rotation into the
+ *                             bearings).
  * @param centralPoint         Grid coordinates of the grid's central cell.
- * @param laserscanPosition    Sensor position in the local frame (metres).
- * @param startPoint           Grid coordinates of the sensor (origin of
- *                             every ray).
+ * @param laserscanPosition    Ray origin in the local frame (metres)
+ * @param startPoint           Grid coordinates of the ray origin.
  * @param scanSize             Number of rays = number of work-groups to
  *                             launch.
  * @param maxPointsPerLine     Threads per work-group; caps the ray length
@@ -306,31 +334,37 @@ inline void submitScanToGridKernel(
           int y = round(y_float);
 
           if (x >= 0 && x < rows && y >= 0 && y < cols) {
+            // Super-cover neighbor cells, bounds-checked INDIVIDUALLY at
+            // grid edges (x - steps[0]) or (y - steps[1])
+            const int xn = x - steps[0];
+            const int yn = y - steps[1];
+            const bool xn_ok = (xn >= 0 && xn < rows);
+            const bool yn_ok = (yn >= 0 && yn < cols);
+
             sycl::atomic_ref<int, sycl::memory_order::relaxed,
                              sycl::memory_scope::device,
                              sycl::access::address_space::global_space>
                 atomic_val(devGrid[x + y * rows]);
-            sycl::atomic_ref<int, sycl::memory_order::relaxed,
-                             sycl::memory_scope::device,
-                             sycl::access::address_space::global_space>
-                atomic_val_xstep(devGrid[(x - steps[0]) + (y * rows)]);
-            sycl::atomic_ref<int, sycl::memory_order::relaxed,
-                             sycl::memory_scope::device,
-                             sycl::access::address_space::global_space>
-                atomic_val_ystep(devGrid[x + ((y - steps[1]) * rows)]);
-            if (x == toPoint[0] && y == toPoint[1]) {
+
+            const bool is_endpoint = (x == toPoint[0] && y == toPoint[1]);
+            if (is_endpoint || devDistances[x + y * rows] < range) {
               atomic_val.fetch_max(
-                  static_cast<int>(Mapping::OccupancyType::OCCUPIED));
-              atomic_val_xstep.fetch_max(
-                  static_cast<int>(Mapping::OccupancyType::EMPTY));
-              atomic_val_ystep.fetch_max(
-                  static_cast<int>(Mapping::OccupancyType::EMPTY));
-            } else {
-              if (devDistances[x + y * rows] < range) {
-                atomic_val.fetch_max(
-                    static_cast<int>(Mapping::OccupancyType::EMPTY));
+                  is_endpoint
+                      ? static_cast<int>(Mapping::OccupancyType::OCCUPIED)
+                      : static_cast<int>(Mapping::OccupancyType::EMPTY));
+              if (xn_ok) {
+                sycl::atomic_ref<int, sycl::memory_order::relaxed,
+                                 sycl::memory_scope::device,
+                                 sycl::access::address_space::global_space>
+                    atomic_val_xstep(devGrid[xn + (y * rows)]);
                 atomic_val_xstep.fetch_max(
                     static_cast<int>(Mapping::OccupancyType::EMPTY));
+              }
+              if (yn_ok) {
+                sycl::atomic_ref<int, sycl::memory_order::relaxed,
+                                 sycl::memory_scope::device,
+                                 sycl::access::address_space::global_space>
+                    atomic_val_ystep(devGrid[x + (yn * rows)]);
                 atomic_val_ystep.fetch_max(
                     static_cast<int>(Mapping::OccupancyType::EMPTY));
               }
@@ -342,51 +376,74 @@ inline void submitScanToGridKernel(
 
 } // namespace
 
-Eigen::MatrixXi &LocalMapperGPU::scanToGrid(ByteSpan data, int point_step,
-                                            int row_step, int height, int width,
-                                            int x_offset, int y_offset,
-                                            int z_offset) {
+Eigen::MatrixXi &LocalMapperGPU::scanToGrid(Span<PointCloudView> clouds) {
+  if (!m_isPointCloud) {
+    throw std::logic_error(
+        "scanToGrid(clouds): mapper was not constructed for pointcloud input");
+  }
+  if (clouds.size() != m_sensorDev.size()) {
+    throw std::invalid_argument(
+        "scanToGrid(clouds): got " + std::to_string(clouds.size()) +
+        " clouds for " + std::to_string(m_sensorDev.size()) + " sensors");
+  }
+  // Validate every cloud before touching the device, so a bad batch cannot
+  // leave a half-fused result
+  for (size_t i = 0; i < clouds.size(); ++i) {
+    const auto &cloud = clouds[i];
+    if (!cloud.empty() &&
+        (cloud.x_offset < 0 || cloud.y_offset < 0 || cloud.z_offset < 0)) {
+      throw std::invalid_argument(
+          "clouds[" + std::to_string(i) +
+          "]: point field offsets (x/y/z) must be non-negative: malformed "
+          "point cloud metadata");
+    }
+  }
+
   try {
-    // Reset output grid to UNEXPLORED before any kernel runs.
+    // Drain anything a previous throwing call may have left in flight
+    m_q.wait();
+
+    // Reset output grid to UNEXPLORED once
     m_q.fill(m_devicePtrGrid, static_cast<int>(OccupancyType::UNEXPLORED),
              m_gridHeight * m_gridWidth);
 
-    // Empty cloud → nothing to project. Return the grid as all-UNEXPLORED
-    const size_t total_bytes = data.size();
-    if (total_bytes == 0 || height == 0 || width == 0) {
-      m_q.memcpy(gridData.data(), m_devicePtrGrid,
-                 sizeof(int) * m_gridWidth * m_gridHeight);
-      m_q.wait_and_throw();
-      return gridData;
-    }
-
-    // Grow the raw-bytes device buffer to fit this scan.
-    if (m_rawCapacity < total_bytes) {
-      if (m_devicePtrRawBytes) {
-        sycl::free(m_devicePtrRawBytes, m_q);
+    for (size_t i = 0; i < clouds.size(); ++i) {
+      const auto &cloud = clouds[i];
+      if (cloud.empty()) {
+        continue; // no data from this sensor this tick
       }
-      m_devicePtrRawBytes = sycl::malloc_device<uint8_t>(total_bytes, m_q);
-      m_rawCapacity = total_bytes;
+      auto &dev = m_sensorDev[i];
+      const size_t total_bytes = cloud.data.size();
+
+      // Grow this sensor's raw-bytes device buffer to fit the cloud
+      if (dev.rawCapacity < total_bytes) {
+        if (dev.rawBytes) {
+          sycl::free(dev.rawBytes, m_q);
+        }
+        dev.rawBytes = sycl::malloc_device<uint8_t>(total_bytes, m_q);
+        dev.rawCapacity = total_bytes;
+      }
+      m_q.memcpy(dev.rawBytes, cloud.data.data(), total_bytes);
+
+      // Pointcloud → per-bin pseudo-scan around this sensor's origin in
+      // body orientation
+      submitPointCloudToLaserScanKernel(
+          m_q, dev.rawBytes, total_bytes, dev.ranges, m_scanSize,
+          static_cast<float>(m_rangeMax), cloud.point_step, cloud.row_step,
+          cloud.width, cloud.height, cloud.x_offset, cloud.y_offset,
+          cloud.z_offset, dev.tf, static_cast<float>(m_minHeight),
+          static_cast<float>(m_maxHeight), dev.fieldType, dev.elementSize,
+          m_max_wg_size);
+
+      // Ray-cast from this sensor's origin with orientation 0 (the mount
+      // rotation is already folded into the bearings)
+      submitScanToGridKernel(
+          m_q, m_devicePtrGrid, dev.distances, m_devicePtrAngles, dev.ranges,
+          m_gridHeight, m_gridWidth, m_resolution, /*orientation*/ 0.0f,
+          m_centralPoint,
+          Eigen::Vector3f{dev.originXY.x(), dev.originXY.y(), 0.0f},
+          dev.startPoint, m_scanSize, m_maxPointsPerLine);
     }
-
-    m_q.memcpy(m_devicePtrRawBytes, data.data(), total_bytes);
-
-    // Pointcloud → per-bin laserscan ranges on device. Fills
-    // m_devicePtrRanges with per-angle-bin minimum distance. Angles
-    // for the subsequent ray-cast kernel were pre-uploaded
-    submitPointCloudToLaserScanKernel(
-        m_q, m_devicePtrRawBytes, total_bytes, m_devicePtrRanges, m_scanSize,
-        static_cast<float>(m_rangeMax), point_step, row_step, width, height,
-        x_offset, y_offset, z_offset, static_cast<float>(m_minHeight),
-        static_cast<float>(m_maxHeight), PointFieldType::FLOAT32,
-        /*element_size*/ 4, m_max_wg_size);
-
-    // Ray-cast from laserscan → occupancy grid.
-    submitScanToGridKernel(m_q, m_devicePtrGrid, m_devicePtrDistances,
-                           m_devicePtrAngles, m_devicePtrRanges, m_gridHeight,
-                           m_gridWidth, m_resolution, m_laserscanOrientation,
-                           m_centralPoint, m_laserscanPosition, m_startPoint,
-                           m_scanSize, m_maxPointsPerLine);
 
     m_q.memcpy(gridData.data(), m_devicePtrGrid,
                sizeof(int) * m_gridWidth * m_gridHeight);
@@ -403,9 +460,27 @@ Eigen::MatrixXi &LocalMapperGPU::scanToGrid(ByteSpan data, int point_step,
   return gridData;
 }
 
+// Single pointcloud overload
+Eigen::MatrixXi &LocalMapperGPU::scanToGrid(ByteSpan data, int point_step,
+                                            int row_step, int height, int width,
+                                            int x_offset, int y_offset,
+                                            int z_offset) {
+  // Allocation-free N=1 adapter
+  const PointCloudView view{data,  point_step, row_step, height,
+                            width, x_offset,   y_offset, z_offset};
+  return scanToGrid(Span<PointCloudView>(&view, 1));
+}
+
+// Laserscan overload
 Eigen::MatrixXi &
 LocalMapperGPU::scanToGrid(Eigen::Ref<const Eigen::VectorXf> angles,
                            Eigen::Ref<const Eigen::VectorXf> ranges) {
+  if (m_isPointCloud) {
+    throw std::logic_error(
+        "scanToGrid(angles, ranges): mapper was constructed for pointcloud "
+        "input; the laserscan overload would overwrite the pre-uploaded "
+        "conversion bin angles");
+  }
 
   try {
     m_q.fill(m_devicePtrGrid, static_cast<int>(OccupancyType::UNEXPLORED),
@@ -433,11 +508,13 @@ LocalMapperGPU::scanToGrid(Eigen::Ref<const Eigen::VectorXf> angles,
                sizeof(double) * m_scanSize);
     m_q.memcpy(m_devicePtrRanges, ranges.data(), sizeof(float) * m_scanSize);
 
-    submitScanToGridKernel(m_q, m_devicePtrGrid, m_devicePtrDistances,
-                           m_devicePtrAngles, m_devicePtrRanges, m_gridHeight,
-                           m_gridWidth, m_resolution, m_laserscanOrientation,
-                           m_centralPoint, m_laserscanPosition, m_startPoint,
-                           m_scanSize, m_maxPointsPerLine);
+    submitScanToGridKernel(
+        m_q, m_devicePtrGrid, m_devicePtrDistances, m_devicePtrAngles,
+        m_devicePtrRanges, m_gridHeight, m_gridWidth, m_resolution,
+        m_sensors[0].yaw, m_centralPoint,
+        Eigen::Vector3f{m_sensors[0].origin_xy.x(), m_sensors[0].origin_xy.y(),
+                        0.0f},
+        m_sensors[0].start_point, m_scanSize, m_maxPointsPerLine);
 
     m_q.memcpy(gridData.data(), m_devicePtrGrid,
                sizeof(int) * m_gridWidth * m_gridHeight);

--- a/src/kompass_cpp/kompass_cpp/src/mapping/local_mapper_gpu.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/mapping/local_mapper_gpu.cpp
@@ -388,9 +388,6 @@ Eigen::MatrixXi &LocalMapperGPU::scanToGrid(Span<PointCloudView> clouds) {
   validateClouds(clouds, m_sensorDev.size());
 
   try {
-    // Drain anything a previous throwing call may have left in flight
-    m_q.wait();
-
     // Reset output grid to UNEXPLORED once
     m_q.fill(m_devicePtrGrid, static_cast<int>(OccupancyType::UNEXPLORED),
              m_gridHeight * m_gridWidth);
@@ -406,6 +403,10 @@ Eigen::MatrixXi &LocalMapperGPU::scanToGrid(Span<PointCloudView> clouds) {
       // Grow this sensor's raw-bytes device buffer to fit the cloud
       if (dev.rawCapacity < total_bytes) {
         if (dev.rawBytes) {
+          // A kernel from a previous throwing call could still be reading
+          // this buffer (sycl::free is host-side and NOT queue-ordered), so
+          // drain before freeing
+          m_q.wait();
           sycl::free(dev.rawBytes, m_q);
         }
         dev.rawBytes = sycl::malloc_device<uint8_t>(total_bytes, m_q);

--- a/src/kompass_cpp/kompass_cpp/src/mapping/local_mapper_gpu.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/mapping/local_mapper_gpu.cpp
@@ -1,6 +1,5 @@
 #include "mapping/local_mapper_gpu.h"
 #include "utils/logger.h"
-#include "utils/pointcloud.h"
 #include <cmath>
 #include <stdexcept>
 #include <sycl/sycl.hpp>
@@ -8,6 +7,7 @@
 namespace Kompass {
 namespace Mapping {
 
+// Mark the kernel submitters below private to this file
 namespace {
 
 /**
@@ -111,6 +111,8 @@ inline void submitPointCloudToLaserScanKernel(
     const int k_num_bins = num_bins;
     const float k_inv_two_pi_times_bins =
         static_cast<float>(k_num_bins) / static_cast<float>(2.0 * M_PI);
+    // Points at/beyond max_range can never win a bin, calculate its sqr
+    const float k_max_range_sq = max_range * max_range;
     const size_t k_total_bytes = total_bytes;
     const PointFieldType k_type = point_field_type;
     const int k_elem_size = element_size;
@@ -183,6 +185,9 @@ inline void submitPointCloudToLaserScanKernel(
           // sensor)
           const float r2 = xr * xr + yr * yr;
           if (r2 < 1e-6f)
+            return;
+          // Beyond max_range -> can never win the per-bin min
+          if (r2 >= k_max_range_sq)
             return;
 
           // Angle + bin: normalize [0, 2π), bin = clamped

--- a/src/kompass_cpp/kompass_cpp/src/utils/critical_zone_check.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/utils/critical_zone_check.cpp
@@ -1,6 +1,5 @@
 #include "utils/critical_zone_check.h"
 #include "utils/angles.h"
-#include "utils/pointcloud.h"
 #include <Eigen/Core>
 #include <stdexcept>
 
@@ -215,18 +214,18 @@ float CriticalZoneChecker::check(Span<PointCloudView> clouds,
           continue;
         }
 
+        // Coarse distance rejection for points beyond slow down distance
+        const float dist_sq = xb * xb + yb * yb;
+        if (dist_sq > slow_limit_sq_) {
+          continue;
+        }
+
         // Body-frame critical cone (forward: |angle| <= half-cone;
         // backward: |angle| >= pi - half-cone)
         const float abs_angle = std::fabs(std::atan2(yb, xb));
         const bool in_zone = forward ? (abs_angle <= critical_angle_)
                                      : (abs_angle >= M_PI - critical_angle_);
         if (!in_zone) {
-          continue;
-        }
-
-        // Skip points beyond slowdown limit
-        const float dist_sq = xb * xb + yb * yb;
-        if (dist_sq > slow_limit_sq_) {
           continue;
         }
 

--- a/src/kompass_cpp/kompass_cpp/src/utils/critical_zone_check.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/utils/critical_zone_check.cpp
@@ -1,23 +1,22 @@
 #include "utils/critical_zone_check.h"
 #include "utils/angles.h"
 #include "utils/pointcloud.h"
-#include "utils/transformation.h"
 #include <Eigen/Core>
+#include <stdexcept>
 
 namespace Kompass {
 /**
- * @brief Emergency (Critical) Zone Checker using LaserScan data
+ * @brief Emergency (Critical) Zone Checker using LaserScan or PointCloud data
  *
  */
 
 CriticalZoneChecker::CriticalZoneChecker(
     InputType input_type, const CollisionChecker::ShapeType robot_shape_type,
     const std::vector<float> &robot_dimensions,
-    const Eigen::Vector3f &sensor_position_body,
-    const Eigen::Vector4f &sensor_rotation_body, const float critical_angle,
+    const std::vector<SensorConfig> &sensors, const float critical_angle,
     const float critical_distance, const float slowdown_distance,
-    const std::vector<double> &angles, const float min_height,
-    const float max_height, const float range_max) {
+    const float min_height, const float max_height, const float range_max,
+    const std::vector<double> &scan_angles) {
   input_type_ = input_type;
   min_height_ = min_height;
   max_height_ = max_height;
@@ -27,15 +26,42 @@ CriticalZoneChecker::CriticalZoneChecker(
   robotRadius_ = CollisionChecker::radiusOf(robot_shape_type, robot_dimensions);
   robotHeight_ = CollisionChecker::heightOf(robot_shape_type, robot_dimensions);
 
-  // Init the sensor position w.r.t body
-  sensor_tf_body_ =
-      getTransformation(sensor_rotation_body, sensor_position_body);
+  if (sensors.empty()) {
+    throw std::invalid_argument(
+        "CriticalZoneChecker requires at least one sensor config");
+  }
+  if (input_type_ == InputType::LASERSCAN) {
+    // No fusion in lasercan path
+    if (sensors.size() != 1) {
+      throw std::invalid_argument(
+          "CriticalZoneChecker laserscan input supports exactly one sensor");
+    }
+    if (scan_angles.empty()) {
+      throw std::invalid_argument(
+          "CriticalZoneChecker laserscan input requires non-empty "
+          "scan_angles");
+    }
+  }
+  sensors_.reserve(sensors.size());
+  for (const auto &sensor : sensors) {
+    SensorRuntime runtime;
+    runtime.tf_body = sensor.tfBody();
+    const Eigen::Matrix4f tf = runtime.tf_body.matrix();
+    runtime.tf = {tf(0, 0), tf(0, 1), tf(0, 2), tf(0, 3),
+                  tf(1, 0), tf(1, 1), tf(1, 2), tf(1, 3),
+                  tf(2, 0), tf(2, 1), tf(2, 2), tf(2, 3)};
+    runtime.field_type = sensor.cloud_field_type;
+    runtime.elem_size = elementSizeOf(sensor.cloud_field_type);
+    sensors_.push_back(runtime);
+  }
 
   // Compute the normalized critical zone angle
   float angle_rad = critical_angle * M_PI / 180.0;
   critical_angle_ = Angle::normalizeToMinusPiPlusPi(angle_rad / 2);
 
-  preset(angles);
+  if (input_type_ == InputType::LASERSCAN) {
+    preset(scan_angles);
+  }
 
   // Set critical distance
   if (slowdown_distance <= critical_distance) {
@@ -45,6 +71,12 @@ CriticalZoneChecker::CriticalZoneChecker(
   }
   critical_distance_ = critical_distance;
   slowdown_distance_ = slowdown_distance;
+
+  // Derived thresholds
+  const float slow_limit =
+      slowdown_distance_ + static_cast<float>(robotRadius_);
+  slow_limit_sq_ = slow_limit * slow_limit;
+  inv_dist_range_ = 1.0f / (slowdown_distance_ - critical_distance_);
 }
 
 void CriticalZoneChecker::preset(const std::vector<double> &angles) {
@@ -52,13 +84,16 @@ void CriticalZoneChecker::preset(const std::vector<double> &angles) {
   float abs_theta;
   sin_angles_.resize(angles.size());
   cos_angles_.resize(angles.size());
+  // Recompute from scratch. Stale sets from a previous call must not survive
+  indicies_forward_.clear();
+  indicies_backward_.clear();
 
   for (size_t i = 0; i < angles.size(); ++i) {
     cos_angles_[i] = std::cos(angles[i]);
     sin_angles_[i] = std::sin(angles[i]);
     cartesianPoint = {cos_angles_[i], sin_angles_[i], 0.0f};
     // Apply TF
-    cartesianPoint = sensor_tf_body_ * cartesianPoint;
+    cartesianPoint = sensors_[0].tf_body * cartesianPoint;
 
     // check if within the zone
     abs_theta = std::abs(std::atan2(cartesianPoint.y(), cartesianPoint.x()));
@@ -74,6 +109,10 @@ void CriticalZoneChecker::preset(const std::vector<double> &angles) {
 
 float CriticalZoneChecker::check(Eigen::Ref<const Eigen::VectorXf> ranges,
                                  const bool forward) {
+  if (input_type_ != InputType::LASERSCAN) {
+    throw std::logic_error(
+        "check(ranges): checker was constructed for pointcloud input");
+  }
   std::vector<size_t> *indicies;
   float x, y, converted_range;
   Eigen::Vector3f cartesianPoint;
@@ -89,35 +128,133 @@ float CriticalZoneChecker::check(Eigen::Ref<const Eigen::VectorXf> ranges,
     y = ranges[index] * sin_angles_[index];
     cartesianPoint = {x, y, 0.0f};
     // Apply TF
-    cartesianPoint = sensor_tf_body_ * cartesianPoint;
+    cartesianPoint = sensors_[0].tf_body * cartesianPoint;
 
-    // check if within the zone
-    converted_range = std::sqrt(std::pow(cartesianPoint.y(), 2) +
-                                std::pow(cartesianPoint.x(), 2));
+    // Coarse squared rejection. Beams beyond the slowdown ring get skipped
+    const float dist_sq = cartesianPoint.x() * cartesianPoint.x() +
+                          cartesianPoint.y() * cartesianPoint.y();
+    if (dist_sq > slow_limit_sq_) {
+      continue;
+    }
+    converted_range = std::sqrt(dist_sq);
     float distance = converted_range - robotRadius_;
     if (distance <= critical_distance_) {
       return 0.0;
     } else if (distance <= slowdown_distance_) {
-      slowdown_factor = std::min(slowdown_factor,
-                                 (distance - critical_distance_) /
-                                     (slowdown_distance_ - critical_distance_));
+      slowdown_factor = std::min(
+          slowdown_factor, (distance - critical_distance_) * inv_dist_range_);
     }
   }
   return slowdown_factor;
 }
 
+float CriticalZoneChecker::check(Span<PointCloudView> clouds,
+                                 const bool forward) {
+  if (input_type_ != InputType::POINTCLOUD) {
+    throw std::logic_error(
+        "check(clouds): checker was not constructed for pointcloud input");
+  }
+  validateClouds(clouds, sensors_.size());
+
+  float min_factor = 1.0f;
+  for (size_t s = 0; s < clouds.size(); ++s) {
+    const auto &cloud = clouds[s];
+    if (cloud.empty()) {
+      continue; // no data from this sensor this tick
+    }
+    // Per-point body-frame walk
+    const auto &sensor = sensors_[s];
+    // Get tf_body values
+    const float t00 = sensor.tf[0], t01 = sensor.tf[1], t02 = sensor.tf[2],
+                t03 = sensor.tf[3];
+    const float t10 = sensor.tf[4], t11 = sensor.tf[5], t12 = sensor.tf[6],
+                t13 = sensor.tf[7];
+    const float t20 = sensor.tf[8], t21 = sensor.tf[9], t22 = sensor.tf[10],
+                t23 = sensor.tf[11];
+    // Get scan params
+    const PointFieldType field_type = sensor.field_type;
+    const int elem_size = sensor.elem_size;
+    const int max_offset =
+        std::max({cloud.x_offset, cloud.y_offset, cloud.z_offset});
+    const int row_bytes = cloud.width * cloud.point_step;
+
+    for (int row = 0; row < cloud.height; ++row) {
+      for (int col = 0; col < row_bytes; col += cloud.point_step) {
+        const std::size_t point_start = row * cloud.row_step + col;
+        if (point_start + max_offset + elem_size > cloud.data.size()) {
+          continue;
+        }
+
+        // Grab x, y, z
+        const float x = load_and_cast_val(
+            cloud.data.data(), point_start + cloud.x_offset, field_type);
+        const float y = load_and_cast_val(
+            cloud.data.data(), point_start + cloud.y_offset, field_type);
+        const float z = load_and_cast_val(
+            cloud.data.data(), point_start + cloud.z_offset, field_type);
+
+        // Reject non-finite points (NaN padding in organized clouds)
+        if (!std::isfinite(x) || !std::isfinite(y) || !std::isfinite(z)) {
+          continue;
+        }
+
+        // Filter sensor points with no planar extent in the SENSOR frame. Maps
+        // onto the mount position (inside the robot) and must never trigger a
+        // stop
+        if (x * x + y * y < 1e-6f) {
+          continue;
+        }
+
+        // Full mount transform into the body frame
+        const float xb = t00 * x + t01 * y + t02 * z + t03;
+        const float yb = t10 * x + t11 * y + t12 * z + t13;
+        const float zb = t20 * x + t21 * y + t22 * z + t23;
+
+        // Body-frame height band
+        if (zb < min_height_ || zb > max_height_) {
+          continue;
+        }
+
+        // Body-frame critical cone (forward: |angle| <= half-cone;
+        // backward: |angle| >= pi - half-cone)
+        const float abs_angle = std::fabs(std::atan2(yb, xb));
+        const bool in_zone = forward ? (abs_angle <= critical_angle_)
+                                     : (abs_angle >= M_PI - critical_angle_);
+        if (!in_zone) {
+          continue;
+        }
+
+        // Skip points beyond slowdown limit
+        const float dist_sq = xb * xb + yb * yb;
+        if (dist_sq > slow_limit_sq_) {
+          continue;
+        }
+
+        const float dist_to_robot =
+            std::sqrt(dist_sq) - static_cast<float>(robotRadius_);
+        if (dist_to_robot <= critical_distance_) {
+          return 0.0f; // emergency stop, early exit
+        }
+        if (dist_to_robot <= slowdown_distance_) {
+          // slowdown factor
+          min_factor =
+              std::min(min_factor,
+                       (dist_to_robot - critical_distance_) * inv_dist_range_);
+        }
+      }
+    }
+  }
+  return min_factor;
+}
+
+// Single pointcloud overload
 float CriticalZoneChecker::check(ByteSpan data, int point_step, int row_step,
                                  int height, int width, int x_offset,
                                  int y_offset, int z_offset,
                                  const bool forward) {
-  // Convert into the member scratch: no per-call allocation. Use identity mount
-  // here. This path creates laserscan bins in the sensor frame and `check`
-  // function applies mount pose per beam afterwards.
-  pointCloudToLaserScanFromRaw(
-      PointCloudView{data, point_step, row_step, height, width, x_offset,
-                     y_offset, z_offset},
-      Eigen::Isometry3f::Identity(), range_max_, min_height_, max_height_,
-      static_cast<int>(sin_angles_.size()), ranges_staging_);
-  return check(Eigen::Ref<const Eigen::VectorXf>(ranges_staging_), forward);
+  // Allocation-free N=1 adapter
+  const PointCloudView view{data,  point_step, row_step, height,
+                            width, x_offset,   y_offset, z_offset};
+  return check(Span<PointCloudView>(&view, 1), forward);
 }
 } // namespace Kompass

--- a/src/kompass_cpp/kompass_cpp/src/utils/critical_zone_check.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/utils/critical_zone_check.cpp
@@ -197,10 +197,8 @@ float CriticalZoneChecker::check(Span<PointCloudView> clouds,
           continue;
         }
 
-        // Filter sensor points with no planar extent in the SENSOR frame. Maps
-        // onto the mount position (inside the robot) and must never trigger a
-        // stop
-        if (x * x + y * y < 1e-6f) {
+        // A point at the sensor origin carries no direction.
+        if (x * x + y * y + z * z < 1e-6f) {
           continue;
         }
 

--- a/src/kompass_cpp/kompass_cpp/src/utils/critical_zone_check.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/utils/critical_zone_check.cpp
@@ -110,10 +110,13 @@ float CriticalZoneChecker::check(ByteSpan data, int point_step, int row_step,
                                  int height, int width, int x_offset,
                                  int y_offset, int z_offset,
                                  const bool forward) {
-  // Convert into the member scratch: no per-call allocation
+  // Convert into the member scratch: no per-call allocation. Use identity mount
+  // here. This path creates laserscan bins in the sensor frame and `check`
+  // function applies mount pose per beam afterwards.
   pointCloudToLaserScanFromRaw(
-      data, point_step, row_step, height, width, x_offset, y_offset, z_offset,
-      range_max_, min_height_, max_height_,
+      PointCloudView{data, point_step, row_step, height, width, x_offset,
+                     y_offset, z_offset},
+      Eigen::Isometry3f::Identity(), range_max_, min_height_, max_height_,
       static_cast<int>(sin_angles_.size()), ranges_staging_);
   return check(Eigen::Ref<const Eigen::VectorXf>(ranges_staging_), forward);
 }

--- a/src/kompass_cpp/kompass_cpp/src/utils/critical_zone_check_gpu.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/utils/critical_zone_check_gpu.cpp
@@ -5,197 +5,233 @@
 
 namespace Kompass {
 
-float CriticalZoneCheckerGPU::check(ByteSpan data, int point_step,
-                                    int row_step, int height, int width,
-                                    int x_offset, int y_offset, int z_offset,
+// Mark the kernel submitter below private to this file
+namespace {
+
+/**
+ * @brief Submit one safety-check kernel for one sensor's cloud.
+ *
+ * One thread per point (grid-stride). Each thread extracts (x, y, z) via
+ * load_and_cast_val, applies the sensor's FULL mount transform, gates on
+ * BODY-frame height, filters by the body-frame critical cone, and min-reduces
+ * its safety factor into the shared `result`.
+ */
+inline void submitCloudCheckKernel(
+    sycl::queue &q, const uint8_t *device_raw_bytes, const size_t total_bytes,
+    float *result, const int point_step, const int row_step, const int width,
+    const int height, const int x_offset, const int y_offset,
+    const int z_offset, const std::array<float, 12> &tf_sensor_body,
+    const float min_z_body, const float max_z_body, const float critical_angle,
+    const float robot_radius, const float critical_distance,
+    const float slowdown_distance, const float slow_limit_sq,
+    const float inv_dist_range_in, const bool check_forward,
+    const PointFieldType point_field_type, const int element_size,
+    const size_t wg_size) {
+  q.submit([&](sycl::handler &h) {
+    // Full mount transform rows as kernel constants: rows 0/1 position the
+    // point in the body plane; row 2 gives the body-frame height for the band
+    // gate
+    const float t00 = tf_sensor_body[0], t01 = tf_sensor_body[1],
+                t02 = tf_sensor_body[2], t03 = tf_sensor_body[3];
+    const float t10 = tf_sensor_body[4], t11 = tf_sensor_body[5],
+                t12 = tf_sensor_body[6], t13 = tf_sensor_body[7];
+    const float t20 = tf_sensor_body[8], t21 = tf_sensor_body[9],
+                t22 = tf_sensor_body[10], t23 = tf_sensor_body[11];
+
+    // Safety Thresholds
+    const float crit_angle = critical_angle;
+    const float r_radius = robot_radius;
+    const float crit_dist = critical_distance;
+    const float slow_dist = slowdown_distance;
+
+    // Precomputed at construction
+    const float slow_dist_sq_limit = slow_limit_sq;
+    const float inv_dist_range = inv_dist_range_in;
+
+    const bool k_forward = check_forward;
+
+    // Kernel Configuration
+    const size_t num_points = static_cast<size_t>(width) * height;
+    const size_t WG_SIZE = wg_size;
+    const size_t global_size = ((num_points + WG_SIZE - 1) / WG_SIZE) * WG_SIZE;
+
+    // Capture params
+    const int m_width = width;
+    const int m_point_step = point_step;
+    const int m_row_step = row_step;
+    const bool is_contiguous = (row_step == width * point_step);
+    const int x_off = x_offset;
+    const int y_off = y_offset;
+    const int z_off = z_offset;
+    const float f_min_z = min_z_body;
+    const float f_max_z = max_z_body;
+    const PointFieldType k_type = point_field_type;
+    const int k_elem_size = element_size;
+    const size_t k_total_bytes = total_bytes;
+
+    const uint8_t *raw_bytes = device_raw_bytes;
+
+    h.parallel_for<class CheckRawCloudSafety>(
+        sycl::nd_range<1>(sycl::range<1>(global_size), sycl::range<1>(WG_SIZE)),
+        [=](sycl::nd_item<1> item) {
+          const size_t idx = item.get_global_id(0);
+          float local_min_factor = 1.0f;
+
+          // --- STRIDE LOOP ---
+          for (size_t i = idx; i < num_points; i += global_size) {
+
+            // Calculate Address
+            size_t byte_offset;
+            if (is_contiguous) {
+              // Fast path: direct multiplication
+              byte_offset = i * m_point_step;
+            } else {
+              // Slow path: only used if rows have padding
+              const int row = static_cast<int>(i / m_width);
+              const int col = static_cast<int>(i % m_width);
+              byte_offset = static_cast<size_t>(row) * m_row_step +
+                            static_cast<size_t>(col) * m_point_step;
+            }
+            // Bounds check
+            int max_offset = x_off;
+            if (y_off > max_offset)
+              max_offset = y_off;
+            if (z_off > max_offset)
+              max_offset = z_off;
+
+            if (byte_offset + max_offset + k_elem_size > k_total_bytes)
+              continue;
+
+            // Get x,y,z
+            const float x_sens =
+                load_and_cast_val(raw_bytes, byte_offset + x_off, k_type);
+            const float y_sens =
+                load_and_cast_val(raw_bytes, byte_offset + y_off, k_type);
+            const float z_sens =
+                load_and_cast_val(raw_bytes, byte_offset + z_off, k_type);
+
+            // Reject non-finite points (NaN padding in organized clouds)
+            if (!sycl::isfinite(x_sens) || !sycl::isfinite(y_sens) ||
+                !sycl::isfinite(z_sens))
+              continue;
+
+            // Filter sensor points with no planar extent
+            if (x_sens * x_sens + y_sens * y_sens < 1e-6f) {
+              continue;
+            }
+
+            // Full mount transform into the body frame
+            const float x_body =
+                x_sens * t00 + y_sens * t01 + z_sens * t02 + t03;
+            const float y_body =
+                x_sens * t10 + y_sens * t11 + z_sens * t12 + t13;
+            const float z_body =
+                x_sens * t20 + y_sens * t21 + z_sens * t22 + t23;
+
+            // Body-frame height band
+            if (z_body < f_min_z || z_body > f_max_z)
+              continue;
+
+            // Coarse distance rejection
+            const float dist_sq = x_body * x_body + y_body * y_body;
+            if (dist_sq > slow_dist_sq_limit)
+              continue;
+
+            // Angular Filter
+            // Check if point lies inside the critical cone (body frame)
+            const float abs_angle = sycl::fabs(sycl::atan2(y_body, x_body));
+
+            bool in_zone = false;
+            if (k_forward) {
+              // Forward check: is angle within [-crit, +crit]?
+              if (abs_angle <= crit_angle)
+                in_zone = true;
+            } else {
+              // Backward check: is angle within [PI - crit, -PI + crit]
+              if (abs_angle >= M_PI - crit_angle)
+                in_zone = true;
+            }
+
+            if (!in_zone)
+              continue;
+
+            const float dist = sycl::sqrt(dist_sq);
+            const float dist_to_robot = dist - r_radius;
+
+            // Compute Safety Factor
+            float factor = 1.0f;
+            if (dist_to_robot <= crit_dist) {
+              factor = 0.0f;
+            } else if (dist_to_robot <= slow_dist) {
+              factor = (dist_to_robot - crit_dist) * inv_dist_range;
+            }
+
+            local_min_factor = sycl::fmin(local_min_factor, factor);
+          }
+
+          // --- REDUCTION ---
+          // Find min across work-group
+          const float group_min = sycl::reduce_over_group(
+              item.get_group(), local_min_factor, sycl::minimum<float>());
+
+          // Write to global memory
+          if (item.get_local_id(0) == 0) {
+            sycl::atomic_ref<float, sycl::memory_order::relaxed,
+                             sycl::memory_scope::device,
+                             sycl::access::address_space::global_space>
+                atomic_res(*result);
+            atomic_res.fetch_min(group_min);
+          }
+        });
+  });
+}
+
+} // namespace
+
+float CriticalZoneCheckerGPU::check(Span<PointCloudView> clouds,
                                     const bool forward) {
-  // Handle Empty Cloud
-  if (data.empty() || width * height == 0) {
-    return 1.0f; // No points -> Safe
+  if (input_type_ != InputType::POINTCLOUD) {
+    throw std::logic_error(
+        "check(clouds): checker was not constructed for pointcloud input");
   }
-
-
-  // Fail loudly for a negative off-set (corrupted metadata)
-  if (x_offset < 0 || y_offset < 0 || z_offset < 0) {
-    throw std::invalid_argument(
-        "Point field offsets (x/y/z) must be non-negative: malformed point "
-        "cloud metadata");
-  }
+  validateClouds(clouds, m_sensorDev.size());
 
   try {
-    // Data Transfer
-    // Copy the vector to the GPU
-    size_t total_bytes = data.size();
-    if (m_rawCapacity < total_bytes) {
-      if (m_devicePtrRawBytes)
-        sycl::free(m_devicePtrRawBytes, m_q);
-      m_devicePtrRawBytes = sycl::malloc_device<uint8_t>(total_bytes, m_q);
-      m_rawCapacity = total_bytes;
+    // Drain anything a previous throwing call may have left in flight
+    m_q.wait();
+
+    // Reset the shared result ONCE
+    *m_result = 1.0f;
+
+    for (size_t s = 0; s < clouds.size(); ++s) {
+      const auto &cloud = clouds[s];
+      if (cloud.empty()) {
+        continue; // no data from this sensor this tick
+      }
+      auto &devState = m_sensorDev[s];
+      const size_t total_bytes = cloud.data.size();
+
+      // Grow this sensor's raw-bytes device buffer to fit the cloud
+      if (devState.rawCapacity < total_bytes) {
+        if (devState.rawBytes) {
+          sycl::free(devState.rawBytes, m_q);
+        }
+        devState.rawBytes = sycl::malloc_device<uint8_t>(total_bytes, m_q);
+        devState.rawCapacity = total_bytes;
+      }
+      m_q.memcpy(devState.rawBytes, cloud.data.data(), total_bytes);
+
+      submitCloudCheckKernel(
+          m_q, devState.rawBytes, total_bytes, m_result, cloud.point_step,
+          cloud.row_step, cloud.width, cloud.height, cloud.x_offset,
+          cloud.y_offset, cloud.z_offset, sensors_[s].tf, min_height_,
+          max_height_, critical_angle_, static_cast<float>(robotRadius_),
+          critical_distance_, slowdown_distance_, slow_limit_sq_,
+          inv_dist_range_, forward, sensors_[s].field_type,
+          sensors_[s].elem_size, max_wg_size_);
     }
-    m_q.memcpy(m_devicePtrRawBytes, data.data(), total_bytes);
 
-    // command scope
-    m_q.submit([&](sycl::handler &h) {
-      // Extract 2D transform from the 3D matrix for planar navigation
-      Eigen::Matrix4f tf = sensor_tf_body_.matrix();
-      float tf_00 = tf(0, 0);
-      float tf_01 = tf(0, 1);
-      float tf_03 = tf(0, 3); // Row 0
-      float tf_10 = tf(1, 0);
-      float tf_11 = tf(1, 1);
-      float tf_13 = tf(1, 3); // Row 1
-
-      // Safety Thresholds
-      float crit_angle = critical_angle_;
-      float r_radius = robotRadius_;
-      float crit_dist = critical_distance_;
-      float slow_dist = slowdown_distance_;
-
-      // Squared thresholds for fast coarse checks
-      float slow_dist_sq_limit =
-          (slow_dist + r_radius) * (slow_dist + r_radius);
-
-      // Inverse for division removal
-      float dist_range = slow_dist - crit_dist;
-      float inv_dist_range = (dist_range > 1e-5f) ? 1.0f / dist_range : 0.0f;
-
-      bool check_forward = forward;
-
-      // Kernel Configuration
-      size_t num_points = width * height;
-      const size_t WG_SIZE = max_wg_size_;
-      size_t global_size = ((num_points + WG_SIZE - 1) / WG_SIZE) * WG_SIZE;
-
-      // Capture pointers
-      auto raw_bytes = m_devicePtrRawBytes;
-      float *result = m_result;
-      *result = 1.0f; // set result default
-
-      // Capture params
-      int m_width = width;
-      int m_point_step = point_step;
-      int m_row_step = row_step;
-      bool is_contiguous = (row_step == width * point_step);
-      int x_off = x_offset;
-      int y_off = y_offset;
-      int z_off = z_offset;
-      float min_z = min_height_; // Class member
-      float max_z = max_height_; // Class member
-      PointFieldType k_type = m_pointFieldType; // Class member
-      int k_elem_size = m_elementSize; // Class member
-
-      h.parallel_for<class CheckRawCloudSafety>(
-          sycl::nd_range<1>(sycl::range<1>(global_size),
-                            sycl::range<1>(WG_SIZE)),
-          [=](sycl::nd_item<1> item) {
-            size_t idx = item.get_global_id(0);
-            float local_min_factor = 1.0f;
-
-            // --- STRIDE LOOP ---
-            for (size_t i = idx; i < num_points; i += global_size) {
-
-              // Calculate Address
-              size_t byte_offset;
-              if (is_contiguous) {
-                // Fast path: direct multiplication
-                byte_offset = i * m_point_step;
-              } else {
-                // Slow path: only used if rows have padding
-                int row = i / m_width;
-                int col = i % m_width;
-                byte_offset = static_cast<size_t>(row) * m_row_step +
-                              static_cast<size_t>(col) * m_point_step;
-              }
-              // Bounds check
-              int max_offset = x_off;
-              if (y_off > max_offset)
-                max_offset = y_off;
-              if (z_off > max_offset)
-                max_offset = z_off;
-
-              // Use k_elem_size
-              if (byte_offset + max_offset + k_elem_size > total_bytes)
-                continue;
-
-              // Early Z-Filter
-              float z =
-                  load_and_cast_val(raw_bytes, byte_offset + z_off, k_type);
-              if (z < min_z || z > max_z)
-                continue;
-
-              // Load X, Y
-              float x_sens =
-                  load_and_cast_val(raw_bytes, byte_offset + x_off, k_type);
-              float y_sens =
-                  load_and_cast_val(raw_bytes, byte_offset + y_off, k_type);
-
-              // Filter (0,0,0) using a small epsilon that handles float
-              // imprecision
-              if (x_sens * x_sens + y_sens * y_sens < 1e-6f) {
-                continue;
-              }
-
-              // Transform to Body Frame
-              // x_body = x*R00 + y*R01 + Tx
-              float x_body = x_sens * tf_00 + y_sens * tf_01 + tf_03;
-              float y_body = x_sens * tf_10 + y_sens * tf_11 + tf_13;
-
-              // Angular Filter
-              // Check if point lies inside the critical cone
-              float abs_angle = sycl::fabs(sycl::atan2(y_body, x_body));
-
-              bool in_zone = false;
-              if (check_forward) {
-                // Forward check: is angle within [-crit, +crit]?
-                if (abs_angle <= crit_angle)
-                  in_zone = true;
-              } else {
-                // Backward check: is angle within [PI - crit, -PI + crit]
-                if (abs_angle >= M_PI - crit_angle)
-                  in_zone = true;
-              }
-
-              if (!in_zone)
-                continue;
-
-              // Distance Check
-              float dist_sq = x_body * x_body + y_body * y_body;
-
-              // Skip sqrt if definitely safe
-              if (dist_sq > slow_dist_sq_limit)
-                continue;
-
-              float dist = sycl::sqrt(dist_sq);
-              float dist_to_robot = dist - r_radius;
-
-              // Compute Safety Factor
-              float factor = 1.0f;
-              if (dist_to_robot <= crit_dist) {
-                factor = 0.0f;
-              } else if (dist_to_robot <= slow_dist) {
-                factor = (dist_to_robot - crit_dist) * inv_dist_range;
-              }
-
-              local_min_factor = sycl::fmin(local_min_factor, factor);
-            }
-
-            // --- REDUCTION ---
-            // Find min across work-group
-            float group_min = sycl::reduce_over_group(
-                item.get_group(), local_min_factor, sycl::minimum<float>());
-
-            // Write to global memory
-            if (item.get_local_id(0) == 0) {
-              sycl::atomic_ref<float, sycl::memory_order::relaxed,
-                               sycl::memory_scope::device,
-                               sycl::access::address_space::global_space>
-                  atomic_res(*result);
-              atomic_res.fetch_min(group_min);
-            }
-          });
-    });
-
-    m_q.wait(); // Wait for result
+    m_q.wait(); // Wait for all sensors' kernels
 
   } catch (const sycl::exception &e) {
     LOG_ERROR("Exception caught: ", e.what());
@@ -205,29 +241,40 @@ float CriticalZoneCheckerGPU::check(ByteSpan data, int point_step,
   return *m_result;
 }
 
+// Single pointcloud overload
+float CriticalZoneCheckerGPU::check(ByteSpan data, int point_step, int row_step,
+                                    int height, int width, int x_offset,
+                                    int y_offset, int z_offset,
+                                    const bool forward) {
+  // Allocation-free N=1 adapter
+  const PointCloudView view{data,  point_step, row_step, height,
+                            width, x_offset,   y_offset, z_offset};
+  return check(Span<PointCloudView>(&view, 1), forward);
+}
+
+// Laserscan overload
 float CriticalZoneCheckerGPU::check(Eigen::Ref<const Eigen::VectorXf> ranges,
                                     const bool forward) {
+  if (input_type_ != InputType::LASERSCAN) {
+    throw std::logic_error(
+        "check(ranges): checker was constructed for pointcloud input");
+  }
   try {
     // Input is float32. Straight H→D copy
-    m_q.memcpy(m_devicePtrRanges, ranges.data(),
-               sizeof(float) * m_scanSize);
+    m_q.memcpy(m_devicePtrRanges, ranges.data(), sizeof(float) * m_scanSize);
 
     // command scope
     m_q.submit([&](sycl::handler &h) {
       const double robot_radius = robotRadius_;
 
       // Prepare Transformation Constants
-      auto tf = sensor_tf_body_.matrix();
+      auto tf = sensors_[0].tf_body.matrix();
       const float m00 = tf(0, 0), m01 = tf(0, 1), m03 = tf(0, 3);
       const float m10 = tf(1, 0), m11 = tf(1, 1), m13 = tf(1, 3);
-      // Prepare Thresholds for squared-distance checks
+      // Thresholds precomputed at construction
       const float crit_dist = critical_distance_;
-      const float slow_dist = slowdown_distance_;
-      const float dist_denom = slow_dist - crit_dist;
-
-      // Check distance: if dist > slow_dist + radius, it is SAFE
-      const float safe_threshold = slow_dist + robot_radius;
-      const float safe_threshold_sq = safe_threshold * safe_threshold;
+      const float inv_dist_range = inv_dist_range_;
+      const float safe_threshold_sq = slow_limit_sq_;
 
       // Select Indices
       size_t *critical_indices;
@@ -279,7 +326,7 @@ float CriticalZoneCheckerGPU::check(Eigen::Ref<const Eigen::VectorXf> ranges,
                 reducer.combine(0.0f);
               } else {
                 // In the slowdown zone (between crit and slow)
-                float factor = (dist_surface - crit_dist) / dist_denom;
+                float factor = (dist_surface - crit_dist) * inv_dist_range;
                 reducer.combine(factor);
               }
             }

--- a/src/kompass_cpp/kompass_cpp/src/utils/critical_zone_check_gpu.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/utils/critical_zone_check_gpu.cpp
@@ -115,8 +115,8 @@ inline void submitCloudCheckKernel(
                 !sycl::isfinite(z_sens))
               continue;
 
-            // Filter sensor points with no planar extent
-            if (x_sens * x_sens + y_sens * y_sens < 1e-6f) {
+            // A point at the sensor origin carries no direction.
+            if (x_sens * x_sens + y_sens * y_sens + z_sens * z_sens < 1e-6f) {
               continue;
             }
 

--- a/src/kompass_cpp/kompass_cpp/src/utils/critical_zone_check_gpu.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/utils/critical_zone_check_gpu.cpp
@@ -197,11 +197,8 @@ float CriticalZoneCheckerGPU::check(Span<PointCloudView> clouds,
   validateClouds(clouds, m_sensorDev.size());
 
   try {
-    // Drain anything a previous throwing call may have left in flight
-    m_q.wait();
-
     // Reset the shared result ONCE
-    *m_result = 1.0f;
+    m_q.fill(m_result, 1.0f, 1);
 
     for (size_t s = 0; s < clouds.size(); ++s) {
       const auto &cloud = clouds[s];
@@ -214,6 +211,10 @@ float CriticalZoneCheckerGPU::check(Span<PointCloudView> clouds,
       // Grow this sensor's raw-bytes device buffer to fit the cloud
       if (devState.rawCapacity < total_bytes) {
         if (devState.rawBytes) {
+          // A kernel from a previous throwing call could still be reading
+          // this buffer (sycl::free is host-side and NOT queue-ordered), so
+          // drain before freeing
+          m_q.wait();
           sycl::free(devState.rawBytes, m_q);
         }
         devState.rawBytes = sycl::malloc_device<uint8_t>(total_bytes, m_q);

--- a/src/kompass_cpp/kompass_cpp/src/utils/trajectory_sampler.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/utils/trajectory_sampler.cpp
@@ -56,6 +56,9 @@ TrajectorySampler::TrajectorySampler(
       getNumTrajectories(ctrType, lin_samples_max_, ang_samples_max_);
 
   this->maxNumThreads = maxNumThreads;
+  if (maxNumThreads > 1) {
+    m_pool = std::make_unique<ThreadPool>(maxNumThreads);
+  }
 }
 
 TrajectorySampler::TrajectorySampler(
@@ -87,6 +90,9 @@ TrajectorySampler::TrajectorySampler(
   numCtrlPoints_ = control_time_ / time_step_;
 
   this->maxNumThreads = maxNumThreads;
+  if (maxNumThreads > 1) {
+    m_pool = std::make_unique<ThreadPool>(maxNumThreads);
+  }
   this->drop_samples_ = config.getParameter<bool>("drop_samples");
 }
 
@@ -188,8 +194,11 @@ TrajectorySampler::generateTrajectoriesNonHolonomic(
   // Sample the (vx × omega) grid for arc-like motion. Skip vx ≈ 0 so no
   // pure-rotation samples are produced — unexecutable for Ackermann, and
   // intentionally excluded for diff-drive (goal-cost cannot rank spins).
-  if (maxNumThreads > 1) {
-    ThreadPool pool(maxNumThreads);
+  if (m_pool) {
+    // run in threadpool
+    static thread_local std::vector<std::future<void>> futures;
+    futures.clear();
+    futures.reserve(numTrajectories);
     for (double vx = min_vx_; vx <= max_vx_; vx += lin_sample_x_resolution_) {
       if (std::abs(vx) >= MIN_VEL) {
         for (double omega = min_omega_; omega <= max_omega_;
@@ -197,10 +206,15 @@ TrajectorySampler::generateTrajectoriesNonHolonomic(
 
           Velocity2D vel = Velocity2D(vx, 0.0, omega); // Limit Y movement
           // Get admissible trajectories in separate threads
-          pool.enqueue(&TrajectorySampler::getAdmissibleTrajsFromVel, this, vel,
-                       current_pose, admissible_velocity_trajectories.get());
+          futures.emplace_back(m_pool->enqueue(
+              &TrajectorySampler::getAdmissibleTrajsFromVel, this, vel,
+              current_pose, admissible_velocity_trajectories.get()));
         }
       }
+    }
+    // wait on the futures before returning
+    for (auto &f : futures) {
+      f.wait();
     }
   } else {
     for (double vx = min_vx_; vx <= max_vx_; vx += lin_sample_x_resolution_) {
@@ -225,8 +239,11 @@ TrajectorySampler::generateTrajectoriesHolonomic(
       std::make_unique<TrajectorySamples2D>(numTrajectories,
                                             numPointsPerTrajectory);
 
-  if (maxNumThreads > 1) {
-    ThreadPool pool(maxNumThreads);
+  if (m_pool) {
+    // spawn in threadpool
+    static thread_local std::vector<std::future<void>> futures;
+    futures.clear();
+    futures.reserve(numTrajectories);
     for (double vx = min_vx_; vx <= max_vx_; vx += lin_sample_x_resolution_) {
       if (std::abs(vx) >= MIN_VEL) {
         // vx, omega
@@ -235,8 +252,9 @@ TrajectorySampler::generateTrajectoriesHolonomic(
 
           Velocity2D vel = Velocity2D(vx, 0.0, omega); // Limit Y movement
           // Get admissible trajectories in separate threads
-          pool.enqueue(&TrajectorySampler::getAdmissibleTrajsFromVel, this, vel,
-                       current_pose, admissible_velocity_trajectories.get());
+          futures.emplace_back(m_pool->enqueue(
+              &TrajectorySampler::getAdmissibleTrajsFromVel, this, vel,
+              current_pose, admissible_velocity_trajectories.get()));
         }
 
         // vx, vy
@@ -245,10 +263,15 @@ TrajectorySampler::generateTrajectoriesHolonomic(
 
           Velocity2D vel = Velocity2D(vx, vy, 0.0); // Limit Y movement
           // Get admissible trajectories in separate threads
-          pool.enqueue(&TrajectorySampler::getAdmissibleTrajsFromVel, this, vel,
-                       current_pose, admissible_velocity_trajectories.get());
+          futures.emplace_back(m_pool->enqueue(
+              &TrajectorySampler::getAdmissibleTrajsFromVel, this, vel,
+              current_pose, admissible_velocity_trajectories.get()));
         }
       }
+    }
+    // wait on the futures before returning
+    for (auto &f : futures) {
+      f.wait();
     }
   } else {
 

--- a/src/kompass_cpp/kompass_cpp/src/utils/trajectory_sampler.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/utils/trajectory_sampler.cpp
@@ -7,7 +7,6 @@
 #include "datatypes/control.h"
 #include "datatypes/path.h"
 #include "datatypes/trajectory.h"
-#include "utils/logger.h"
 #include "utils/threadpool.h"
 #include "utils/trajectory_sampler.h"
 namespace Kompass {

--- a/src/kompass_cpp/tests/critical_zone_test.cpp
+++ b/src/kompass_cpp/tests/critical_zone_test.cpp
@@ -30,9 +30,10 @@ BOOST_AUTO_TEST_CASE(test_critical_zone_check) {
   float min_height = 0.1, max_height = 2.0;
 
   CriticalZoneChecker zoneChecker(
-      inputType, robotShapeType, robotDimensions, sensor_position_body,
-      sensor_rotation_body, critical_angle, critical_distance,
-      slowdown_distance, scan_angles, min_height, max_height, 20.0);
+      inputType, robotShapeType, robotDimensions,
+      {SensorConfig{sensor_position_body, sensor_rotation_body}},
+      critical_angle, critical_distance, slowdown_distance, min_height,
+      max_height, 20.0, scan_angles);
 
   LOG_INFO("Testing Emergency Stop with CPU (LASERSCAN)");
 
@@ -193,20 +194,14 @@ BOOST_AUTO_TEST_CASE(test_critical_zone_check) {
 
   LOG_INFO("Testing Emergency Stop with CPU (POINTCLOUD)");
 
-  // Instantiate a separate checker for PointCloud
-  Eigen::Vector3f pcPos{0.0, 0.0, 0.0};
-  Eigen::Vector4f pcRot{0.0, 0.0, 0.0, 1.0};
-
-  std::vector<double> pc_angles;
-  std::vector<double> dummy_ranges;
-  initLaserscan(360, 10.0, dummy_ranges, pc_angles); // 1-degree resolution
-
-  CriticalZoneChecker pcChecker(
-      CriticalZoneChecker::InputType::POINTCLOUD, robotShapeType, robotDimensions, pcPos,
-      pcRot, critical_angle, critical_distance /*crit_dist*/,
-      slowdown_distance /*slow_dist*/,
-      pc_angles, // Size 360
-      0.1 /*min_h*/, 2.0 /*max_h*/, 20.0);
+  // Instantiate a separate checker for PointCloud (identity mount; the
+  // body-frame band coincides with the sensor frame here)
+  CriticalZoneChecker pcChecker(CriticalZoneChecker::InputType::POINTCLOUD,
+                                robotShapeType, robotDimensions,
+                                {SensorConfig{}}, critical_angle,
+                                critical_distance /*crit_dist*/,
+                                slowdown_distance /*slow_dist*/,
+                                0.1 /*min_h*/, 2.0 /*max_h*/, 20.0);
 
   std::vector<uint8_t> cloud_data;
 
@@ -330,5 +325,195 @@ BOOST_AUTO_TEST_CASE(test_critical_zone_check) {
 
     if (result > 0.4 && result < 0.6)
       LOG_INFO("Test14 PASSED: PointCloud Slowdown Factor: ", result);
+  }
+}
+
+// ===========================================================================
+//      MULTI-SENSOR POINT CLOUD TESTS (15-18)
+// ===========================================================================
+
+namespace {
+
+const auto MS_SHAPE = CollisionChecker::ShapeType::CYLINDER;
+const std::vector<float> MS_DIMS{0.51f, 2.0f};
+constexpr float MS_CRIT_ANGLE = 160.0f;
+constexpr float MS_CRIT_DIST = 0.3f;
+constexpr float MS_SLOW_DIST = 0.6f;
+constexpr float MS_MIN_H = 0.1f; // body frame
+constexpr float MS_MAX_H = 2.0f; // body frame
+
+const int MS_POINT_STEP = sizeof(PointXYZ);
+const int MS_X_OFF = offsetof(PointXYZ, x);
+const int MS_Y_OFF = offsetof(PointXYZ, y);
+const int MS_Z_OFF = offsetof(PointXYZ, z);
+
+PointCloudView ms_view(const std::vector<uint8_t> &cloud) {
+  const int n = static_cast<int>(cloud.size() / MS_POINT_STEP);
+  return PointCloudView{cloud, MS_POINT_STEP, n * MS_POINT_STEP,
+                        n > 0 ? 1 : 0, n,
+                        MS_X_OFF,      MS_Y_OFF, MS_Z_OFF};
+}
+
+CriticalZoneChecker make_ms_checker(const std::vector<SensorConfig> &sensors) {
+  return CriticalZoneChecker(CriticalZoneChecker::InputType::POINTCLOUD,
+                             MS_SHAPE, MS_DIMS, sensors, MS_CRIT_ANGLE,
+                             MS_CRIT_DIST, MS_SLOW_DIST, MS_MIN_H, MS_MAX_H,
+                             20.0f);
+}
+
+std::vector<SensorConfig> ms_front_back() {
+  return {SensorConfig::fromYaw({0.2f, 0.0f, 0.2f}, 0.0f),
+          SensorConfig::fromYaw({-0.2f, 0.0f, 0.2f},
+                                static_cast<float>(M_PI))};
+}
+
+} // namespace
+
+// --- Test 15: Back-Sensor Obstacle & Moving Backward (Headline Case) ---
+BOOST_AUTO_TEST_CASE(test_cpu_multi_back_obstacle_stops_reverse) {
+  Timer time;
+  auto checker = make_ms_checker(ms_front_back());
+  std::vector<uint8_t> back_cloud;
+  // Obstacle seen ONLY by the back sensor (mounted at x=-0.2, yaw=pi).
+  // Back-sensor frame (0.55, 0, 0.3) -> body (-0.75, 0, 0.5).
+  // Dist = 0.75. 0.75 - Radius(0.51) = 0.24 < Crit(0.3) -> Critical.
+  addPointToCloud(back_cloud, 0.55f, 0.0f, 0.3f);
+  const std::vector<uint8_t> empty_front;
+
+  const float backward = checker.check(
+      {ms_view(empty_front), ms_view(back_cloud)}, /*forward*/ false);
+  BOOST_TEST(backward == 0.0f,
+             "Obstacle is behind and robot is moving backward -> Critical "
+             "zone result should be 0.0, returned "
+                 << backward);
+
+  const float forward = checker.check(
+      {ms_view(empty_front), ms_view(back_cloud)}, /*forward*/ true);
+  BOOST_TEST(forward == 1.0f,
+             "Obstacle is behind and robot is moving forward -> Critical "
+             "zone result should be 1.0, returned "
+                 << forward);
+
+  if (backward == 0.0f && forward == 1.0f) {
+    LOG_INFO("Test15 PASSED: Back-sensor obstacle stops reverse motion and "
+             "does not affect forward motion");
+  }
+}
+
+// --- Test 16: Min-Wins Fusion Across Clouds ---
+BOOST_AUTO_TEST_CASE(test_cpu_multi_min_across_clouds) {
+  Timer time;
+  auto checker = make_ms_checker(ms_front_back());
+  std::vector<uint8_t> front_cloud;
+  // Front-sensor frame (0.75, 0, 0.3) -> body (0.95, 0, 0.5).
+  // Dist to robot = 0.95 - 0.51 = 0.44. Slowdown range [0.3, 0.6] ->
+  // factor (0.44 - 0.3) / 0.3 = ~0.467.
+  addPointToCloud(front_cloud, 0.75f, 0.0f, 0.3f);
+  std::vector<uint8_t> back_cloud;
+  // Far point in the back cloud -> safe, must not affect the fused result
+  addPointToCloud(back_cloud, 5.0f, 0.0f, 0.3f);
+
+  const float slow = checker.check(
+      {ms_view(front_cloud), ms_view(back_cloud)}, /*forward*/ true);
+  BOOST_TEST((slow > 0.4f && slow < 0.55f),
+             "Front slowdown point + far back point -> fused factor should "
+             "be ~0.467, returned "
+                 << slow);
+
+  // Front-sensor frame (0.6, 0, 0.3) -> body (0.8, 0, 0.5).
+  // 0.8 - Radius(0.51) = 0.29 < Crit(0.3) -> Critical, must win the min.
+  addPointToCloud(front_cloud, 0.6f, 0.0f, 0.3f);
+  const float stop = checker.check(
+      {ms_view(front_cloud), ms_view(back_cloud)}, /*forward*/ true);
+  BOOST_TEST(stop == 0.0f,
+             "Critical point should win the min across clouds -> result "
+             "should be 0.0, returned "
+                 << stop);
+
+  // All-empty batch -> nothing observed this tick -> no constraint
+  const std::vector<uint8_t> empty;
+  const float idle =
+      checker.check({ms_view(empty), ms_view(empty)}, /*forward*/ true);
+  BOOST_TEST(idle == 1.0f,
+             "All-empty batch -> result should be 1.0, returned " << idle);
+
+  if (slow > 0.4f && slow < 0.55f && stop == 0.0f && idle == 1.0f) {
+    LOG_INFO("Test16 PASSED: Min factor wins across fused clouds, slowdown "
+             "factor = ",
+             slow);
+  }
+}
+
+// --- Test 17: Tilted Mount, Exact Values ---
+BOOST_AUTO_TEST_CASE(test_cpu_multi_tilted_mount_exact) {
+  Timer time;
+  // 25 deg pitch mount at z=0.3 (quaternion built from the half angle)
+  const float half_pitch = 12.5f * static_cast<float>(M_PI) / 180.0f;
+  SensorConfig tilted;
+  tilted.position = {0.0f, 0.0f, 0.3f};
+  tilted.rotation = {0.0f, std::sin(half_pitch), 0.0f, std::cos(half_pitch)};
+  auto checker = make_ms_checker({tilted});
+
+  std::vector<uint8_t> cloud;
+  // Sensor frame (0.8, 0, 0.3): the full transform leans z INTO x:
+  // x_body = 0.8*cos25 + 0.3*sin25 = 0.852 -> slowdown factor ~0.14.
+  // Dropping the transform's z column (the old approximation) gives
+  // x_body = 0.725 -> a false STOP, so a 0 here means the tilt terms
+  // regressed.
+  addPointToCloud(cloud, 0.8f, 0.0f, 0.3f);
+  const float factor = checker.check({ms_view(cloud)}, /*forward*/ true);
+  BOOST_TEST((factor > 0.05f && factor < 0.25f),
+             "Tilted mount -> slowdown factor should be ~0.14 under the "
+             "full transform, returned "
+                 << factor);
+
+  if (factor > 0.05f && factor < 0.25f) {
+    LOG_INFO("Test17 PASSED: Full tilt transform applied, slowdown factor = ",
+             factor);
+  }
+}
+
+// --- Test 18: N=1 Adapter & Error Paths ---
+BOOST_AUTO_TEST_CASE(test_cpu_multi_adapter_and_errors) {
+  Timer time;
+  auto single = make_ms_checker({SensorConfig{}});
+  std::vector<uint8_t> cloud;
+  addPointToCloud(cloud, 0.95f, 0.0f, 0.5f);
+  addPointToCloud(cloud, 0.75f, 0.0f, 0.5f);
+
+  // The single-cloud byte entry is an N=1 adapter onto the batched
+  // path -> identical result for the identical cloud
+  const auto view = ms_view(cloud);
+  const float legacy =
+      single.check(view.data, view.point_step, view.row_step, view.height,
+                   view.width, view.x_offset, view.y_offset, view.z_offset,
+                   /*forward*/ true);
+  const float batched = single.check({view}, /*forward*/ true);
+  BOOST_TEST(legacy == batched,
+             "Adapter and batched entry should agree, returned "
+                 << legacy << " vs " << batched);
+
+  // Cloud count mismatch: two configured sensors, one cloud
+  auto multi = make_ms_checker(ms_front_back());
+  BOOST_CHECK_THROW(multi.check({view}, true), std::invalid_argument);
+
+  // Malformed metadata must name the offending cloud in the error message
+  PointCloudView bad = ms_view(cloud);
+  bad.y_offset = -4;
+  BOOST_CHECK_EXCEPTION(
+      multi.check({ms_view(cloud), bad}, true), std::invalid_argument,
+      [](const std::invalid_argument &e) {
+        return std::string(e.what()).find("clouds[1]") != std::string::npos &&
+               std::string(e.what()).find("non-negative") != std::string::npos;
+      });
+
+  // Laserscan entry on a pointcloud-mode checker throws
+  Eigen::VectorXf ranges(4);
+  ranges.setConstant(1.0f);
+  BOOST_CHECK_THROW(multi.check(ranges, true), std::logic_error);
+
+  if (legacy == batched) {
+    LOG_INFO("Test18 PASSED: N=1 adapter matches batched entry and error "
+             "paths throw as expected");
   }
 }

--- a/src/kompass_cpp/tests/critical_zone_test.cpp
+++ b/src/kompass_cpp/tests/critical_zone_test.cpp
@@ -517,3 +517,42 @@ BOOST_AUTO_TEST_CASE(test_cpu_multi_adapter_and_errors) {
              "paths throw as expected");
   }
 }
+
+// --- Test 19: Optical-Axis Point Is Not Filtered (Depth Camera) ---
+BOOST_AUTO_TEST_CASE(test_cpu_multi_optical_axis_not_filtered) {
+  Timer time;
+  // Depth camera in the ROS optical frame (z forward, x right, y down),
+  // mounted at (0.1, 0, 0.3). Body-from-optical quaternion [x,y,z,w] =
+  // [-0.5, 0.5, -0.5, 0.5]: x_body = z_opt, y_body = -x_opt, z_body = -y_opt
+  SensorConfig camera;
+  camera.position = {0.1f, 0.0f, 0.3f};
+  camera.rotation = {-0.5f, 0.5f, -0.5f, 0.5f};
+  auto checker = make_ms_checker({camera});
+
+  std::vector<uint8_t> cloud;
+  // Sensor (0, 0, 0.4) lies ON the optical axis -> body (0.5, 0, 0.3).
+  // Dist = 0.5. 0.5 - Radius(0.51) = -0.01 < Crit(0.3) -> Critical. A
+  // planar sensor-frame origin filter (x^2+y^2 < 1e-6) deletes this point
+  // -> full speed into an obstacle 40 cm dead ahead of the camera
+  addPointToCloud(cloud, 0.0f, 0.0f, 0.4f);
+  const float factor = checker.check({ms_view(cloud)}, /*forward*/ true);
+  BOOST_TEST(factor == 0.0f,
+             "On-axis point 40 cm ahead of a depth camera -> Critical zone "
+             "result should be 0.0, returned "
+                 << factor);
+
+  // A TRUE origin point (all three coordinates zero) must still be
+  // rejected: it maps onto the mount position inside the robot
+  std::vector<uint8_t> origin_cloud;
+  addPointToCloud(origin_cloud, 0.0f, 0.0f, 0.0f);
+  const float clear = checker.check({ms_view(origin_cloud)}, /*forward*/ true);
+  BOOST_TEST(clear == 1.0f,
+             "Sensor-origin self-return -> Critical zone result should be "
+             "1.0, returned "
+                 << clear);
+
+  if (factor == 0.0f && clear == 1.0f) {
+    LOG_INFO("Test19 PASSED: Optical-axis obstacle detected and origin "
+             "self-return filtered");
+  }
+}

--- a/src/kompass_cpp/tests/critical_zone_test_gpu.cpp
+++ b/src/kompass_cpp/tests/critical_zone_test_gpu.cpp
@@ -488,3 +488,41 @@ BOOST_AUTO_TEST_CASE(test_multi_sensor_error_paths) {
   BOOST_CHECK_THROW(shared_laserscan_checker().check({make_view(cloud)}, true),
                     std::logic_error);
 }
+
+// --- Test 22: Optical-Axis Point Is Not Filtered (Depth Camera) ---
+// Depth camera in the ROS optical frame (z forward, x right, y down),
+// mounted at (0.1, 0, 0.3): a point ON the optical axis is straight ahead
+// of the robot and must trip the forward check. Sensor (0, 0, 0.4) ->
+// body (0.5, 0, 0.3): 0.5 - Radius(0.51) = -0.01 < Crit(0.3) -> Critical.
+// A TRUE origin point must still be rejected (it maps onto the mount position
+// inside the robot).
+BOOST_AUTO_TEST_CASE(test_multi_sensor_optical_axis_not_filtered) {
+  Timer time;
+  SensorConfig camera;
+  camera.position = {0.1f, 0.0f, 0.3f};
+  // Body-from-optical: x_body = z_opt, y_body = -x_opt, z_body = -y_opt
+  camera.rotation = {-0.5f, 0.5f, -0.5f, 0.5f};
+
+  static CriticalZoneCheckerGPU *camera_checker = new CriticalZoneCheckerGPU(
+      CriticalZoneChecker::InputType::POINTCLOUD, ROBOT_SHAPE, ROBOT_DIMS,
+      {camera}, CRIT_ANGLE, CRIT_DIST, SLOW_DIST, POINTCLOUD_MIN_H,
+      POINTCLOUD_MAX_H, MAX_RANGE);
+
+  std::vector<uint8_t> cloud;
+  addPointToCloud(cloud, 0.0f, 0.0f, 0.4f);
+  const float factor = camera_checker->check({make_view(cloud)},
+                                             /*forward*/ true);
+  BOOST_TEST(factor == 0.0f,
+             "On-axis point 40 cm ahead of a depth camera -> expected 0.0, "
+             "got "
+                 << factor);
+
+  std::vector<uint8_t> origin_cloud;
+  addPointToCloud(origin_cloud, 0.0f, 0.0f, 0.0f);
+  const float clear = camera_checker->check({make_view(origin_cloud)},
+                                            /*forward*/ true);
+  BOOST_TEST(clear == 1.0f,
+             "Sensor-origin self-return should be filtered -> expected 1.0, "
+             "got "
+                 << clear);
+}

--- a/src/kompass_cpp/tests/critical_zone_test_gpu.cpp
+++ b/src/kompass_cpp/tests/critical_zone_test_gpu.cpp
@@ -10,8 +10,7 @@
 //
 // Workaround: one checker per input mode (laserscan, pointcloud) held by
 // an intentionally-leaked function-local static. Each test also builds
-// its own fresh input state to avoid cross-test dependencies. Same
-// pattern in mapper_test_gpu.cpp and pointcloud_to_laserscan_test_gpu.cpp.
+// its own fresh input state to avoid cross-test dependencies.
 
 #include "test.h"
 #include <Eigen/Dense>
@@ -23,7 +22,7 @@
 #include <vector>
 
 // ---------------------------------------------------------------------------
-// Shared config (same values as the original single-case test).
+// Shared config
 // ---------------------------------------------------------------------------
 
 namespace {
@@ -60,20 +59,30 @@ std::vector<double> make_reference_angles() {
 CriticalZoneCheckerGPU &shared_laserscan_checker() {
   static CriticalZoneCheckerGPU *c = new CriticalZoneCheckerGPU(
       CriticalZoneChecker::InputType::LASERSCAN, ROBOT_SHAPE, ROBOT_DIMS,
-      /*sensor_pos*/ Eigen::Vector3f{0.22f, 0.0f, 0.4f},
-      /*sensor_rot*/ Eigen::Vector4f{0.0f, 0.0f, 0.99f, 0.0f},
-      CRIT_ANGLE, CRIT_DIST, SLOW_DIST, make_reference_angles(),
-      LASERSCAN_MIN_H, LASERSCAN_MAX_H, MAX_RANGE);
+      {SensorConfig{Eigen::Vector3f{0.22f, 0.0f, 0.4f},
+                    Eigen::Vector4f{0.0f, 0.0f, 0.99f, 0.0f}}},
+      CRIT_ANGLE, CRIT_DIST, SLOW_DIST, LASERSCAN_MIN_H, LASERSCAN_MAX_H,
+      MAX_RANGE, make_reference_angles());
   return *c;
 }
 
 CriticalZoneCheckerGPU &shared_pointcloud_checker() {
   static CriticalZoneCheckerGPU *c = new CriticalZoneCheckerGPU(
       CriticalZoneChecker::InputType::POINTCLOUD, ROBOT_SHAPE, ROBOT_DIMS,
-      /*sensor_pos*/ Eigen::Vector3f{0.0f, 0.0f, 0.0f},
-      /*sensor_rot*/ Eigen::Vector4f{0.0f, 0.0f, 0.0f, 1.0f},
-      CRIT_ANGLE, CRIT_DIST, SLOW_DIST, make_reference_angles(),
-      POINTCLOUD_MIN_H, POINTCLOUD_MAX_H, MAX_RANGE);
+      {SensorConfig{}}, CRIT_ANGLE, CRIT_DIST, SLOW_DIST, POINTCLOUD_MIN_H,
+      POINTCLOUD_MAX_H, MAX_RANGE);
+  return *c;
+}
+
+// Front + back mounted sensors (fusion tests). Mount heights 0.2 m; the
+// body-frame band [POINTCLOUD_MIN_H, POINTCLOUD_MAX_H] is shared
+CriticalZoneCheckerGPU &shared_multi_checker() {
+  static CriticalZoneCheckerGPU *c = new CriticalZoneCheckerGPU(
+      CriticalZoneChecker::InputType::POINTCLOUD, ROBOT_SHAPE, ROBOT_DIMS,
+      {SensorConfig::fromYaw({0.2f, 0.0f, 0.2f}, 0.0f),
+       SensorConfig::fromYaw({-0.2f, 0.0f, 0.2f}, static_cast<float>(M_PI))},
+      CRIT_ANGLE, CRIT_DIST, SLOW_DIST, POINTCLOUD_MIN_H, POINTCLOUD_MAX_H,
+      MAX_RANGE);
   return *c;
 }
 
@@ -122,7 +131,8 @@ BOOST_AUTO_TEST_CASE(test_laserscan_behind_moving_forward) {
   setLaserscanAtAngle(0.1, 0.2, scan.ranges, scan.angles);
   setLaserscanAtAngle(-0.1, 0.2, scan.ranges, scan.angles);
 
-  float result = shared_laserscan_checker().check(toVecF(scan.ranges), /*forward*/ true);
+  float result =
+      shared_laserscan_checker().check(toVecF(scan.ranges), /*forward*/ true);
   BOOST_TEST(result == 1.0,
              "Angles behind, moving forward -> expected 1.0, got " << result);
 }
@@ -131,7 +141,8 @@ BOOST_AUTO_TEST_CASE(test_laserscan_front_far_moving_forward) {
   Timer time;
   auto scan = fresh_laserscan();
 
-  float result = shared_laserscan_checker().check(toVecF(scan.ranges), /*forward*/ true);
+  float result =
+      shared_laserscan_checker().check(toVecF(scan.ranges), /*forward*/ true);
   BOOST_TEST(result == 1.0,
              "Angles in front, far, moving forward -> expected 1.0, got "
                  << result);
@@ -144,7 +155,8 @@ BOOST_AUTO_TEST_CASE(test_laserscan_front_close_moving_forward) {
   setLaserscanAtAngle(M_PI + 0.1, 0.2, scan.ranges, scan.angles);
   setLaserscanAtAngle(M_PI - 0.1, 0.2, scan.ranges, scan.angles);
 
-  float result = shared_laserscan_checker().check(toVecF(scan.ranges), /*forward*/ true);
+  float result =
+      shared_laserscan_checker().check(toVecF(scan.ranges), /*forward*/ true);
   BOOST_TEST(result == 0.0,
              "Angles in front, close, moving forward -> expected 0.0, got "
                  << result);
@@ -157,7 +169,8 @@ BOOST_AUTO_TEST_CASE(test_laserscan_front_close_moving_backward) {
   setLaserscanAtAngle(M_PI + 0.1, 0.2, scan.ranges, scan.angles);
   setLaserscanAtAngle(M_PI - 0.1, 0.2, scan.ranges, scan.angles);
 
-  float result = shared_laserscan_checker().check(toVecF(scan.ranges), /*forward*/ false);
+  float result =
+      shared_laserscan_checker().check(toVecF(scan.ranges), /*forward*/ false);
   BOOST_TEST(result == 1.0,
              "Angles in front, close, moving backward -> expected 1.0, got "
                  << result);
@@ -170,7 +183,8 @@ BOOST_AUTO_TEST_CASE(test_laserscan_back_close_moving_backward) {
   setLaserscanAtAngle(0.1, 0.2, scan.ranges, scan.angles);
   setLaserscanAtAngle(-0.1, 0.2, scan.ranges, scan.angles);
 
-  float result = shared_laserscan_checker().check(toVecF(scan.ranges), /*forward*/ false);
+  float result =
+      shared_laserscan_checker().check(toVecF(scan.ranges), /*forward*/ false);
   BOOST_TEST(result == 0.0,
              "Angles behind, close, moving backward -> expected 0.0, got "
                  << result);
@@ -181,10 +195,12 @@ BOOST_AUTO_TEST_CASE(test_laserscan_back_slowdown_moving_backward) {
   auto scan = fresh_laserscan();
   setLaserscanAtAngle(0.0, 1.3, scan.ranges, scan.angles);
 
-  float result = shared_laserscan_checker().check(toVecF(scan.ranges), /*forward*/ false);
+  float result =
+      shared_laserscan_checker().check(toVecF(scan.ranges), /*forward*/ false);
   BOOST_TEST((result > 0.0 && result < 1.0),
              "Angle behind in slowdown zone, moving backward -> expected in "
-             "(0, 1), got " << result);
+             "(0, 1), got "
+                 << result);
 }
 
 BOOST_AUTO_TEST_CASE(test_laserscan_back_slowdown_moving_forward) {
@@ -192,10 +208,12 @@ BOOST_AUTO_TEST_CASE(test_laserscan_back_slowdown_moving_forward) {
   auto scan = fresh_laserscan();
   setLaserscanAtAngle(0.0, 1.3, scan.ranges, scan.angles);
 
-  float result = shared_laserscan_checker().check(toVecF(scan.ranges), /*forward*/ true);
+  float result =
+      shared_laserscan_checker().check(toVecF(scan.ranges), /*forward*/ true);
   BOOST_TEST(result == 1.0,
              "Angle behind in slowdown zone, moving forward -> expected 1.0, "
-             "got " << result);
+             "got "
+                 << result);
 }
 
 BOOST_AUTO_TEST_CASE(test_laserscan_front_slowdown_moving_forward) {
@@ -203,10 +221,12 @@ BOOST_AUTO_TEST_CASE(test_laserscan_front_slowdown_moving_forward) {
   auto scan = fresh_laserscan();
   setLaserscanAtAngle(M_PI, 0.7, scan.ranges, scan.angles);
 
-  float result = shared_laserscan_checker().check(toVecF(scan.ranges), /*forward*/ true);
+  float result =
+      shared_laserscan_checker().check(toVecF(scan.ranges), /*forward*/ true);
   BOOST_TEST((result > 0.0 && result < 1.0),
              "Angle in front in slowdown zone, moving forward -> expected in "
-             "(0, 1), got " << result);
+             "(0, 1), got "
+                 << result);
 }
 
 // ===========================================================================
@@ -264,8 +284,8 @@ BOOST_AUTO_TEST_CASE(test_pointcloud_mixed_stop_wins) {
   addPointToCloud(cloud, 0.75f, 0.0f, 0.5f);
 
   float result = run_pc_check(cloud, /*forward*/ true);
-  BOOST_TEST(result == 0.0f, "Stop-zone point should win min reduction, got "
-                                 << result);
+  BOOST_TEST(result == 0.0f,
+             "Stop-zone point should win min reduction, got " << result);
 }
 
 BOOST_AUTO_TEST_CASE(test_pointcloud_mixed_slowdown_backward) {
@@ -285,4 +305,186 @@ BOOST_AUTO_TEST_CASE(test_pointcloud_mixed_slowdown_backward) {
   BOOST_TEST((result > 0.4f && result < 0.6f),
              "Mixed cloud, moving backward -> expected slowdown ~0.5, got "
                  << result);
+}
+
+// ===========================================================================
+// MULTI-SENSOR POINTCLOUD tests (15-21): front + back mounts, see
+// shared_multi_checker above
+// ===========================================================================
+
+PointCloudView make_view(const std::vector<uint8_t> &cloud) {
+  const int n = static_cast<int>(cloud.size() / PC_POINT_STEP);
+  return PointCloudView{cloud, PC_POINT_STEP, n * PC_POINT_STEP, n > 0 ? 1 : 0,
+                        n,     PC_X_OFF,      PC_Y_OFF,          PC_Z_OFF};
+}
+
+// Back-Sensor Obstacle & Moving Backward (Headline Case) ---
+// An obstacle seen ONLY by the back sensor must stop reverse motion and
+// leave forward motion untouched. Back-sensor frame (0.55, 0, 0.3) ->
+// body (-0.75, 0, 0.5). Dist = 0.75. 0.75 - Radius(0.51) = 0.24 <
+// Crit(0.3) -> stop when backing up.
+BOOST_AUTO_TEST_CASE(test_multi_sensor_back_obstacle_stops_reverse) {
+  Timer time;
+  std::vector<uint8_t> back_cloud;
+  addPointToCloud(back_cloud, 0.55f, 0.0f, 0.3f);
+  const std::vector<uint8_t> empty_front;
+
+  auto &checker = shared_multi_checker();
+  const float backward =
+      checker.check({make_view(empty_front), make_view(back_cloud)},
+                    /*forward*/ false);
+  BOOST_TEST(backward == 0.0f,
+             "back obstacle must stop reverse motion, got " << backward);
+
+  const float forward = checker.check(
+      {make_view(empty_front), make_view(back_cloud)}, /*forward*/ true);
+  BOOST_TEST(forward == 1.0f,
+             "back obstacle must not affect forward motion, got " << forward);
+}
+
+// --- Critical Cone Is a Body-Frame Gate ---
+// The cone is not a per-sensor gate: a point in the BACK sensor's cloud
+// that lands ahead of the robot must trip the forward check. Back-sensor
+// frame (-0.9, 0, 0.3) -> body (0.7, 0, 0.5). 0.7 - Radius(0.51) = 0.19 <
+// Crit(0.3) -> forward stop from the back sensor's data.
+BOOST_AUTO_TEST_CASE(test_multi_sensor_cone_is_body_frame) {
+  Timer time;
+  std::vector<uint8_t> back_cloud;
+  addPointToCloud(back_cloud, -0.9f, 0.0f, 0.3f);
+  const std::vector<uint8_t> empty_front;
+
+  const float forward = shared_multi_checker().check(
+      {make_view(empty_front), make_view(back_cloud)}, /*forward*/ true);
+  BOOST_TEST(forward == 0.0f,
+             "a back-sensor point ahead of the robot must trip the forward "
+             "check, got "
+                 << forward);
+}
+
+// --- Min-Wins Fusion Across Clouds ---
+// Front cloud holds a slowdown-zone point: front-sensor (0.75, 0, 0.3) ->
+// body (0.95, 0, 0.5), factor (0.95 - 0.51 - 0.3) / 0.3 = ~0.467. The
+// back cloud is far. Fused factor equals the slowdown factor; adding a
+// closer front point lowers it to 0.
+BOOST_AUTO_TEST_CASE(test_multi_sensor_min_across_clouds) {
+  Timer time;
+  std::vector<uint8_t> front_cloud;
+  addPointToCloud(front_cloud, 0.75f, 0.0f, 0.3f);
+  std::vector<uint8_t> back_cloud;
+  addPointToCloud(back_cloud, 5.0f, 0.0f, 0.3f); // far, safe
+
+  auto &checker = shared_multi_checker();
+  const float slow = checker.check(
+      {make_view(front_cloud), make_view(back_cloud)}, /*forward*/ true);
+  BOOST_TEST((slow > 0.4f && slow < 0.55f),
+             "expected slowdown factor ~0.467, got " << slow);
+
+  addPointToCloud(front_cloud, 0.6f, 0.0f, 0.3f); // body 0.8 -> critical
+  const float stop = checker.check(
+      {make_view(front_cloud), make_view(back_cloud)}, /*forward*/ true);
+  BOOST_TEST(stop == 0.0f, "critical point must win the min, got " << stop);
+}
+
+// --- Repeat-Call State ---
+// A stop result must not leak into the next call (guards the shared-result
+// reset being hoisted before the batch's submits).
+BOOST_AUTO_TEST_CASE(test_multi_sensor_repeat_call_state) {
+  Timer time;
+  std::vector<uint8_t> danger;
+  addPointToCloud(danger, 0.55f, 0.0f, 0.3f); // front: body 0.75 -> stop
+  std::vector<uint8_t> safe;
+  addPointToCloud(safe, 5.0f, 0.0f, 0.3f);
+
+  auto &checker = shared_multi_checker();
+  const float stop =
+      checker.check({make_view(danger), make_view(safe)}, /*forward*/ true);
+  BOOST_TEST(stop == 0.0f);
+
+  const float clear =
+      checker.check({make_view(safe), make_view(safe)}, /*forward*/ true);
+  BOOST_TEST(clear == 1.0f,
+             "stop from the previous call leaked into this one, got " << clear);
+
+  // All-empty batch -> nothing observed -> no constraint
+  const std::vector<uint8_t> empty;
+  const float idle =
+      checker.check({make_view(empty), make_view(empty)}, /*forward*/ true);
+  BOOST_TEST(idle == 1.0f);
+}
+
+// --- Tilted Mount, Exact Values ---
+// 25 deg pitch at z=0.3 seeing sensor-frame (0.8, 0, 0.3). With the full
+// transform the point's z leans INTO x:
+// x_body = 0.8*cos25 + 0.3*sin25 = 0.852 -> slowdown (factor ~0.14).
+// The old kernel dropped the z column (x_body = 0.725 -> false STOP), so
+// a 0 here means the tilt terms regressed.
+BOOST_AUTO_TEST_CASE(test_multi_sensor_tilted_mount_exact) {
+  Timer time;
+  const float half_pitch = 12.5f * static_cast<float>(M_PI) / 180.0f;
+  SensorConfig tilted;
+  tilted.position = {0.0f, 0.0f, 0.3f};
+  tilted.rotation = {0.0f, std::sin(half_pitch), 0.0f, std::cos(half_pitch)};
+
+  static CriticalZoneCheckerGPU *tilted_checker = new CriticalZoneCheckerGPU(
+      CriticalZoneChecker::InputType::POINTCLOUD, ROBOT_SHAPE, ROBOT_DIMS,
+      {tilted}, CRIT_ANGLE, CRIT_DIST, SLOW_DIST, POINTCLOUD_MIN_H,
+      POINTCLOUD_MAX_H, MAX_RANGE);
+
+  std::vector<uint8_t> cloud;
+  addPointToCloud(cloud, 0.8f, 0.0f, 0.3f);
+  const float factor =
+      tilted_checker->check({make_view(cloud)}, /*forward*/ true);
+  BOOST_TEST((factor > 0.05f && factor < 0.25f),
+             "expected slowdown ~0.14 under the full tilt transform, got "
+                 << factor);
+}
+
+// --- N=1 Adapter ---
+// The  single-cloud byte entry is an N=1 adapter onto the batched
+// path: identical result for the identical cloud.
+BOOST_AUTO_TEST_CASE(test_multi_sensor_n1_adapter) {
+  Timer time;
+  std::vector<uint8_t> cloud;
+  addPointToCloud(cloud, 0.95f, 0.0f, 0.5f);
+  addPointToCloud(cloud, -1.0f, -1.0f, 0.5f);
+  addPointToCloud(cloud, 0.75f, 0.0f, 0.5f);
+
+  const float legacy = run_pc_check(cloud, /*forward*/ true);
+  const float batched =
+      shared_pointcloud_checker().check({make_view(cloud)}, /*forward*/ true);
+  BOOST_TEST(legacy == batched, "adapter and batched entry disagree: "
+                                    << legacy << " vs " << batched);
+}
+
+// --- Error Paths ---
+// Cloud-count mismatch, negative offsets named per cloud, and mode guards
+// on both entries.
+BOOST_AUTO_TEST_CASE(test_multi_sensor_error_paths) {
+  Timer time;
+  std::vector<uint8_t> cloud;
+  addPointToCloud(cloud, 5.0f, 0.0f, 0.3f);
+
+  auto &checker = shared_multi_checker();
+
+  BOOST_CHECK_THROW(checker.check({make_view(cloud)}, true),
+                    std::invalid_argument);
+
+  PointCloudView bad = make_view(cloud);
+  bad.y_offset = -4;
+  BOOST_CHECK_EXCEPTION(
+      checker.check({make_view(cloud), bad}, true), std::invalid_argument,
+      [](const std::invalid_argument &e) {
+        return std::string(e.what()).find("clouds[1]") != std::string::npos &&
+               std::string(e.what()).find("non-negative") != std::string::npos;
+      });
+
+  // Laserscan entry on a pointcloud-mode checker throws (was a silent
+  // memcpy into a null device pointer)
+  Eigen::VectorXf ranges(4);
+  ranges.setConstant(1.0f);
+  BOOST_CHECK_THROW(checker.check(ranges, true), std::logic_error);
+
+  // Batched entry on a laserscan-mode checker throws
+  BOOST_CHECK_THROW(shared_laserscan_checker().check({make_view(cloud)}, true),
+                    std::logic_error);
 }

--- a/src/kompass_cpp/tests/mapper_test.cpp
+++ b/src/kompass_cpp/tests/mapper_test.cpp
@@ -425,3 +425,45 @@ BOOST_AUTO_TEST_CASE(test_multi_sensor_error_paths) {
   BOOST_CHECK_THROW(scan_mapper.scanToGrid({makeView(cloud)}),
                     std::logic_error);
 }
+
+// Packs xyz points into a raw FLOAT64 buffer (point_step 24, offsets 0/8/16)
+static std::vector<uint8_t> packXYZ64(const std::vector<Eigen::Vector3f> &pts) {
+  std::vector<uint8_t> data;
+  data.reserve(pts.size() * 3 * sizeof(double));
+  for (const auto &p : pts) {
+    for (int k = 0; k < 3; ++k) {
+      const double v = static_cast<double>(p[k]);
+      const auto *bytes = reinterpret_cast<const uint8_t *>(&v);
+      data.insert(data.end(), bytes, bytes + sizeof(double));
+    }
+  }
+  return data;
+}
+
+/**
+ * A FLOAT64 cloud must produce exactly the grid its FLOAT32 twin produces:
+ * SensorConfig.cloud_field_type dispatches the CPU field decoding.
+ */
+BOOST_AUTO_TEST_CASE(test_multi_sensor_float64_cloud) {
+  const std::vector<Eigen::Vector3f> points = {
+      {0.4f, 0.0f, -0.1f}, {0.0f, 0.5f, -0.1f}, {-0.3f, -0.3f, -0.1f}};
+
+  auto mapper32 = makeMultiMapper({SensorConfig::fromYaw({0.3f, 0.0f, 0.2f},
+                                                         0.0f)});
+  const auto cloud32 = packXYZ(points);
+  const Eigen::MatrixXi grid32 = mapper32.scanToGrid({makeView(cloud32)});
+
+  SensorConfig sensor64 = SensorConfig::fromYaw({0.3f, 0.0f, 0.2f}, 0.0f);
+  sensor64.cloud_field_type = PointFieldType::FLOAT64;
+  auto mapper64 = makeMultiMapper({sensor64});
+  const auto cloud64 = packXYZ64(points);
+  const int n = static_cast<int>(points.size());
+  const PointCloudView view64{cloud64, 24, 24 * n, 1, n, 0, 8, 16};
+  const Eigen::MatrixXi grid64 = mapper64.scanToGrid({view64});
+
+  BOOST_CHECK_GT(countPointsInGrid(
+                     grid32, static_cast<int>(Mapping::OccupancyType::OCCUPIED)),
+                 0);
+  BOOST_TEST((grid32.array() == grid64.array()).all(),
+             "FLOAT64 cloud must produce the exact grid of its FLOAT32 twin");
+}

--- a/src/kompass_cpp/tests/mapper_test.cpp
+++ b/src/kompass_cpp/tests/mapper_test.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
+#include <string>
 #include <vector>
 
 using namespace Kompass;
@@ -29,7 +30,6 @@ struct GridMapConfig {
   float rangeSure;
   float rangeMax;
   float wallSize;
-  float angleStep;
   float minHeight;
   float maxHeight;
   int maxNumThreads;
@@ -48,14 +48,14 @@ struct GridMapConfig {
         centralPoint(std::round(grid_height / 2) - 1,
                      std::round(grid_width / 2) - 1),
         pPrior(0.6), pOccupied(0.9), pEmpty(1 - pOccupied), rangeSure(0.1),
-        rangeMax(20.0), wallSize(0.2), angleStep(0.01), minHeight(0.0),
+        rangeMax(20.0), wallSize(0.2), minHeight(0.0),
         maxHeight(0.0), maxNumThreads(10),
         limit(grid_width > grid_height ? grid_width * grid_res * std::sqrt(2)
                                        : grid_height * grid_res * std::sqrt(2)),
         maxPointsPerLine(static_cast<int>((limit / grid_res) * 1.5)),
         local_mapper(Mapping::LocalMapper(
-            grid_height, grid_width, grid_res, {0.0, 0.0, 0.0}, 0.0, false, 0, pPrior,
-            pOccupied, pEmpty, rangeSure, rangeMax, wallSize, angleStep,
+            grid_height, grid_width, grid_res, {SensorConfig{}}, false, 0,
+            pPrior, pOccupied, pEmpty, rangeSure, rangeMax, wallSize,
             maxHeight, minHeight, maxPointsPerLine, maxNumThreads)) {
 
     // Logging the central point and limit circle radius
@@ -149,7 +149,7 @@ BOOST_AUTO_TEST_CASE(test_mapper_circles) {
 
     Timer timer;
     auto [mat1, mat2] =
-        local_mapper.scanToGridBaysian(circle_scan.angles, filtered_ranges);
+        local_mapper.scanToGridBayesian(circle_scan.angles, filtered_ranges);
     gridData = &mat1;
     gridDataProb = &mat2;
   }
@@ -178,7 +178,7 @@ BOOST_AUTO_TEST_CASE(test_mapper_circles) {
   {
     Timer timer;
     auto [mat1, mat2] =
-        local_mapper.scanToGridBaysian(circle_scan.angles, filtered_ranges);
+        local_mapper.scanToGridBayesian(circle_scan.angles, filtered_ranges);
     gridData = &mat1;
     gridDataProb = &mat2;
   }
@@ -205,7 +205,7 @@ BOOST_AUTO_TEST_CASE(test_mapper_circles) {
   }
   {
     Timer timer;
-    local_mapper.scanToGridBaysian(circle_scan.angles, filtered_ranges);
+    local_mapper.scanToGridBayesian(circle_scan.angles, filtered_ranges);
   }
   occ_points = countPointsInGrid(
       *gridData, static_cast<int>(Mapping::OccupancyType::OCCUPIED));
@@ -221,3 +221,207 @@ BOOST_AUTO_TEST_CASE(test_mapper_circles) {
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+// ---------------------------------------------------------------------------
+// Multi-sensor pointcloud fusion (CPU)
+// ---------------------------------------------------------------------------
+
+// Packs xyz points into a raw FLOAT32 buffer (point_step 12)
+static std::vector<uint8_t> packXYZ(const std::vector<Eigen::Vector3f> &pts) {
+  std::vector<uint8_t> data;
+  data.reserve(pts.size() * 3 * sizeof(float));
+  for (const auto &p : pts) {
+    for (int k = 0; k < 3; ++k) {
+      float v = p[k];
+      const auto *bytes = reinterpret_cast<const uint8_t *>(&v);
+      data.insert(data.end(), bytes, bytes + sizeof(float));
+    }
+  }
+  return data;
+}
+
+static PointCloudView makeView(const std::vector<uint8_t> &data) {
+  const int n = static_cast<int>(data.size() / 12);
+  return PointCloudView{data, 12, 12 * n, 1, n, 0, 4, 8};
+}
+
+// Shared config for the multi-sensor cases: 20x20 grid at 0.1 m/cell
+// (2 m x 2 m), 360 bins, body-frame band [0, 0.5]
+static Mapping::LocalMapper
+makeMultiMapper(const std::vector<SensorConfig> &sensors) {
+  return Mapping::LocalMapper(20, 20, 0.1f, sensors, /*isPointCloud*/ true,
+                              /*scanSize*/ 360, /*maxHeight*/ 0.5f,
+                              /*minHeight*/ 0.0f, /*rangeMax*/ 5.0f,
+                              /*maxPointsPerLine*/ 43, /*maxNumThreads*/ 1);
+}
+
+static int countOccupiedInRows(const Eigen::MatrixXi &grid, int rowBegin,
+                               int rowEnd /*inclusive*/) {
+  int count = 0;
+  for (int i = rowBegin; i <= rowEnd; ++i) {
+    for (int j = 0; j < grid.cols(); ++j) {
+      if (grid(i, j) == static_cast<int>(Mapping::OccupancyType::OCCUPIED)) {
+        ++count;
+      }
+    }
+  }
+  return count;
+}
+
+/**
+ * Front + back mounted sensors, each seeing one obstacle straight ahead in
+ * its own frame: the fused grid must contain occupied cells both ahead of
+ * and behind the grid center, each roughly where the body-frame endpoint
+ * lands, with free space carved from each sensor's own origin.
+ */
+BOOST_AUTO_TEST_CASE(test_multi_sensor_fusion_front_back) {
+  const std::vector<SensorConfig> sensors = {
+      SensorConfig::fromYaw({0.3f, 0.0f, 0.2f}, 0.0f),
+      SensorConfig::fromYaw({-0.3f, 0.0f, 0.2f}, static_cast<float>(M_PI))};
+  auto mapper = makeMultiMapper(sensors);
+
+  // One point 0.4 m straight ahead in each sensor's own frame, slightly
+  // below its mount (body z = 0.1, inside the band)
+  const auto cloudFront = packXYZ({{0.4f, 0.0f, -0.1f}}); // body (0.7, 0, 0.1)
+  const auto cloudBack = packXYZ({{0.4f, 0.0f, -0.1f}});  // body (-0.7, 0, 0.1)
+
+  const auto &grid =
+      mapper.scanToGrid({makeView(cloudFront), makeView(cloudBack)});
+
+  // Center row index is 9; the front obstacle lands around row 15-16, the
+  // back one around row 2-4 (truncation quantizes the two sides
+  // asymmetrically). Assert into halves with slack, and that each obstacle
+  // sits near the center column
+  BOOST_CHECK_GT(countOccupiedInRows(grid, 14, 17), 0); // ahead
+  BOOST_CHECK_GT(countOccupiedInRows(grid, 1, 4), 0);   // behind
+  // Both rays carved some free space
+  BOOST_CHECK_GT(countPointsInGrid(
+                     grid, static_cast<int>(Mapping::OccupancyType::EMPTY)),
+                 0);
+  LOG_INFO("Fused front+back grid (CPU):");
+  std::cout << grid << std::endl;
+
+  // Each cloud alone must leave the opposite half untouched
+  const auto &gridFrontOnly =
+      mapper.scanToGrid({makeView(cloudFront), PointCloudView{}});
+  BOOST_CHECK_GT(countOccupiedInRows(gridFrontOnly, 14, 17), 0);
+  BOOST_CHECK_EQUAL(countOccupiedInRows(gridFrontOnly, 0, 8), 0);
+  LOG_INFO("Front-sensor-only grid (CPU):");
+  std::cout << gridFrontOnly << std::endl;
+
+  const auto &gridBackOnly =
+      mapper.scanToGrid({PointCloudView{}, makeView(cloudBack)});
+  BOOST_CHECK_GT(countOccupiedInRows(gridBackOnly, 1, 4), 0);
+  BOOST_CHECK_EQUAL(countOccupiedInRows(gridBackOnly, 10, 19), 0);
+  LOG_INFO("Back-sensor-only grid (CPU):");
+  std::cout << gridBackOnly << std::endl;
+}
+
+/**
+ * A yaw-rotated, offset mount must place the obstacle at the body-frame
+ * location: sensor at (0.2, 0) yawed +90 deg seeing a point 0.5 m ahead in
+ * its own frame -> body (0.2, 0.5), i.e. left of the robot, not ahead.
+ */
+BOOST_AUTO_TEST_CASE(test_multi_sensor_mount_transform) {
+  const std::vector<SensorConfig> sensors = {
+      SensorConfig::fromYaw({0.2f, 0.0f, 0.0f}, static_cast<float>(M_PI_2))};
+  auto mapper = makeMultiMapper(sensors);
+
+  const auto cloud = packXYZ({{0.5f, 0.0f, 0.1f}}); // body (0.2, 0.5, 0.1)
+  const auto &grid = mapper.scanToGrid({makeView(cloud)});
+
+  // Expected cell around (11, 14); allow +-1 for truncation at cell borders
+  bool found = false;
+  for (int i = 10; i <= 12 && !found; ++i) {
+    for (int j = 13; j <= 15 && !found; ++j) {
+      found = grid(i, j) == static_cast<int>(Mapping::OccupancyType::OCCUPIED);
+    }
+  }
+  BOOST_CHECK(found);
+  // Nothing straight ahead of the robot (the naive un-transformed location)
+  BOOST_CHECK_EQUAL(countOccupiedInRows(grid, 13, 19), 0);
+  LOG_INFO("Yawed offset mount grid (CPU), obstacle expected left of center:");
+  std::cout << grid << std::endl;
+}
+
+/**
+ * Empty views mean "no data from this sensor": the other sensors still
+ * contribute, and an all-empty batch yields an all-UNEXPLORED grid.
+ */
+BOOST_AUTO_TEST_CASE(test_multi_sensor_empty_clouds) {
+  const std::vector<SensorConfig> sensors = {
+      SensorConfig::fromYaw({0.3f, 0.0f, 0.2f}, 0.0f),
+      SensorConfig::fromYaw({-0.3f, 0.0f, 0.2f}, static_cast<float>(M_PI))};
+  auto mapper = makeMultiMapper(sensors);
+
+  const auto &gridAllEmpty =
+      mapper.scanToGrid({PointCloudView{}, PointCloudView{}});
+  BOOST_CHECK_EQUAL(
+      countPointsInGrid(gridAllEmpty,
+                        static_cast<int>(Mapping::OccupancyType::UNEXPLORED)),
+      20 * 20);
+}
+
+/**
+ * The single-cloud byte entry is an N=1 adapter onto the batched
+ * path: identical output for the identical cloud.
+ */
+BOOST_AUTO_TEST_CASE(test_multi_sensor_n1_equals_legacy_entry) {
+  // A ring of points at 1 m, various heights inside the band
+  std::vector<Eigen::Vector3f> pts;
+  for (int d = 0; d < 360; d += 5) {
+    const float a = d * static_cast<float>(M_PI) / 180.0f;
+    pts.push_back({std::cos(a), std::sin(a), 0.1f + 0.001f * d});
+  }
+  const auto cloud = packXYZ(pts);
+
+  // Identity mount, pointcloud mode
+  Mapping::LocalMapper legacy(20, 20, 0.1f, {SensorConfig{}}, true, 360, 0.5f,
+                              0.0f, 5.0f, 43, 1);
+  const auto view = makeView(cloud);
+  const Eigen::MatrixXi legacyGrid =
+      legacy.scanToGrid(view.data, view.point_step, view.row_step, view.height,
+                        view.width, view.x_offset, view.y_offset,
+                        view.z_offset);
+
+  auto multi = makeMultiMapper({SensorConfig{}}); // identity, N=1
+  const auto &batchedGrid = multi.scanToGrid({view});
+
+  BOOST_CHECK((legacyGrid.array() == batchedGrid.array()).all());
+  BOOST_CHECK_GT(countPointsInGrid(batchedGrid,
+                                   static_cast<int>(
+                                       Mapping::OccupancyType::OCCUPIED)),
+                 0);
+}
+
+/**
+ * Error paths: cloud-count mismatch, negative offsets named per cloud,
+ * batched call on a laserscan-configured mapper.
+ */
+BOOST_AUTO_TEST_CASE(test_multi_sensor_error_paths) {
+  auto mapper = makeMultiMapper(
+      {SensorConfig{}, SensorConfig::fromYaw({-0.3f, 0.0f, 0.2f},
+                                             static_cast<float>(M_PI))});
+
+  const auto cloud = packXYZ({{1.0f, 0.0f, 0.1f}});
+
+  // Wrong count
+  BOOST_CHECK_THROW(mapper.scanToGrid({makeView(cloud)}),
+                    std::invalid_argument);
+
+  // Negative offset in the SECOND cloud: message must name clouds[1]
+  PointCloudView bad = makeView(cloud);
+  bad.y_offset = -4;
+  BOOST_CHECK_EXCEPTION(
+      mapper.scanToGrid({makeView(cloud), bad}), std::invalid_argument,
+      [](const std::invalid_argument &e) {
+        return std::string(e.what()).find("clouds[1]") != std::string::npos &&
+               std::string(e.what()).find("non-negative") != std::string::npos;
+      });
+
+  // Laserscan-configured mapper cannot take clouds
+  Mapping::LocalMapper scan_mapper(20, 20, 0.1f, {SensorConfig{}}, false, 0,
+                                   0.5f, 0.0f, 5.0f, 43, 1);
+  BOOST_CHECK_THROW(scan_mapper.scanToGrid({makeView(cloud)}),
+                    std::logic_error);
+}

--- a/src/kompass_cpp/tests/mapper_test_gpu.cpp
+++ b/src/kompass_cpp/tests/mapper_test_gpu.cpp
@@ -39,7 +39,6 @@ struct GridMapConfig {
   int grid_width;
   float grid_res;
   float rangeMax;
-  float angleStep;
   float minHeight;
   float maxHeight;
   float actual_size;
@@ -52,15 +51,14 @@ struct GridMapConfig {
   GridMapConfig()
       : angle_increment(0.1), corner_distance(0.5), random_points(50),
         grid_height(10), grid_width(10), grid_res(0.1), rangeMax(20.0),
-        angleStep(0.01), minHeight(0.0), maxHeight(0.0),
-        actual_size(grid_width * grid_res),
+        minHeight(0.0), maxHeight(0.0), actual_size(grid_width * grid_res),
         centralPoint(std::round(grid_height / 2) - 1,
                      std::round(grid_width / 2) - 1),
         limit(grid_width > grid_height ? grid_width * grid_res * std::sqrt(2)
                                        : grid_height * grid_res * std::sqrt(2)),
         gpu_local_mapper(Mapping::LocalMapperGPU(
-            grid_height, grid_width, grid_res, {0.0, 0.0, 0.0}, 0.0, false, 63,
-            angleStep, maxHeight, minHeight, rangeMax)) {
+            grid_height, grid_width, grid_res, {SensorConfig{}}, false, 63,
+            maxHeight, minHeight, rangeMax)) {
     LOG_INFO("Central point: ", centralPoint.x(), ", ", centralPoint.y());
     LOG_INFO("Limit Circle Radius: ", limit);
   }
@@ -81,8 +79,7 @@ struct PointCloudMapConfig {
   int grid_width;
   float grid_res;
   float rangeMax;
-  int scan_size;   // number of angular bins produced by the conversion kernel
-  float angleStep; // uniform spacing across [0, 2π)
+  int scan_size; // number of angular bins produced by the conversion kernel
   float minHeight;
   float maxHeight;
 
@@ -90,12 +87,11 @@ struct PointCloudMapConfig {
 
   PointCloudMapConfig()
       : grid_height(21), grid_width(21), grid_res(0.1f), rangeMax(5.0f),
-        scan_size(360), angleStep(static_cast<float>(2.0 * M_PI / 360.0)),
-        minHeight(-1.0f), maxHeight(1.0f),
+        scan_size(360), minHeight(-1.0f), maxHeight(1.0f),
         mapper(Mapping::LocalMapperGPU(
-            grid_height, grid_width, grid_res, {0.0f, 0.0f, 0.0f}, 0.0f,
-            /*isPointCloud*/ true, scan_size, angleStep, maxHeight, minHeight,
-            rangeMax)) {}
+            grid_height, grid_width, grid_res, {SensorConfig{}},
+            /*isPointCloud*/ true, scan_size, maxHeight, minHeight, rangeMax)) {
+  }
 };
 
 PointCloudMapConfig &get_pc_config() {
@@ -170,7 +166,8 @@ void run_circle_scan(double radius) {
 
   Eigen::VectorXf filtered_ranges(circle_scan.ranges.size());
   for (Eigen::Index i = 0; i < circle_scan.ranges.size(); ++i) {
-    filtered_ranges[i] = std::min(static_cast<float>(cfg.limit), circle_scan.ranges[i]);
+    filtered_ranges[i] =
+        std::min(static_cast<float>(cfg.limit), circle_scan.ranges[i]);
   }
 
   Eigen::MatrixXi *gridData = nullptr;
@@ -192,8 +189,8 @@ void run_circle_scan(double radius) {
   std::cout << *gridData << std::endl;
 
   // For radii larger than the grid half-diagonal (≈ 0.707 m here) every ray's
-  // endpoint lands outside the grid and gets dropped by the kernel's bounds check
-  // so n_occ can legitimately be 0.
+  // endpoint lands outside the grid and gets dropped by the kernel's bounds
+  // check so n_occ can legitimately be 0.
   const int total = static_cast<int>(gridData->size());
   BOOST_TEST(n_occ + n_empty + n_unknown == total,
              "cell counts must sum to total (" << total << "), got "
@@ -266,24 +263,20 @@ BOOST_AUTO_TEST_CASE(test_mapper_pointcloud_circle) {
              "expected some EMPTY cells along the rays from origin");
 }
 
-// A height band that lies entirely below the sensor, i.e. max_z < 0. The sign
-// of the bound carries no meaning of its own: a negative upper edge is a real
-// edge, not a request to disable the gate. The CPU
-// pointCloudToLaserScanFromRaw treats it that way, so the GPU kernel must too
-// -- otherwise the same (min_height, max_height) config yields different
-// occupancy grids on the two backends. Guards the band that a sensor mounted
-// above the volume of interest produces.
+// A height band that lies entirely below the body origin, i.e. max_z < 0.
+// The sign of the bound carries no meaning of its own: a negative upper edge
+// is a real edge, not a request to disable the gate. The CPU
+// pointCloudToLaserScanFromRaw treats it that way, so the GPU kernel must as
+// well.
 BOOST_AUTO_TEST_CASE(test_mapper_pointcloud_negative_max_z_band) {
   const int grid_height = 21, grid_width = 21;
   const float grid_res = 0.1f, rangeMax = 5.0f;
   const int scan_size = 360;
-  const float angleStep = static_cast<float>(2.0 * M_PI / 360.0);
   const float minHeight = -1.2f, maxHeight = -0.2f;
 
-  Mapping::LocalMapperGPU mapper(grid_height, grid_width, grid_res,
-                                 {0.0f, 0.0f, 0.0f}, 0.0f,
-                                 /*isPointCloud*/ true, scan_size, angleStep,
-                                 maxHeight, minHeight, rangeMax);
+  Mapping::LocalMapperGPU mapper(
+      grid_height, grid_width, grid_res, {SensorConfig{}},
+      /*isPointCloud*/ true, scan_size, maxHeight, minHeight, rangeMax);
 
   constexpr int N = 200;
   const int point_step = static_cast<int>(sizeof(PointXYZ));
@@ -328,4 +321,375 @@ BOOST_AUTO_TEST_CASE(test_mapper_pointcloud_negative_max_z_band) {
       grid_band, static_cast<int>(Mapping::OccupancyType::OCCUPIED));
   BOOST_TEST(n_occ_band > 0,
              "expected OCCUPIED cells from a ring inside the negative band");
+}
+
+// ---------------------------------------------------------------------------
+// Multi-sensor pointcloud fusion (GPU)
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Builds a ring cloud: `n` points on a circle of `radius` at height `z`
+// (sensor frame)
+std::vector<uint8_t> makeRing(float radius, float z, int n) {
+  std::vector<uint8_t> cloud;
+  for (int i = 0; i < n; ++i) {
+    const float theta = 2.0f * static_cast<float>(M_PI) * i / n;
+    addPointToCloud(cloud, radius * std::cos(theta), radius * std::sin(theta),
+                    z);
+  }
+  return cloud;
+}
+
+PointCloudView makeCloudView(const std::vector<uint8_t> &cloud) {
+  const int point_step = static_cast<int>(sizeof(PointXYZ));
+  const int n = static_cast<int>(cloud.size() / point_step);
+  return PointCloudView{cloud,
+                        point_step,
+                        n * point_step,
+                        /*height*/ 1,
+                        /*width*/ n,
+                        static_cast<int>(offsetof(PointXYZ, x)),
+                        static_cast<int>(offsetof(PointXYZ, y)),
+                        static_cast<int>(offsetof(PointXYZ, z))};
+}
+
+// Fraction of cells holding the same occupancy code in both grids.
+// CPU and GPU quantize ray endpoints differently (truncation vs ceil) and
+// bin bearings in double vs float, so exact equality is not achievable —
+// the calibrated agreement between the two backends is ~0.93
+double gridAgreement(const Eigen::MatrixXi &a, const Eigen::MatrixXi &b) {
+  int same = 0;
+  for (int i = 0; i < a.rows(); ++i) {
+    for (int j = 0; j < a.cols(); ++j) {
+      if (a(i, j) == b(i, j)) {
+        ++same;
+      }
+    }
+  }
+  return static_cast<double>(same) / static_cast<double>(a.size());
+}
+
+int countOccupiedInRows(const Eigen::MatrixXi &grid, int rowBegin,
+                        int rowEnd /*inclusive*/) {
+  int count = 0;
+  for (int i = rowBegin; i <= rowEnd; ++i) {
+    for (int j = 0; j < grid.cols(); ++j) {
+      if (grid(i, j) == static_cast<int>(Mapping::OccupancyType::OCCUPIED)) {
+        ++count;
+      }
+    }
+  }
+  return count;
+}
+
+// True when every OCCUPIED cell of `a` has an OCCUPIED cell of `b` within
+// Chebyshev distance 1. Insensitive to the backends' one-cell endpoint
+// quantization difference, but a systematic transform error (cells displaced
+// by several cells) fails it
+bool occupiedWithinOneCell(const Eigen::MatrixXi &a, const Eigen::MatrixXi &b) {
+  const int occ = static_cast<int>(Mapping::OccupancyType::OCCUPIED);
+  for (int i = 0; i < a.rows(); ++i) {
+    for (int j = 0; j < a.cols(); ++j) {
+      if (a(i, j) != occ) {
+        continue;
+      }
+      bool matched = false;
+      for (int di = -1; di <= 1 && !matched; ++di) {
+        for (int dj = -1; dj <= 1 && !matched; ++dj) {
+          const int ni = i + di, nj = j + dj;
+          if (ni >= 0 && ni < b.rows() && nj >= 0 && nj < b.cols() &&
+              b(ni, nj) == occ) {
+            matched = true;
+          }
+        }
+      }
+      if (!matched) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+constexpr int kMppl = 45; // shared by CPU and GPU mappers in parity tests
+
+} // namespace
+
+/**
+ * Front + back mounted sensors, each seeing one obstacle straight ahead in
+ * its own frame: the fused GPU grid must contain OCCUPIED cells both ahead
+ * of and behind the grid center, and each cloud alone must leave the other
+ * half untouched.
+ */
+BOOST_AUTO_TEST_CASE(test_multi_sensor_fusion_front_back_gpu) {
+  const std::vector<SensorConfig> sensors = {
+      SensorConfig::fromYaw({0.3f, 0.0f, 0.2f}, 0.0f),
+      SensorConfig::fromYaw({-0.3f, 0.0f, 0.2f}, static_cast<float>(M_PI))};
+  Mapping::LocalMapperGPU mapper(20, 20, 0.1f, sensors, /*isPointCloud*/ true,
+                                 /*scanSize*/ 360, /*maxHeight*/ 0.5f,
+                                 /*minHeight*/ 0.0f, /*rangeMax*/ 5.0f, kMppl);
+
+  // One point 0.4 m straight ahead in each sensor's own frame, slightly
+  // below its mount (body z = 0.1, inside the band)
+  std::vector<uint8_t> front;
+  addPointToCloud(front, 0.4f, 0.0f, -0.1f); // body (0.7, 0, 0.1)
+  std::vector<uint8_t> back;
+  addPointToCloud(back, 0.4f, 0.0f, -0.1f); // body (-0.7, 0, 0.1)
+
+  const auto &grid =
+      mapper.scanToGrid({makeCloudView(front), makeCloudView(back)});
+  BOOST_TEST(countOccupiedInRows(grid, 14, 17) > 0, "no OCCUPIED cell ahead");
+  BOOST_TEST(countOccupiedInRows(grid, 1, 4) > 0, "no OCCUPIED cell behind");
+  LOG_INFO("Fused front+back grid (GPU):");
+  std::cout << grid << std::endl;
+
+  const auto &gridFrontOnly =
+      mapper.scanToGrid({makeCloudView(front), PointCloudView{}});
+  BOOST_TEST(countOccupiedInRows(gridFrontOnly, 14, 17) > 0);
+  BOOST_TEST(countOccupiedInRows(gridFrontOnly, 0, 8) == 0,
+             "front-only batch put OCCUPIED cells behind the robot");
+  LOG_INFO("Front-sensor-only grid (GPU):");
+  std::cout << gridFrontOnly << std::endl;
+
+  const auto &gridBackOnly =
+      mapper.scanToGrid({PointCloudView{}, makeCloudView(back)});
+  BOOST_TEST(countOccupiedInRows(gridBackOnly, 1, 4) > 0);
+  BOOST_TEST(countOccupiedInRows(gridBackOnly, 10, 19) == 0,
+             "back-only batch put OCCUPIED cells ahead of the robot");
+  LOG_INFO("Back-sensor-only grid (GPU):");
+  std::cout << gridBackOnly << std::endl;
+
+  // All-empty batch -> untouched (all-UNEXPLORED) grid
+  const auto &gridEmpty =
+      mapper.scanToGrid({PointCloudView{}, PointCloudView{}});
+  BOOST_TEST(
+      countPointsInGrid(gridEmpty,
+                        static_cast<int>(Mapping::OccupancyType::UNEXPLORED)) ==
+      20 * 20);
+}
+
+/**
+ * Two-sensor fused grids must agree between the CPU and GPU backends.
+ */
+BOOST_AUTO_TEST_CASE(test_multi_sensor_cpu_gpu_parity) {
+  const std::vector<SensorConfig> sensors = {
+      SensorConfig::fromYaw({0.2f, 0.0f, 0.2f}, 0.0f),
+      SensorConfig::fromYaw({-0.2f, 0.0f, 0.2f}, static_cast<float>(M_PI))};
+
+  const auto front = makeRing(0.5f, -0.1f, 100);
+  const auto back = makeRing(0.4f, -0.1f, 100);
+  const std::vector<PointCloudView> clouds = {makeCloudView(front),
+                                              makeCloudView(back)};
+
+  Mapping::LocalMapper cpu(21, 21, 0.1f, sensors, true, 360, 0.5f, 0.0f, 5.0f,
+                           kMppl, /*threads*/ 1);
+  Mapping::LocalMapperGPU gpu(21, 21, 0.1f, sensors, true, 360, 0.5f, 0.0f,
+                              5.0f, kMppl);
+
+  const Eigen::MatrixXi cpuGrid = cpu.scanToGrid(clouds);
+  const Eigen::MatrixXi &gpuGrid = gpu.scanToGrid(clouds);
+
+  // Two fused passes roughly square the single-sensor ~0.93 cell agreement
+  // (truncation-vs-ceil endpoint band), hence the 0.85 floor.
+  LOG_INFO("Two-sensor fused grid (CPU):");
+  std::cout << cpuGrid << std::endl;
+  LOG_INFO("Two-sensor fused grid (GPU):");
+  std::cout << gpuGrid << std::endl;
+
+  const double agreement = gridAgreement(cpuGrid, gpuGrid);
+  LOG_INFO("CPU/GPU fused-grid agreement: ", agreement);
+  BOOST_TEST(agreement >= 0.85,
+             "CPU/GPU fused grids diverged: agreement " << agreement);
+  BOOST_TEST(occupiedWithinOneCell(gpuGrid, cpuGrid),
+             "a GPU OCCUPIED cell has no CPU counterpart within one cell");
+  BOOST_TEST(occupiedWithinOneCell(cpuGrid, gpuGrid),
+             "a CPU OCCUPIED cell has no GPU counterpart within one cell");
+  BOOST_TEST(countPointsInGrid(
+                 gpuGrid, static_cast<int>(Mapping::OccupancyType::OCCUPIED)) >
+             0);
+}
+
+/**
+ * Non-square grid parity (20 rows x 40 cols).
+ */
+BOOST_AUTO_TEST_CASE(test_multi_sensor_cpu_gpu_parity_nonsquare) {
+  const std::vector<SensorConfig> sensors = {SensorConfig{}}; // identity
+
+  const auto ring = makeRing(0.6f, 0.1f, 150);
+  const std::vector<PointCloudView> clouds = {makeCloudView(ring)};
+
+  Mapping::LocalMapper cpu(20, 40, 0.1f, sensors, true, 360, 0.5f, 0.0f, 5.0f,
+                           kMppl, /*threads*/ 1);
+  Mapping::LocalMapperGPU gpu(20, 40, 0.1f, sensors, true, 360, 0.5f, 0.0f,
+                              5.0f, kMppl);
+
+  const Eigen::MatrixXi cpuGrid = cpu.scanToGrid(clouds);
+  const Eigen::MatrixXi &gpuGrid = gpu.scanToGrid(clouds);
+
+  LOG_INFO("Non-square grid (CPU):");
+  std::cout << cpuGrid << std::endl;
+  LOG_INFO("Non-square grid (GPU):");
+  std::cout << gpuGrid << std::endl;
+
+  const double agreement = gridAgreement(cpuGrid, gpuGrid);
+  LOG_INFO("CPU/GPU non-square agreement: ", agreement);
+  BOOST_TEST(agreement >= 0.90,
+             "CPU/GPU non-square grids diverged: agreement " << agreement);
+  BOOST_TEST(countPointsInGrid(
+                 gpuGrid, static_cast<int>(Mapping::OccupancyType::EMPTY)) > 0);
+}
+
+/**
+ * Tilted mount (15 deg pitch): the GPU kernel must apply the full rotation,
+ * not just yaw. Parity against the CPU path, which is pinned to the Eigen
+ * reference.
+ */
+BOOST_AUTO_TEST_CASE(test_multi_sensor_tilted_mount_gpu) {
+  const float half_pitch = 7.5f * static_cast<float>(M_PI) / 180.0f;
+  SensorConfig tilted;
+  tilted.position = {0.0f, 0.0f, 0.3f};
+  tilted.rotation = {0.0f, std::sin(half_pitch), 0.0f, std::cos(half_pitch)};
+  const std::vector<SensorConfig> sensors = {tilted};
+
+  const auto ring = makeRing(1.0f, 0.0f, 200);
+  const std::vector<PointCloudView> clouds = {makeCloudView(ring)};
+
+  Mapping::LocalMapper cpu(21, 21, 0.1f, sensors, true, 360, 1.0f, -1.0f, 5.0f,
+                           kMppl, /*threads*/ 1);
+  Mapping::LocalMapperGPU gpu(21, 21, 0.1f, sensors, true, 360, 1.0f, -1.0f,
+                              5.0f, kMppl);
+
+  const Eigen::MatrixXi cpuGrid = cpu.scanToGrid(clouds);
+  const Eigen::MatrixXi &gpuGrid = gpu.scanToGrid(clouds);
+
+  // A near-grid-edge ring maximises the endpoint quantization band, hence
+  // the low smoke floor; the sharp check is the one-cell OCCUPIED
+  // correspondence (a wrong tilt application would displace the ring by
+  // several cells)
+  LOG_INFO("Tilted-mount grid (CPU):");
+  std::cout << cpuGrid << std::endl;
+  LOG_INFO("Tilted-mount grid (GPU):");
+  std::cout << gpuGrid << std::endl;
+
+  const double agreement = gridAgreement(cpuGrid, gpuGrid);
+  LOG_INFO("CPU/GPU tilted-mount agreement: ", agreement);
+  BOOST_TEST(agreement >= 0.80,
+             "CPU/GPU tilted-mount grids diverged: agreement " << agreement);
+  BOOST_TEST(occupiedWithinOneCell(gpuGrid, cpuGrid),
+             "a GPU OCCUPIED cell has no CPU counterpart within one cell");
+  BOOST_TEST(occupiedWithinOneCell(cpuGrid, gpuGrid),
+             "a CPU OCCUPIED cell has no GPU counterpart within one cell");
+  BOOST_TEST(countPointsInGrid(
+                 gpuGrid, static_cast<int>(Mapping::OccupancyType::OCCUPIED)) >
+             0);
+}
+
+/**
+ * Offset-mount EMPTY carving: a sensor mounted ahead of the body center,
+ * with a ring that fills EVERY bin at 0.5 m (so no max-range rays can mask
+ * the gate). The corridor between the sensor cell and the ring must be
+ * carved EMPTY.
+ */
+BOOST_AUTO_TEST_CASE(test_multi_sensor_offset_mount_empty_carving) {
+  const std::vector<SensorConfig> sensors = {
+      SensorConfig::fromYaw({0.3f, 0.0f, 0.0f}, 0.0f)};
+  Mapping::LocalMapper cpu(20, 20, 0.1f, sensors, true, 360, 0.5f, 0.0f, 5.0f,
+                           kMppl, /*threads*/ 1);
+  Mapping::LocalMapperGPU gpu(20, 20, 0.1f, sensors, true, 360, 0.5f, 0.0f,
+                              5.0f, kMppl);
+
+  // 720 points -> every one of the 360 bins holds a genuine 0.5 m return
+  const auto ring = makeRing(0.5f, 0.1f, 720);
+  const std::vector<PointCloudView> clouds = {makeCloudView(ring)};
+
+  const Eigen::MatrixXi cpuGrid = cpu.scanToGrid(clouds);
+  const Eigen::MatrixXi &gpuGrid = gpu.scanToGrid(clouds);
+
+  LOG_INFO("Offset-mount ring grid (CPU):");
+  std::cout << cpuGrid << std::endl;
+  LOG_INFO("Offset-mount ring grid (GPU):");
+  std::cout << gpuGrid << std::endl;
+
+  // Sensor cell is row 12 (0.3 m ahead of the center row 9); the ring ahead
+  // of it sits around rows 16-17. The corridor rows 13..15 near the center
+  // column must be EMPTY — with a mirrored distance table its values there
+  // (0.7..1.0) all exceed the 0.5 m ranges and no EMPTY survives
+  int emptyAheadCorridor = 0;
+  for (int i = 13; i <= 15; ++i) {
+    for (int j = 8; j <= 10; ++j) {
+      if (gpuGrid(i, j) == static_cast<int>(Mapping::OccupancyType::EMPTY)) {
+        ++emptyAheadCorridor;
+      }
+    }
+  }
+  BOOST_TEST(emptyAheadCorridor > 0,
+             "no EMPTY cells carved between the offset sensor and its ring "
+             "(distance-table origin is mirrored?)");
+
+  const double agreement = gridAgreement(cpuGrid, gpuGrid);
+  LOG_INFO("CPU/GPU offset-mount agreement: ", agreement);
+  BOOST_TEST(agreement >= 0.85,
+             "CPU/GPU offset-mount grids diverged: agreement " << agreement);
+  BOOST_TEST(occupiedWithinOneCell(gpuGrid, cpuGrid));
+  BOOST_TEST(occupiedWithinOneCell(cpuGrid, gpuGrid));
+}
+
+/**
+ * The single-cloud byte entry is an N=1 adapter onto the batched
+ * path: identical output for the identical cloud.
+ */
+BOOST_AUTO_TEST_CASE(test_multi_sensor_n1_adapter_gpu) {
+  auto &cfg = get_pc_config();
+  const auto ring = makeRing(0.5f, 0.1f, 200);
+  const auto view = makeCloudView(ring);
+
+  const Eigen::MatrixXi legacyGrid = cfg.mapper.scanToGrid(
+      view.data, view.point_step, view.row_step, view.height, view.width,
+      view.x_offset, view.y_offset, view.z_offset);
+  const Eigen::MatrixXi &batchedGrid = cfg.mapper.scanToGrid({view});
+
+  BOOST_TEST((legacyGrid.array() == batchedGrid.array()).all(),
+             "legacy N=1 entry and batched entry disagree");
+}
+
+/**
+ * Error paths: cloud-count mismatch, negative offsets named per cloud,
+ * batched call on a laserscan-configured mapper, and the laserscan overload
+ * on a pointcloud-configured mapper (angle-buffer corruption guard).
+ */
+BOOST_AUTO_TEST_CASE(test_multi_sensor_error_paths_gpu) {
+  const std::vector<SensorConfig> sensors = {
+      SensorConfig{},
+      SensorConfig::fromYaw({-0.3f, 0.0f, 0.2f}, static_cast<float>(M_PI))};
+  Mapping::LocalMapperGPU mapper(20, 20, 0.1f, sensors, true, 360, 0.5f, 0.0f,
+                                 5.0f, kMppl);
+
+  const auto ring = makeRing(0.5f, 0.1f, 50);
+
+  // Wrong count
+  BOOST_CHECK_THROW(mapper.scanToGrid({makeCloudView(ring)}),
+                    std::invalid_argument);
+
+  // Negative offset in the SECOND cloud: message must name clouds[1]
+  PointCloudView bad = makeCloudView(ring);
+  bad.y_offset = -4;
+  BOOST_CHECK_EXCEPTION(
+      mapper.scanToGrid({makeCloudView(ring), bad}), std::invalid_argument,
+      [](const std::invalid_argument &e) {
+        return std::string(e.what()).find("clouds[1]") != std::string::npos &&
+               std::string(e.what()).find("non-negative") != std::string::npos;
+      });
+
+  // The laserscan overload on a pointcloud-mode mapper must throw instead of
+  // silently overwriting the pre-uploaded conversion bin angles
+  Eigen::VectorXf angles(4), ranges(4);
+  angles.setZero();
+  ranges.setConstant(1.0f);
+  BOOST_CHECK_THROW(mapper.scanToGrid(angles, ranges), std::logic_error);
+
+  // Batched call on the laserscan-configured singleton must throw
+  auto &scan_cfg = get_config();
+  BOOST_CHECK_THROW(scan_cfg.gpu_local_mapper.scanToGrid({makeCloudView(ring)}),
+                    std::logic_error);
 }

--- a/src/kompass_cpp/tests/pointcloud_test.cpp
+++ b/src/kompass_cpp/tests/pointcloud_test.cpp
@@ -137,8 +137,8 @@ void run_test(const std::vector<uint8_t> &data, int width,
   pointCloudToLaserScanFromRaw(
       PointCloudView{data, point_step, row_step, height, width, x_offset,
                      y_offset, z_offset},
-      Eigen::Isometry3f::Identity(), max_range, min_z, max_z, angle_step,
-      ranges, angles);
+      PointFieldType::FLOAT32, Eigen::Isometry3f::Identity(), max_range, min_z,
+      max_z, angle_step, ranges, angles);
 
   saveScanToJson(std::vector<double>(ranges.begin(), ranges.end()),
                  std::vector<double>(angles.begin(), angles.end()),
@@ -231,8 +231,8 @@ BOOST_AUTO_TEST_CASE(test_pointcloud_conversion_body_frame_reference) {
 
   Eigen::VectorXf ranges;
   pointCloudToLaserScanFromRaw(
-      PointCloudView{data, 12, 12 * num_points, 1, num_points, 0, 4, 8}, tf,
-      max_range, min_z, max_z, num_bins, ranges);
+      PointCloudView{data, 12, 12 * num_points, 1, num_points, 0, 4, 8},
+      PointFieldType::FLOAT32, tf, max_range, min_z, max_z, num_bins, ranges);
 
   // Reference implementation (same scalar math, written independently of the
   // buffer walk)
@@ -309,12 +309,14 @@ BOOST_AUTO_TEST_CASE(test_pointcloud_conversion_yaw_equivalence) {
   tf.translate(Eigen::Vector3f(0.0f, 0.0f, sensor_z));
   tf.rotate(eulerToRotationMatrix(0.0f, 0.0f, yaw));
   Eigen::VectorXf ranges_mounted;
-  pointCloudToLaserScanFromRaw(view, tf, max_range, body_min_z, body_max_z,
-                               num_bins, ranges_mounted);
+  pointCloudToLaserScanFromRaw(view, PointFieldType::FLOAT32, tf, max_range,
+                               body_min_z, body_max_z, num_bins,
+                               ranges_mounted);
 
   // Identity conversion: sensor-frame band shifted down by the mount height
   Eigen::VectorXf ranges_identity;
-  pointCloudToLaserScanFromRaw(view, Eigen::Isometry3f::Identity(), max_range,
+  pointCloudToLaserScanFromRaw(view, PointFieldType::FLOAT32,
+                               Eigen::Isometry3f::Identity(), max_range,
                                body_min_z - sensor_z, body_max_z - sensor_z,
                                num_bins, ranges_identity);
 
@@ -322,4 +324,48 @@ BOOST_AUTO_TEST_CASE(test_pointcloud_conversion_yaw_equivalence) {
     const int rotated = (b + yaw_bins) % num_bins;
     BOOST_CHECK_SMALL(ranges_mounted[rotated] - ranges_identity[b], 1e-4f);
   }
+}
+
+/**
+ * FLOAT64 clouds decode through the same primitive: the same points packed
+ * as doubles (point_step 24, offsets 0/8/16) must produce the exact ranges
+ * of their FLOAT32 packing when the field type says so.
+ */
+BOOST_AUTO_TEST_CASE(test_pointcloud_float64_fields) {
+  const std::vector<Eigen::Vector3f> points = {
+      {1.0f, 0.0f, 0.5f}, {0.0f, 2.0f, 0.5f}, {-1.5f, -1.5f, 0.5f}};
+  const int n = static_cast<int>(points.size());
+
+  std::vector<uint8_t> data32;
+  std::vector<uint8_t> data64;
+  for (const auto &p : points) {
+    for (int k = 0; k < 3; ++k) {
+      const float f = p[k];
+      const double d = static_cast<double>(p[k]);
+      const auto *fb = reinterpret_cast<const uint8_t *>(&f);
+      const auto *db = reinterpret_cast<const uint8_t *>(&d);
+      data32.insert(data32.end(), fb, fb + sizeof(float));
+      data64.insert(data64.end(), db, db + sizeof(double));
+    }
+  }
+
+  const double max_range = 10.0, min_z = 0.0, max_z = 1.0;
+  const int num_bins = 360;
+
+  Eigen::VectorXf ranges32, ranges64;
+  pointCloudToLaserScanFromRaw(
+      PointCloudView{data32, 12, 12 * n, 1, n, 0, 4, 8},
+      PointFieldType::FLOAT32, Eigen::Isometry3f::Identity(), max_range, min_z,
+      max_z, num_bins, ranges32);
+  pointCloudToLaserScanFromRaw(
+      PointCloudView{data64, 24, 24 * n, 1, n, 0, 8, 16},
+      PointFieldType::FLOAT64, Eigen::Isometry3f::Identity(), max_range, min_z,
+      max_z, num_bins, ranges64);
+
+  BOOST_CHECK_EQUAL(ranges32.size(), ranges64.size());
+  for (int b = 0; b < num_bins; ++b) {
+    BOOST_CHECK_EQUAL(ranges32[b], ranges64[b]);
+  }
+  // Sanity: the clouds actually landed in some bins
+  BOOST_TEST((ranges32.array() < static_cast<float>(max_range)).any());
 }

--- a/src/kompass_cpp/tests/pointcloud_test.cpp
+++ b/src/kompass_cpp/tests/pointcloud_test.cpp
@@ -134,9 +134,11 @@ void run_test(const std::vector<uint8_t> &data, int width,
   ofs.write(reinterpret_cast<const char *>(data.data()), data.size());
   ofs.close();
 
-  pointCloudToLaserScanFromRaw(data, point_step, row_step, height, width,
-                               x_offset, y_offset, z_offset, max_range, min_z,
-                               max_z, angle_step, ranges, angles);
+  pointCloudToLaserScanFromRaw(
+      PointCloudView{data, point_step, row_step, height, width, x_offset,
+                     y_offset, z_offset},
+      Eigen::Isometry3f::Identity(), max_range, min_z, max_z, angle_step,
+      ranges, angles);
 
   saveScanToJson(std::vector<double>(ranges.begin(), ranges.end()),
                  std::vector<double>(angles.begin(), angles.end()),
@@ -179,4 +181,145 @@ BOOST_AUTO_TEST_CASE(test_pointcloud_conversion_cube) {
   std::vector<uint8_t> data = generateCubePointCloud(size, num_points);
 
   run_test(data, num_points, "cube");
+}
+
+/**
+ * @brief Packs xyz points into a raw FLOAT32 buffer (point_step 12)
+ */
+static std::vector<uint8_t> packPoints(const std::vector<Eigen::Vector3f> &pts) {
+  std::vector<uint8_t> data;
+  data.reserve(pts.size() * 3 * sizeof(float));
+  for (const auto &p : pts) {
+    for (int k = 0; k < 3; ++k) {
+      float v = p[k];
+      data.insert(data.end(), reinterpret_cast<const uint8_t *>(&v),
+                  reinterpret_cast<const uint8_t *>(&v) + sizeof(float));
+    }
+  }
+  return data;
+}
+
+/**
+ * The raw-buffer conversion under a full (tilted + translated) mount isometry
+ * must agree with a straightforward per-point reference: rotate, gate on
+ * body-frame z, bin by planar bearing, keep the min planar range per bin.
+ */
+BOOST_AUTO_TEST_CASE(test_pointcloud_conversion_body_frame_reference) {
+  Timer time;
+
+  std::mt19937 gen(42); // fixed seed: deterministic
+  std::uniform_real_distribution<float> coord(-3.0f, 3.0f);
+
+  const int num_points = 2000;
+  std::vector<Eigen::Vector3f> pts;
+  pts.reserve(num_points);
+  for (int i = 0; i < num_points; ++i) {
+    pts.push_back({coord(gen), coord(gen), coord(gen)});
+  }
+  const std::vector<uint8_t> data = packPoints(pts);
+
+  // Mount with translation and roll/pitch/yaw all non-zero
+  Eigen::Isometry3f tf = Eigen::Isometry3f::Identity();
+  tf.translate(Eigen::Vector3f(0.4f, -0.2f, 0.35f));
+  tf.rotate(eulerToRotationMatrix(-10.0f * M_PI / 180.0f,
+                                  20.0f * M_PI / 180.0f,
+                                  130.0f * M_PI / 180.0f));
+
+  const double max_range = 20.0;
+  const double min_z = 0.0, max_z = 1.5; // body frame
+  const int num_bins = 360;
+
+  Eigen::VectorXf ranges;
+  pointCloudToLaserScanFromRaw(
+      PointCloudView{data, 12, 12 * num_points, 1, num_points, 0, 4, 8}, tf,
+      max_range, min_z, max_z, num_bins, ranges);
+
+  // Reference implementation (same scalar math, written independently of the
+  // buffer walk)
+  Eigen::VectorXf ref(num_bins);
+  ref.setConstant(static_cast<float>(max_range));
+  const Eigen::Matrix3f rot = tf.rotation();
+  const float t_z = tf.translation().z();
+  const double two_pi = 2.0 * M_PI;
+  for (const auto &p : pts) {
+    if (p.x() * p.x() + p.y() * p.y() + p.z() * p.z() < 1e-6f)
+      continue;
+    const float xr = rot(0, 0) * p.x() + rot(0, 1) * p.y() + rot(0, 2) * p.z();
+    const float yr = rot(1, 0) * p.x() + rot(1, 1) * p.y() + rot(1, 2) * p.z();
+    const float zb =
+        rot(2, 0) * p.x() + rot(2, 1) * p.y() + rot(2, 2) * p.z() + t_z;
+    if (zb < min_z || zb > max_z)
+      continue;
+    const float range_sq = xr * xr + yr * yr;
+    if (range_sq < 1e-6f)
+      continue;
+    double angle = std::atan2(yr, xr);
+    if (angle < 0.0)
+      angle += two_pi;
+    const int bin = std::clamp(static_cast<int>((angle / two_pi) * num_bins),
+                               0, num_bins - 1);
+    ref[bin] = std::min(ref[bin], std::sqrt(range_sq));
+  }
+
+  BOOST_REQUIRE_EQUAL(ranges.size(), num_bins);
+  int populated = 0;
+  for (int b = 0; b < num_bins; ++b) {
+    BOOST_CHECK_SMALL(ranges[b] - ref[b], 1e-5f);
+    if (ref[b] < max_range)
+      ++populated;
+  }
+  // Sanity: the band actually kept a meaningful subset of the cloud
+  BOOST_CHECK_GT(populated, 50);
+}
+
+/**
+ * A yaw + height mount must be equivalent to the identity conversion with the
+ * z band shifted by the mount height and the bins rotated by the yaw
+ * (the documented migration formula). Points sit at bin centers so float
+ * rounding cannot flip bins.
+ */
+BOOST_AUTO_TEST_CASE(test_pointcloud_conversion_yaw_equivalence) {
+  Timer time;
+
+  const int num_bins = 360;
+  const int yaw_bins = 90; // 90 deg = exactly 90 bins
+  const float yaw = M_PI / 2.0f;
+  const float sensor_z = 0.3f;
+  const double two_pi = 2.0 * M_PI;
+
+  std::mt19937 gen(7);
+  std::uniform_real_distribution<float> range_dist(0.5f, 8.0f);
+  std::uniform_real_distribution<float> z_dist(-0.5f, 1.0f);
+
+  std::vector<Eigen::Vector3f> pts;
+  for (int b = 0; b < num_bins; b += 3) { // every third bin, at its center
+    const float theta = (b + 0.5f) * static_cast<float>(two_pi) / num_bins;
+    const float r = range_dist(gen);
+    pts.push_back({r * std::cos(theta), r * std::sin(theta), z_dist(gen)});
+  }
+  const std::vector<uint8_t> data = packPoints(pts);
+  const int n = static_cast<int>(pts.size());
+  const PointCloudView view{data, 12, 12 * n, 1, n, 0, 4, 8};
+
+  const double max_range = 20.0;
+  const double body_min_z = 0.0, body_max_z = 1.0;
+
+  // Mounted conversion: body-frame band
+  Eigen::Isometry3f tf = Eigen::Isometry3f::Identity();
+  tf.translate(Eigen::Vector3f(0.0f, 0.0f, sensor_z));
+  tf.rotate(eulerToRotationMatrix(0.0f, 0.0f, yaw));
+  Eigen::VectorXf ranges_mounted;
+  pointCloudToLaserScanFromRaw(view, tf, max_range, body_min_z, body_max_z,
+                               num_bins, ranges_mounted);
+
+  // Identity conversion: sensor-frame band shifted down by the mount height
+  Eigen::VectorXf ranges_identity;
+  pointCloudToLaserScanFromRaw(view, Eigen::Isometry3f::Identity(), max_range,
+                               body_min_z - sensor_z, body_max_z - sensor_z,
+                               num_bins, ranges_identity);
+
+  for (int b = 0; b < num_bins; ++b) {
+    const int rotated = (b + yaw_bins) % num_bins;
+    BOOST_CHECK_SMALL(ranges_mounted[rotated] - ranges_identity[b], 1e-4f);
+  }
 }

--- a/tests/test_laserscan_emergency_stop.py
+++ b/tests/test_laserscan_emergency_stop.py
@@ -29,10 +29,6 @@ def laser_scan_data() -> Dict[str, np.ndarray]:
     return laser_scan_data_fixed()
 
 
-# Angular bin resolution for the pointcloud-configured checker (rad); the
-# conversion kernel bins cloud points into a virtual scan at this step
-_POINTCLOUD_ANGLE_STEP = 0.01
-
 
 def _make_checker(
     use_gpu: bool,
@@ -45,7 +41,7 @@ def _make_checker(
     Constructed the same way Kompass' drive manager does it in production —
     the raw class is the only supported entry point. A laser scan checker
     takes the real scan angles; a pointcloud checker (``scan_angles=None``)
-    bins the cloud into a virtual scan instead.
+    gates every point directly in the body frame instead.
 
     :param use_gpu: Use the GPU implementation; the test is skipped when the
         build does not include it
@@ -57,7 +53,7 @@ def _make_checker(
     :param sensor_rotation: Sensor rotation in the body frame (quaternion)
     :type sensor_rotation: Optional[np.ndarray]
     """
-    from kompass_cpp.types import SensorInputType
+    from kompass_cpp.types import SensorConfig, SensorInputType
 
     if use_gpu:
         try:
@@ -74,21 +70,28 @@ def _make_checker(
         geometry_params=np.array([robot_radius, 0.4]),
     )
 
+    sensor = SensorConfig(
+        position=sensor_position
+        if sensor_position is not None
+        else np.array([0.0, 0.0, 0.0], dtype=np.float32),
+        rotation=sensor_rotation
+        if sensor_rotation is not None
+        else np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32),
+    )
+
     if scan_angles is not None:
         input_type = SensorInputType.LASERSCAN
+        angles_kwargs = {"scan_angles": scan_angles}
     else:
+        # Pointcloud checkers take no scan angles: points are gated per
+        # point in the body frame
         input_type = SensorInputType.POINTCLOUD
-        scan_angles = np.arange(0.0, 2 * np.pi, _POINTCLOUD_ANGLE_STEP)
+        angles_kwargs = {}
 
     return Checker(
         robot_shape=robot.geometry_type,
         robot_dimensions=robot.geometry_params,
-        sensor_position_body=sensor_position
-        if sensor_position is not None
-        else np.array([0.0, 0.0, 0.0], dtype=np.float32),
-        sensor_rotation_body=sensor_rotation
-        if sensor_rotation is not None
-        else np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32),
+        sensor_configs=[sensor],
         critical_angle=90.0,
         critical_distance=0.5,
         slowdown_distance=1.0,
@@ -96,7 +99,7 @@ def _make_checker(
         max_height=robot.height,
         range_max=20.0,
         input_type=input_type,
-        scan_angles=scan_angles,
+        **angles_kwargs,
     )
 
 

--- a/tests/test_local_mapper_bindings.py
+++ b/tests/test_local_mapper_bindings.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from kompass_cpp.mapping import OCCUPANCY_TYPE
+from kompass_cpp.types import SensorConfig
 
 
 # LocalMapperGPU is only exported when the build has SYCL. Import guarded
@@ -61,11 +62,9 @@ def test_gpu_binding_signature_laserscan_ctor():
         grid_height=40,
         grid_width=40,
         resolution=0.05,
-        laserscan_position=np.array([0.0, 0.0, 0.0], dtype=np.float32),
-        laserscan_orientation=0.0,
+        sensor_configs=[SensorConfig()],
         is_pointcloud=False,
         scan_size=360,
-        angle_step=0.01,
         max_height=2.0,
         min_height=0.0,
         range_max=10.0,
@@ -85,11 +84,9 @@ def test_gpu_binding_laserscan_scan_to_grid_basic():
         grid_height=grid_height,
         grid_width=grid_width,
         resolution=0.05,
-        laserscan_position=np.array([0.0, 0.0, 0.0], dtype=np.float32),
-        laserscan_orientation=0.0,
+        sensor_configs=[SensorConfig()],
         is_pointcloud=False,
         scan_size=n,
-        angle_step=float(2.0 * np.pi / n),
         max_height=2.0,
         min_height=0.0,
         range_max=10.0,
@@ -131,11 +128,9 @@ def test_gpu_binding_pointcloud_scan_to_grid_basic():
         grid_height=grid_height,
         grid_width=grid_width,
         resolution=0.05,
-        laserscan_position=np.array([0.0, 0.0, 0.0], dtype=np.float32),
-        laserscan_orientation=0.0,
+        sensor_configs=[SensorConfig()],
         is_pointcloud=True,
         scan_size=n_rays,
-        angle_step=float(2.0 * np.pi / n_rays),
         max_height=1.5,
         min_height=-0.5,
         range_max=5.0,
@@ -176,11 +171,9 @@ def test_gpu_binding_pointcloud_z_filter_above_ceiling():
         grid_height=grid_height,
         grid_width=grid_width,
         resolution=0.05,
-        laserscan_position=np.array([0.0, 0.0, 0.0], dtype=np.float32),
-        laserscan_orientation=0.0,
+        sensor_configs=[SensorConfig()],
         is_pointcloud=True,
         scan_size=n_rays,
-        angle_step=float(2.0 * np.pi / n_rays),
         max_height=1.0,
         min_height=0.0,
         range_max=5.0,
@@ -217,11 +210,9 @@ def test_gpu_binding_pointcloud_empty_cloud_does_not_crash():
         grid_height=grid_height,
         grid_width=grid_width,
         resolution=0.1,
-        laserscan_position=np.array([0.0, 0.0, 0.0], dtype=np.float32),
-        laserscan_orientation=0.0,
+        sensor_configs=[SensorConfig()],
         is_pointcloud=True,
         scan_size=n_rays,
-        angle_step=float(2.0 * np.pi / n_rays),
         max_height=1.0,
         min_height=0.0,
         range_max=5.0,
@@ -273,11 +264,9 @@ def test_cpu_binding_laserscan_scan_to_grid_basic():
         grid_height=grid_height,
         grid_width=grid_width,
         resolution=0.05,
-        laserscan_position=np.array([0.0, 0.0, 0.0], dtype=np.float32),
-        laserscan_orientation=0.0,
+        sensor_configs=[SensorConfig()],
         is_pointcloud=False,
         scan_size=n,
-        angle_step=float(2.0 * np.pi / n),
         max_height=2.0,
         min_height=0.0,
         range_max=10.0,
@@ -308,11 +297,9 @@ def test_cpu_binding_pointcloud_scan_to_grid_basic():
         grid_height=grid_height,
         grid_width=grid_width,
         resolution=0.05,
-        laserscan_position=np.array([0.0, 0.0, 0.0], dtype=np.float32),
-        laserscan_orientation=0.0,
+        sensor_configs=[SensorConfig()],
         is_pointcloud=True,
         scan_size=n_rays,
-        angle_step=float(2.0 * np.pi / n_rays),
         max_height=1.5,
         min_height=-0.5,
         range_max=5.0,
@@ -341,8 +328,8 @@ def test_cpu_binding_pointcloud_scan_to_grid_basic():
     assert n_occ > 0, "ring obstacles must mark occupied cells"
 
 
-def test_cpu_binding_laserscan_scan_to_grid_baysian_returns_tuple():
-    """Regression test: the laserscan `scan_to_grid_baysian` binding used to
+def test_cpu_binding_laserscan_scan_to_grid_bayesian_returns_tuple():
+    """Regression test: the laserscan `scan_to_grid_bayesian` binding used to
     point at plain `scanToGrid` (same argument list, wrong overload_cast
     target), so it returned a single matrix instead of the
     (occupancy, probability) tuple the Python wrapper unpacks."""
@@ -353,8 +340,7 @@ def test_cpu_binding_laserscan_scan_to_grid_baysian_returns_tuple():
         grid_height=grid_height,
         grid_width=grid_width,
         resolution=0.05,
-        laserscan_position=np.array([0.0, 0.0, 0.0], dtype=np.float32),
-        laserscan_orientation=0.0,
+        sensor_configs=[SensorConfig()],
         is_pointcloud=False,
         scan_size=n,
         p_prior=0.6,
@@ -363,7 +349,6 @@ def test_cpu_binding_laserscan_scan_to_grid_baysian_returns_tuple():
         range_sure=0.1,
         range_max=10.0,
         wall_size=0.1,
-        angle_step=float(2.0 * np.pi / n),
         max_height=2.0,
         min_height=0.0,
         max_points_per_line=32,
@@ -372,7 +357,7 @@ def test_cpu_binding_laserscan_scan_to_grid_baysian_returns_tuple():
     angles = np.linspace(0.0, 2.0 * np.pi, n, endpoint=False)
     ranges = np.full(n, 0.5, dtype=np.float64)
 
-    result = mapper.scan_to_grid_baysian(angles=angles, ranges=ranges)
+    result = mapper.scan_to_grid_bayesian(angles=angles, ranges=ranges)
 
     assert isinstance(result, tuple) and len(result) == 2
     occupancy, probability = result
@@ -396,11 +381,9 @@ def test_cpu_binding_laserscan_dtypes_and_noncontiguous_agree():
         grid_height=40,
         grid_width=40,
         resolution=0.05,
-        laserscan_position=np.array([0.0, 0.0, 0.0], dtype=np.float32),
-        laserscan_orientation=0.0,
+        sensor_configs=[SensorConfig()],
         is_pointcloud=False,
         scan_size=n,
-        angle_step=float(2.0 * np.pi / n),
         max_height=2.0,
         min_height=0.0,
         range_max=10.0,
@@ -433,11 +416,9 @@ def test_cpu_binding_pointcloud_accepts_bytes():
         grid_height=grid_height,
         grid_width=grid_width,
         resolution=0.05,
-        laserscan_position=np.array([0.0, 0.0, 0.0], dtype=np.float32),
-        laserscan_orientation=0.0,
+        sensor_configs=[SensorConfig()],
         is_pointcloud=True,
         scan_size=n_rays,
-        angle_step=float(2.0 * np.pi / n_rays),
         max_height=1.5,
         min_height=-0.5,
         range_max=5.0,
@@ -480,11 +461,9 @@ def test_cpu_binding_pointcloud_nan_points_are_ignored():
             grid_height=40,
             grid_width=40,
             resolution=0.05,
-            laserscan_position=np.array([0.0, 0.0, 0.0], dtype=np.float32),
-            laserscan_orientation=0.0,
+            sensor_configs=[SensorConfig()],
             is_pointcloud=True,
             scan_size=360,
-            angle_step=float(2.0 * np.pi / 360),
             max_height=1.5,
             min_height=-0.5,
             range_max=5.0,
@@ -520,11 +499,9 @@ def test_gpu_binding_pointcloud_nan_points_are_ignored():
             grid_height=40,
             grid_width=40,
             resolution=0.05,
-            laserscan_position=np.array([0.0, 0.0, 0.0], dtype=np.float32),
-            laserscan_orientation=0.0,
+            sensor_configs=[SensorConfig()],
             is_pointcloud=True,
             scan_size=360,
-            angle_step=float(2.0 * np.pi / 360),
             max_height=1.5,
             min_height=-0.5,
             range_max=5.0,
@@ -561,11 +538,9 @@ def test_gpu_binding_pointcloud_rejects_negative_offsets():
         grid_height=40,
         grid_width=40,
         resolution=0.05,
-        laserscan_position=np.array([0.0, 0.0, 0.0], dtype=np.float32),
-        laserscan_orientation=0.0,
+        sensor_configs=[SensorConfig()],
         is_pointcloud=True,
         scan_size=n_rays,
-        angle_step=float(2.0 * np.pi / n_rays),
         max_height=1.5,
         min_height=-0.5,
         range_max=5.0,

--- a/tests/test_local_mapper_multisensor.py
+++ b/tests/test_local_mapper_multisensor.py
@@ -281,3 +281,44 @@ def test_wrapper_multisensor_guards():
     # Cloud count must match the configured sensor count
     with pytest.raises(ValueError, match="Expected 2 clouds"):
         mapper.update_from_pointclouds(PoseData(), clouds=[cloud])
+
+
+def test_cpu_mapper_honors_float64_field_type():
+    """A FLOAT64 cloud through the CPU mapper must produce the exact grid of
+    its FLOAT32 twin when SensorConfig.cloud_field_type says FLOAT64."""
+    from kompass_cpp.types import PointFieldType
+
+    points = [(0.4, 0.0, -0.1), (0.0, 0.5, -0.1), (-0.3, -0.3, -0.1)]
+
+    mapper32 = _make_mapper(
+        [SensorConfig(position=np.array([0.3, 0.0, 0.2], dtype=np.float32))],
+        use_gpu=False,
+    )
+    grid32 = np.asarray(mapper32.scan_to_grid(clouds=[_cloud_dict(points)])).copy()
+
+    buffer64 = np.zeros((len(points), 3), dtype=np.float64)
+    for row, point in enumerate(points):
+        buffer64[row] = point
+    cloud64 = {
+        "data": buffer64.reshape(-1).view(np.uint8),
+        "point_step": 24,
+        "row_step": 24 * len(points),
+        "height": 1,
+        "width": len(points),
+        "x_offset": 0,
+        "y_offset": 8,
+        "z_offset": 16,
+    }
+    mapper64 = _make_mapper(
+        [
+            SensorConfig(
+                position=np.array([0.3, 0.0, 0.2], dtype=np.float32),
+                cloud_field_type=PointFieldType.FLOAT64,
+            )
+        ],
+        use_gpu=False,
+    )
+    grid64 = np.asarray(mapper64.scan_to_grid(clouds=[cloud64]))
+
+    assert (grid32 == OCCUPIED).sum() > 0
+    np.testing.assert_array_equal(grid32, grid64)

--- a/tests/test_local_mapper_multisensor.py
+++ b/tests/test_local_mapper_multisensor.py
@@ -1,0 +1,283 @@
+"""Multi-sensor point cloud fusion tests: raw kompass_cpp bindings and the
+kompass_core.mapping.LocalMapper wrapper."""
+
+import types
+
+import numpy as np
+import pytest
+
+from kompass_cpp.mapping import OCCUPANCY_TYPE
+from kompass_cpp.mapping import LocalMapper as LocalMapperCpp
+from kompass_cpp.types import SensorConfig
+
+try:
+    from kompass_cpp.mapping import LocalMapperGPU
+
+    _HAS_GPU = True
+except ImportError:
+    _HAS_GPU = False
+
+from kompass_core.datatypes.pose import PoseData
+from kompass_core.datatypes.scan_model import ScanModelConfig
+from kompass_core.mapping import LocalMapper, MapConfig
+
+OCCUPIED = OCCUPANCY_TYPE.OCCUPIED.value
+UNEXPLORED = OCCUPANCY_TYPE.UNEXPLORED.value
+
+_PC_STRIDE = 16  # 16B points (x, y, z, pad), matching the other test files
+
+
+def _pack_points(points) -> np.ndarray:
+    """Packs (x, y, z) tuples into a PointCloud2-style uint8 buffer."""
+    buffer = np.zeros((len(points), 4), dtype=np.float32)
+    for row, point in enumerate(points):
+        buffer[row, :3] = point
+    return buffer.reshape(-1).view(np.uint8)
+
+
+def _cloud_dict(points, extra_keys: bool = True) -> dict:
+    data = _pack_points(points)
+    cloud = {
+        "data": data,
+        "point_step": _PC_STRIDE,
+        "row_step": _PC_STRIDE * len(points),
+        "height": 1,
+        "width": len(points),
+        "x_offset": 0,
+        "y_offset": 4,
+        "z_offset": 8,
+    }
+    if extra_keys:
+        # A whole container gets splatted in practice; extras must be ignored
+        cloud["frame_id"] = "livox_frame"
+        cloud["timestamp"] = 0.0
+    return cloud
+
+
+def _quat_yaw(yaw: float) -> np.ndarray:
+    return np.array(
+        [0.0, 0.0, np.sin(yaw / 2.0), np.cos(yaw / 2.0)], dtype=np.float32
+    )
+
+
+def _front_back_sensors():
+    return [
+        SensorConfig(position=np.array([0.3, 0.0, 0.2], dtype=np.float32)),
+        SensorConfig(
+            position=np.array([-0.3, 0.0, 0.2], dtype=np.float32),
+            rotation=_quat_yaw(np.pi),
+        ),
+    ]
+
+
+def _make_mapper(sensor_configs, use_gpu: bool):
+    """Raw-binding mapper: 20x20 grid at 0.1 m/cell, 360 bins,
+    body-frame band [0, 0.5]."""
+    kwargs = dict(
+        grid_height=20,
+        grid_width=20,
+        resolution=0.1,
+        sensor_configs=sensor_configs,
+        is_pointcloud=True,
+        scan_size=360,
+        max_height=0.5,
+        min_height=0.0,
+        range_max=5.0,
+        max_points_per_line=43,
+    )
+    if use_gpu:
+        if not _HAS_GPU:
+            pytest.skip("kompass_cpp built without GPU support")
+        return LocalMapperGPU(**kwargs)
+    return LocalMapperCpp(**kwargs, max_num_threads=1)
+
+
+_BACKENDS = [False, True]
+
+
+# ---------------------------------------------------------------------------
+# Raw bindings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("use_gpu", _BACKENDS)
+def test_multisensor_fusion_front_back(use_gpu):
+    """One obstacle ahead of each sensor in its own frame: the fused grid
+    holds OCCUPIED cells both ahead of and behind the robot center."""
+    mapper = _make_mapper(_front_back_sensors(), use_gpu)
+
+    front = _cloud_dict([(0.4, 0.0, -0.1)])  # body (0.7, 0, 0.1)
+    back = _cloud_dict([(0.4, 0.0, -0.1)])  # body (-0.7, 0, 0.1)
+
+    grid = np.asarray(mapper.scan_to_grid(clouds=[front, back]))
+    assert (grid[14:18, :] == OCCUPIED).any(), "no OCCUPIED cell ahead"
+    assert (grid[1:5, :] == OCCUPIED).any(), "no OCCUPIED cell behind"
+
+
+@pytest.mark.parametrize("use_gpu", _BACKENDS)
+def test_multisensor_none_means_no_data(use_gpu):
+    """None entries are skipped; an all-None batch yields an untouched grid."""
+    mapper = _make_mapper(_front_back_sensors(), use_gpu)
+
+    front = _cloud_dict([(0.4, 0.0, -0.1)])
+    grid = np.asarray(mapper.scan_to_grid(clouds=[front, None]))
+    assert (grid[14:18, :] == OCCUPIED).any()
+    assert not (grid[0:9, :] == OCCUPIED).any(), (
+        "front-only batch put OCCUPIED cells behind the robot"
+    )
+
+    grid = np.asarray(mapper.scan_to_grid(clouds=[None, None]))
+    assert (grid == UNEXPLORED).all()
+
+
+@pytest.mark.parametrize("use_gpu", _BACKENDS)
+def test_multisensor_elements_must_be_dicts(use_gpu):
+    """The contract is tight: an element is a dict (asdict()-style) or None.
+    Attribute-carrying objects are rejected with the offending index."""
+    mapper = _make_mapper(_front_back_sensors(), use_gpu)
+
+    front = _cloud_dict([(0.4, 0.0, -0.1)])
+    back_obj = types.SimpleNamespace(**_cloud_dict([(0.4, 0.0, -0.1)]))
+    with pytest.raises(ValueError, match=r"clouds\[1\].*dict"):
+        mapper.scan_to_grid(clouds=[front, back_obj])
+
+
+@pytest.mark.parametrize("use_gpu", _BACKENDS)
+def test_multisensor_bytes_data(use_gpu):
+    """`bytes` buffers (PointCloud2.data) cross the batched entry too."""
+    mapper = _make_mapper(_front_back_sensors(), use_gpu)
+
+    front = _cloud_dict([(0.4, 0.0, -0.1)])
+    as_array = np.asarray(mapper.scan_to_grid(clouds=[front, None])).copy()
+
+    front_bytes = dict(front)
+    front_bytes["data"] = front["data"].tobytes()
+    as_bytes = np.asarray(mapper.scan_to_grid(clouds=[front_bytes, None]))
+    assert (as_array == as_bytes).all()
+
+
+@pytest.mark.parametrize("use_gpu", _BACKENDS)
+def test_multisensor_error_paths(use_gpu):
+    mapper = _make_mapper(_front_back_sensors(), use_gpu)
+    front = _cloud_dict([(0.4, 0.0, -0.1)])
+
+    # Cloud count must match the configured sensor count
+    with pytest.raises(ValueError):
+        mapper.scan_to_grid(clouds=[front])
+
+    # Negative offsets are named per cloud
+    bad = _cloud_dict([(0.4, 0.0, -0.1)])
+    bad["y_offset"] = -4
+    with pytest.raises(ValueError, match=r"clouds\[1\].*non-negative"):
+        mapper.scan_to_grid(clouds=[front, bad])
+
+    # Missing layout fields are named per cloud
+    incomplete = {"data": front["data"]}
+    with pytest.raises(ValueError, match=r"clouds\[0\].*point_step"):
+        mapper.scan_to_grid(clouds=[incomplete, front])
+
+
+# ---------------------------------------------------------------------------
+# kompass_core wrapper
+# ---------------------------------------------------------------------------
+
+
+def _wrapper_configs():
+    map_config = MapConfig(width=2.0, height=2.0, resolution=0.1)
+    scan_model = ScanModelConfig(
+        angle_step=float(2.0 * np.pi / 360.0),
+        max_height=0.5,
+        min_height=0.0,
+        range_max=5.0,
+    )
+    return map_config, scan_model
+
+
+def test_wrapper_multisensor_fusion():
+    map_config, scan_model = _wrapper_configs()
+    mapper = LocalMapper(
+        config=map_config,
+        scan_model_config=scan_model,
+        sensors=_front_back_sensors(),
+    )
+    assert mapper.num_sensors == 2
+
+    mapper.update_from_pointclouds(
+        PoseData(),
+        clouds=[_cloud_dict([(0.4, 0.0, -0.1)]), _cloud_dict([(0.4, 0.0, -0.1)])],
+    )
+    occupancy = mapper.occupancy
+    assert (occupancy[14:18, :] == OCCUPIED).any(), "no OCCUPIED cell ahead"
+    assert (occupancy[1:5, :] == OCCUPIED).any(), "no OCCUPIED cell behind"
+
+
+def test_wrapper_multisensor_accepts_pose_data_mounts():
+    map_config, scan_model = _wrapper_configs()
+    mapper = LocalMapper(
+        config=map_config,
+        scan_model_config=scan_model,
+        sensors=[PoseData()],
+    )
+    mapper.update_from_pointclouds(
+        PoseData(), clouds=[_cloud_dict([(0.5, 0.0, 0.1)])]
+    )
+    assert (mapper.occupancy == OCCUPIED).any()
+
+
+def test_wrapper_multisensor_guards():
+    map_config, scan_model = _wrapper_configs()
+
+    # Mutually exclusive mount arguments
+    with pytest.raises(ValueError, match="not both"):
+        LocalMapper(
+            config=map_config,
+            scan_model_config=scan_model,
+            pose_laser_scanner_in_robot=PoseData(),
+            sensors=[SensorConfig()],
+        )
+
+    # At least one sensor
+    with pytest.raises(ValueError, match="at least one"):
+        LocalMapper(config=map_config, scan_model_config=scan_model, sensors=[])
+
+    # The multi-sensor pipeline is non-Bayesian by contract, rejected at
+    # construction for ANY sensor count (config errors must not surface at
+    # runtime)
+    bayes_config = MapConfig(
+        width=2.0, height=2.0, resolution=0.1, bayesian_update=True
+    )
+    for sensor_set in (_front_back_sensors(), [SensorConfig()]):
+        with pytest.raises(ValueError, match="multi-sensor pipeline"):
+            LocalMapper(
+                config=bayes_config,
+                scan_model_config=scan_model,
+                sensors=sensor_set,
+            )
+
+    # The plural entry requires multi-sensor construction
+    legacy_mapper = LocalMapper(config=map_config, scan_model_config=scan_model)
+    with pytest.raises(RuntimeError, match="sensors="):
+        legacy_mapper.update_from_pointclouds(
+            PoseData(), clouds=[_cloud_dict([(0.4, 0.0, -0.1)])]
+        )
+
+    mapper = LocalMapper(
+        config=map_config,
+        scan_model_config=scan_model,
+        sensors=_front_back_sensors(),
+    )
+
+    # Single-cloud and laserscan entries reject the multi-sensor mode
+    cloud = _cloud_dict([(0.4, 0.0, -0.1)])
+    with pytest.raises(RuntimeError, match="update_from_pointclouds"):
+        mapper.update_from_pointcloud(PoseData(), **cloud)
+    with pytest.raises(NotImplementedError):
+        mapper.update_from_laserscan(
+            PoseData(),
+            ranges=np.ones(4, dtype=np.float32),
+            angles=np.zeros(4, dtype=np.float32),
+        )
+
+    # Cloud count must match the configured sensor count
+    with pytest.raises(ValueError, match="Expected 2 clouds"):
+        mapper.update_from_pointclouds(PoseData(), clouds=[cloud])

--- a/tests/test_local_mapper_pytest.py
+++ b/tests/test_local_mapper_pytest.py
@@ -22,7 +22,7 @@ from kompass_cpp.mapping import OCCUPANCY_TYPE
 
 RESOURCES_DIR = Path(__file__).parent / "resources" / "mapping"
 LASERSCAN_JSON = RESOURCES_DIR / "laserscan_data.json"
-LIVOX_CLOUD_JSON = RESOURCES_DIR / "livox_pointcloud_sample_0.json"
+LIVOX_CLOUD_JSON = RESOURCES_DIR / "livox_pointcloud_sample_1.json"
 
 
 def _get_random_pose(rng: random.Random,
@@ -373,7 +373,7 @@ def test_update_from_pointcloud_origin_only_points_filtered():
 @pytest.mark.skipif(
     not LIVOX_CLOUD_JSON.exists() or LIVOX_CLOUD_JSON.stat().st_size < 1_000_000,
     reason=(
-        "livox_pointcloud_sample_0.json not available (too large for CI). "
+        "livox_pointcloud_sample_1.json not available (too large for CI). "
         "Drop the file into tests/resources/mapping/ to enable this test."
     ),
 )

--- a/tests/test_multi_pointcloud_emergency_stop.py
+++ b/tests/test_multi_pointcloud_emergency_stop.py
@@ -1,0 +1,180 @@
+"""Multi-sensor (multi point cloud) emergency stop tests, on the raw
+kompass_cpp checkers — mirrors how Kompass' drive manager will construct
+them for a robot with front + back lidars."""
+
+import numpy as np
+import pytest
+
+from kompass_cpp.types import RobotGeometry, SensorConfig, SensorInputType
+from kompass_cpp.utils import CriticalZoneChecker
+
+try:
+    from kompass_cpp.utils import CriticalZoneCheckerGPU
+
+    _HAS_GPU = True
+except ImportError:
+    _HAS_GPU = False
+
+
+_PC_STRIDE = 16  # 16B points (x, y, z, pad)
+
+# Robot: cylinder radius 0.5; critical 0.3 (stop inside 0.8 m from center),
+# slowdown 0.6 (ramp up to 1.1 m)
+_ROBOT_RADIUS = 0.5
+_CRIT = 0.3
+_SLOW = 0.6
+
+
+def _pack_points(points) -> dict:
+    buffer = np.zeros((len(points), 4), dtype=np.float32)
+    for row, point in enumerate(points):
+        buffer[row, :3] = point
+    return {
+        "data": buffer.reshape(-1).view(np.uint8),
+        "point_step": _PC_STRIDE,
+        "row_step": _PC_STRIDE * len(points),
+        "height": 1,
+        "width": len(points),
+        "x_offset": 0,
+        "y_offset": 4,
+        "z_offset": 8,
+    }
+
+
+def _quat_yaw(yaw: float) -> np.ndarray:
+    return np.array(
+        [0.0, 0.0, np.sin(yaw / 2.0), np.cos(yaw / 2.0)], dtype=np.float32
+    )
+
+
+def _front_back_sensors():
+    """Front and back lidars at x = +/-0.2 m, mounted 0.2 m high."""
+    return [
+        SensorConfig(position=np.array([0.2, 0.0, 0.2], dtype=np.float32)),
+        SensorConfig(
+            position=np.array([-0.2, 0.0, 0.2], dtype=np.float32),
+            rotation=_quat_yaw(np.pi),
+        ),
+    ]
+
+
+def _make_checker(use_gpu: bool, sensors=None):
+    if use_gpu:
+        if not _HAS_GPU:
+            pytest.skip("Build has no GPU implementation")
+        checker_class = CriticalZoneCheckerGPU
+    else:
+        checker_class = CriticalZoneChecker
+    return checker_class(
+        input_type=SensorInputType.POINTCLOUD,
+        robot_shape=RobotGeometry.CYLINDER,
+        robot_dimensions=np.array([_ROBOT_RADIUS, 1.0], dtype=np.float32),
+        sensor_configs=sensors if sensors is not None else _front_back_sensors(),
+        critical_angle=90.0,
+        critical_distance=_CRIT,
+        slowdown_distance=_SLOW,
+        min_height=0.0,  # body frame: ground ...
+        max_height=1.0,  # ... to robot top
+        range_max=20.0,
+    )
+
+
+_BACKENDS = [False, True]
+
+
+@pytest.mark.parametrize("use_gpu", _BACKENDS)
+def test_back_obstacle_stops_reverse_only(use_gpu):
+    """The headline two-Livox case: an obstacle seen ONLY by the back sensor
+    stops reverse motion and leaves forward motion untouched.
+    Back-sensor frame (0.5, 0, 0.1) -> body (-0.7, 0, 0.3):
+    0.7 - 0.5 (radius) = 0.2 < 0.3 (critical)."""
+    checker = _make_checker(use_gpu)
+    back = _pack_points([(0.5, 0.0, 0.1)])
+
+    assert checker.check(clouds=[None, back], forward=False) == 0.0
+    assert checker.check(clouds=[None, back], forward=True) == 1.0
+
+
+@pytest.mark.parametrize("use_gpu", _BACKENDS)
+def test_min_factor_across_clouds(use_gpu):
+    """Fused result is the minimum over both sensors' factors."""
+    checker = _make_checker(use_gpu)
+    # Front-sensor frame (0.75, 0, 0.1) -> body (0.95, 0, 0.3):
+    # factor = (0.95 - 0.5 - 0.3) / 0.3 = 0.5
+    front_slow = _pack_points([(0.75, 0.0, 0.1)])
+    back_far = _pack_points([(5.0, 0.0, 0.1)])
+
+    factor = checker.check(clouds=[front_slow, back_far], forward=True)
+    assert 0.4 < factor < 0.6
+
+    # Adding a critical point to the FRONT cloud drives the min to 0
+    front_mixed = _pack_points([(0.75, 0.0, 0.1), (0.55, 0.0, 0.1)])
+    assert checker.check(clouds=[front_mixed, back_far], forward=True) == 0.0
+
+
+@pytest.mark.parametrize("use_gpu", _BACKENDS)
+def test_repeat_calls_and_empty_batches(use_gpu):
+    """A stop must not leak into the next call, and an all-None batch is
+    unconstrained (nothing observed)."""
+    checker = _make_checker(use_gpu)
+    danger = _pack_points([(0.5, 0.0, 0.1)])
+    safe = _pack_points([(5.0, 0.0, 0.1)])
+
+    assert checker.check(clouds=[danger, None], forward=True) == 0.0
+    assert checker.check(clouds=[safe, safe], forward=True) == 1.0
+    assert checker.check(clouds=[None, None], forward=True) == 1.0
+
+
+@pytest.mark.parametrize("use_gpu", _BACKENDS)
+def test_body_frame_height_band(use_gpu):
+    """The band gates BODY-frame z: with sensors mounted at 0.2 m, a point at
+    sensor z = -0.1 sits at body z = 0.1 (inside [0, 1]) and must count; a
+    point at sensor z = 0.9 sits at body z = 1.1 (above the band) and must
+    not."""
+    checker = _make_checker(use_gpu)
+
+    in_band = _pack_points([(0.5, 0.0, -0.1)])  # body z = 0.1
+    assert checker.check(clouds=[in_band, None], forward=True) == 0.0
+
+    above_band = _pack_points([(0.5, 0.0, 0.9)])  # body z = 1.1
+    assert checker.check(clouds=[above_band, None], forward=True) == 1.0
+
+
+@pytest.mark.parametrize("use_gpu", _BACKENDS)
+def test_num_sensors_and_errors(use_gpu):
+    checker = _make_checker(use_gpu)
+    assert checker.num_sensors == 2
+
+    cloud = _pack_points([(5.0, 0.0, 0.1)])
+
+    with pytest.raises(ValueError):
+        checker.check(clouds=[cloud], forward=True)
+
+    bad = _pack_points([(5.0, 0.0, 0.1)])
+    bad["y_offset"] = -4
+    with pytest.raises(ValueError, match=r"clouds\[1\].*non-negative"):
+        checker.check(clouds=[cloud, bad], forward=True)
+
+    # Laserscan input on a pointcloud checker is rejected loudly
+    with pytest.raises(RuntimeError):
+        checker.check(
+            ranges=np.ones(4, dtype=np.float32).reshape(-1), forward=True
+        )
+
+
+@pytest.mark.parametrize("use_gpu", _BACKENDS)
+def test_cpu_gpu_agree(use_gpu):
+    """Both backends compute the same factor for the same batch (the CPU
+    per-point loop mirrors the GPU kernel)."""
+    if not use_gpu:
+        pytest.skip("comparison runs once, from the GPU parametrization")
+    cpu = _make_checker(False)
+    gpu = _make_checker(True)
+
+    front = _pack_points([(0.75, 0.0, 0.1), (2.0, 1.0, 0.1)])
+    back = _pack_points([(0.9, 0.2, 0.1), (5.0, 0.0, 0.1)])
+
+    for forward in (True, False):
+        cpu_factor = cpu.check(clouds=[front, back], forward=forward)
+        gpu_factor = gpu.check(clouds=[front, back], forward=forward)
+        assert cpu_factor == pytest.approx(gpu_factor, abs=1e-5)

--- a/tests/test_pointcloud_data.py
+++ b/tests/test_pointcloud_data.py
@@ -7,7 +7,7 @@ from kompass_cpp.utils import pointcloud_to_laserscan_from_raw
 
 
 RESOURCES_DIR = Path(__file__).parent / "resources" / "mapping"
-LIVOX_CLOUD_JSON = RESOURCES_DIR / "livox_pointcloud_sample_0.json"
+LIVOX_CLOUD_JSON = RESOURCES_DIR / "livox_pointcloud_sample_1.json"
 
 
 # ---------------------------------------------------------------------------
@@ -305,7 +305,7 @@ def test_conversion_z_band_entirely_below_the_sensor_is_honoured():
 @pytest.mark.skipif(
     not LIVOX_CLOUD_JSON.exists() or LIVOX_CLOUD_JSON.stat().st_size < 1_000_000,
     reason=(
-        "livox_pointcloud_sample_0.json not committed (too large for CI). "
+        "livox_pointcloud_sample_1.json not committed (too large for CI). "
         "Drop the file into tests/resources/mapping/ to enable this test."
     ),
 )

--- a/tests/test_zero_copy_boundary.py
+++ b/tests/test_zero_copy_boundary.py
@@ -1,0 +1,125 @@
+"""Zero-copy guard for the batched cloud entries.
+
+The batched ``clouds=[...]`` bindings extract METADATA ONLY under the GIL
+(8 ints + a buffer view per cloud); the point bytes must never be copied
+or converted at the Python boundary. This guard times the batched N=1
+entry against the legacy single-cloud entry on the same 100k-point buffer:
+they run the identical C++ path, so any per-point boundary work (which
+would be 10-100x the metadata cost) blows the ratio immediately.
+
+CPU classes are used on purpose: no JIT warm-up noise, and the binding
+boundary under test is the same code for the GPU classes.
+"""
+
+import time
+
+import numpy as np
+
+from kompass_cpp.mapping import LocalMapper as LocalMapperCpp
+from kompass_cpp.types import RobotGeometry, SensorConfig, SensorInputType
+from kompass_cpp.utils import CriticalZoneChecker
+
+_PC_STRIDE = 16  # 16B points (x, y, z, pad)
+_N_POINTS = 100_000
+_REPS = 30
+# A metadata-only boundary measures ~1.0; per-point work measures 10x+.
+# 1.5 tolerates scheduler noise without ever masking a regression.
+_MAX_RATIO = 1.5
+
+
+def _far_cloud(n: int = _N_POINTS) -> dict:
+    """n points uniformly in a 2-10 m ring around the sensor: outside the
+    checker's slowdown ring (no early-exit, every point is swept) and
+    inside the mapper's range_max (every point reaches the binning)."""
+    rng = np.random.default_rng(1234)
+    buffer = np.zeros((n, 4), dtype=np.float32)
+    radius = rng.uniform(2.0, 10.0, size=n).astype(np.float32)
+    theta = rng.uniform(-np.pi, np.pi, size=n).astype(np.float32)
+    buffer[:, 0] = radius * np.cos(theta)
+    buffer[:, 1] = radius * np.sin(theta)
+    buffer[:, 2] = rng.uniform(0.1, 0.9, size=n).astype(np.float32)
+    return {
+        "data": buffer.reshape(-1).view(np.uint8),
+        "point_step": _PC_STRIDE,
+        "row_step": _PC_STRIDE * n,
+        "height": 1,
+        "width": n,
+        "x_offset": 0,
+        "y_offset": 4,
+        "z_offset": 8,
+    }
+
+
+def _median_ratio(single_call, batched_call, reps: int = _REPS) -> float:
+    """Interleaved A/B timing -> median(batched) / median(single)."""
+    for _ in range(3):
+        single_call()
+        batched_call()
+    singles, batched = [], []
+    for _ in range(reps):
+        t0 = time.perf_counter()
+        single_call()
+        t1 = time.perf_counter()
+        batched_call()
+        t2 = time.perf_counter()
+        singles.append(t1 - t0)
+        batched.append(t2 - t1)
+    return float(np.median(batched) / np.median(singles))
+
+
+def test_checker_batched_n1_within_noise_of_single_cloud():
+    checker = CriticalZoneChecker(
+        input_type=SensorInputType.POINTCLOUD,
+        robot_shape=RobotGeometry.CYLINDER,
+        robot_dimensions=np.array([0.5, 1.0], dtype=np.float32),
+        sensor_configs=[SensorConfig()],
+        critical_angle=90.0,
+        critical_distance=0.3,
+        slowdown_distance=0.6,
+        min_height=0.0,
+        max_height=1.0,
+        range_max=20.0,
+    )
+    cloud = _far_cloud()
+
+    # Same C++ path -> identical result before we bother timing anything
+    assert checker.check(**cloud, forward=True) == checker.check(
+        clouds=[cloud], forward=True
+    )
+
+    ratio = _median_ratio(
+        lambda: checker.check(**cloud, forward=True),
+        lambda: checker.check(clouds=[cloud], forward=True),
+    )
+    assert ratio < _MAX_RATIO, (
+        f"batched N=1 check() costs {ratio:.2f}x the single-cloud entry: "
+        "the binding boundary is doing per-point work"
+    )
+
+
+def test_mapper_batched_n1_within_noise_of_single_cloud():
+    mapper = LocalMapperCpp(
+        grid_height=100,
+        grid_width=100,
+        resolution=0.05,
+        sensor_configs=[SensorConfig()],
+        is_pointcloud=True,
+        scan_size=360,
+        max_height=1.0,
+        min_height=0.0,
+        range_max=20.0,
+    )
+    cloud = _far_cloud()
+
+    single_grid = np.asarray(mapper.scan_to_grid(**cloud)).copy()
+    batched_grid = np.asarray(mapper.scan_to_grid(clouds=[cloud]))
+    np.testing.assert_array_equal(single_grid, batched_grid)
+
+    ratio = _median_ratio(
+        lambda: mapper.scan_to_grid(**cloud),
+        lambda: mapper.scan_to_grid(clouds=[cloud]),
+    )
+    assert ratio < _MAX_RATIO, (
+        f"batched N=1 scan_to_grid() costs {ratio:.2f}x the single-cloud "
+        "entry: the binding boundary is doing per-point work"
+    )


### PR DESCRIPTION
## Summary

Adds multi-sensor (multi point cloud) fusion to the local mapper and the critical zone checker on both CPU and GPU backends: one mapper fuses N clouds into a single occupancy grid, and one checker returns the minimum safety factor across N clouds. Built for robots carrying several 3D lidars (e.g. front + back Livox) feeding one grid and one emergency-stop decision.

## Design

- **`SensorConfig` + `PointCloudView`** (`datatypes/sensors.h`): full 3D mount pose (position + quaternion) and point field encoding per sensor; non-owning zero-copy views over raw cloud bytes. `clouds[i]` pairs positionally with `sensor_configs[i]`; `None`/empty means "no data from this sensor this tick".
- **No cloud concatenation** — free-space carving is per-sensor-origin, so each cloud is converted and raycast from its own origin; fusion happens at the grid via max-monotone writes (GPU: atomic `fetch_max`). The checker fuses as `min()` over per-sensor factors, and its critical cone is a body-frame gate: a back-sensor point ahead of the robot trips the forward check.
- **Body-frame semantics everywhere**: every point cloud path applies the sensor's full 3×4 mount transform, then gates on a body-frame height band shared by all sensors (typically `[0, robot_height]`). Migration from the old sensor-frame band: `[a, b] -> [a + s_z, b + s_z]`.
- **Zero-copy preserved**: batched bindings extract metadata only under the GIL (8 ints + a buffer view per cloud, keep-alive pinned across the GIL-released call); the point bytes are never copied or converted in Python. Guarded by a new timing test (`tests/test_zero_copy_boundary.py`) asserting the batched N=1 entry matches the single-cloud entry within noise at 100k points.
- Single-cloud signatures survive as thin N=1 adapters onto the batched path; all per-tick-invariant values (transforms, squared thresholds, inverse ramps) are derived once at construction.

## Breaking changes

- Constructors consolidated around `sensor_configs` (yaw-only mount parameters removed); laserscan mode requires exactly one sensor and non-empty `scan_angles` at construction.
- Point cloud height band is body-frame on every path (see migration formula above).
- Config errors (Bayesian + multi-sensor, count mismatches, mode mixing) throw at construction/entry instead of failing mid-tick.
- `baysian_update`/`scanToGridBaysian` renamed to the correct Bayesian spelling.
- CPU and GPU checker point cloud semantics unified; the GPU kernel previously dropped the transform's z column, producing false stops on tilted mounts.

Kompass migrates alongside this release (separate PR); no backward compatibility is kept pre-1.0.

## Fixes and Improvements

- `gridToLocal` was the negation of `localToGrid`'s inverse — offset-mounted sensors got mirrored origins in the GPU distance tables, suppressing free-space carving (regression test proves the fix A/B).
- GPU raycast neighbor stamps could write one cell out of bounds at grid edges.
- GPU distance table used the wrong stride on non-square grids and inflated distances by the sensor height.
- Per-sensor `cloud_field_type` honored on the GPU conversion (was hard-coded FLOAT32).
- `preset()` did not clear the forward/backward index sets before recomputing.

## Performance

- DWA's trajectory sampler no longer constructs and joins a thread pool on every generation call — the pool is created once and reused, with an explicit futures barrier.
- Checker pipelines reject on squared distance before the `atan2` cone filter; the point cloud conversion rejects points beyond `max_range` before binning (they can never win a bin).
- New benchmarks: `Mapper_MultiCloud_2x50k` and `CriticalZone_2x50k_Cloud`, directly comparable to the 100k single-cloud entries. On the SYCL host device the batched checker costs +4% over single for the same total points; the multi mapper adds one raycast pass per extra sensor (the price of per-origin carving).
