### PR TITLE
Zero-copy vision depth boundary, vision hot-path optimization, and broad bindings sweep

### DIFF
--- a/src/kompass_core/control/dwa.py
+++ b/src/kompass_core/control/dwa.py
@@ -324,19 +324,21 @@ class DWA(FollowerTemplate):
         # float32 C-contiguous is the zero-copy fast path at the binding
         # (no-op for ROS-native data)
         if local_map is not None:
-            sensor_data = np.ascontiguousarray(local_map, dtype=np.float32)
+            sensor_args = (np.ascontiguousarray(local_map, dtype=np.float32),)
         elif ranges is not None and angles is not None:
             if len(angles) != len(ranges):
                 logging.error(
                     "Received incompatible LaserScan data -> Cannot compute control"
                 )
                 return False
-            sensor_data = kompass_cpp.types.LaserScan(
-                ranges=np.asarray(ranges, dtype=np.float32),
-                angles=np.asarray(angles, dtype=np.float32),
+            # Passed as raw arrays. The scan is built C++-side after the GIL
+            # release
+            sensor_args = (
+                np.asarray(ranges, dtype=np.float32),
+                np.asarray(angles, dtype=np.float32),
             )
         elif points is not None:
-            sensor_data = np.ascontiguousarray(points, dtype=np.float32)
+            sensor_args = (np.ascontiguousarray(points, dtype=np.float32),)
         else:
             logging.error(
                 "Cannot compute control without sensor data. Provide 'ranges' and 'angles', 'points' or 'local_map' input"
@@ -346,10 +348,10 @@ class DWA(FollowerTemplate):
         try:
             if debug:
                 self._planner.debug_velocity_search(
-                    current_velocity, sensor_data, self._config.drop_samples
+                    current_velocity, *sensor_args, self._config.drop_samples
                 )
             self._result = self._planner.compute_velocity_commands(
-                current_velocity, sensor_data
+                current_velocity, *sensor_args
             )
 
         except Exception as e:

--- a/src/kompass_core/control/rgbd_follower.py
+++ b/src/kompass_core/control/rgbd_follower.py
@@ -558,6 +558,11 @@ class VisionRGBDFollower(ControllerTemplate):
         :return: Whether the planner found a valid solution
         :rtype: bool
         """
+        if depth_image is None:
+            # No depth this tick, skip.
+            logging.debug("RGBDFollower loop_step called without a depth image")
+            return False
+
         robot_cmd = None
         if not self._config._use_local_coordinates:
             # Global mode: state is mandatory — detector and control law need it

--- a/src/kompass_core/control/rgbd_follower.py
+++ b/src/kompass_core/control/rgbd_follower.py
@@ -145,12 +145,15 @@ class VisionRGBDFollowerConfig(FollowerConfig):
     * - camera_position_to_robot
       - `np.ndarray`
       - `[0.0, 0.0, 0.0]`
-      - Translation vector from the robot base to the camera frame (m).
+      - Translation from the robot base to the camera's **optical** frame (m),
+        which is the frame a ROS Image or CameraInfo names in its header.
 
     * - camera_rotation_to_robot
       - `np.ndarray`
-      - `[0.0, 0.0, 0.0, 1.0]`
-      - Quaternion `(x, y, z, w)` from the robot base to the camera frame.
+      - `[-0.5, 0.5, -0.5, 0.5]`
+      - Quaternion `(x, y, z, w)` from the robot base to the camera's
+        **optical** frame. The default is the REP 103 turn, i.e. a camera at
+        the body origin looking straight ahead.
 
     ```
     """
@@ -234,8 +237,12 @@ class VisionRGBDFollowerConfig(FollowerConfig):
         default=np.array([0.0, 0.0, 0.0], dtype=np.float32)
     )
 
+    # Pose of the camera's OPTICAL frame in the robot base, matching what a TF
+    # lookup against a depth Image/CameraInfo frame_id resolves to. The default
+    # is the REP 103 optical -> body turn: a camera at the body origin looking
+    # straight ahead.
     camera_rotation_to_robot: np.ndarray = field(
-        default=np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32)
+        default=np.array([-0.5, 0.5, -0.5, 0.5], dtype=np.float32)
     )
 
     def to_kompass_cpp(self) -> RGBDFollowerParameters:

--- a/src/kompass_core/datatypes/obstacles.py
+++ b/src/kompass_core/datatypes/obstacles.py
@@ -1,17 +1,10 @@
 from enum import IntEnum
 from typing import Any, Tuple
 
+from kompass_cpp.mapping import OCCUPANCY_TYPE
 from .pose import PoseData
 
-
-class OCCUPANCY_TYPE(IntEnum):
-    """
-    Integer Enum to represent the occupancy status on a grid
-    """
-
-    UNEXPLORED = -1
-    EMPTY = 0
-    OCCUPIED = 100
+__all__ = ["OCCUPANCY_TYPE", "OBSTACLE_TYPE", "ObstaclesData"]
 
 
 class OBSTACLE_TYPE(IntEnum):

--- a/src/kompass_core/vision.py
+++ b/src/kompass_core/vision.py
@@ -1,3 +1,3 @@
-from kompass_cpp.vision import DepthDetector
+from kompass_cpp.vision import CameraFrameConvention, DepthDetector
 
-__all__ = ["DepthDetector"]
+__all__ = ["CameraFrameConvention", "DepthDetector"]

--- a/src/kompass_cpp/bindings/bindings.h
+++ b/src/kompass_cpp/bindings/bindings.h
@@ -35,6 +35,34 @@ inline Kompass::ByteSpan toSpan(const ByteArray &a) {
   return Kompass::ByteSpan(a.data(), a.size());
 }
 
+// Zero-copy input types for aligned depth images: a 2-D C-contiguous
+// (rows, cols) numpy array, uint16 (depth in millimetres, ROS 16UC1) or
+// float32 (depth in metres, ROS 32FC1. Wrong-dtype or non-contiguous input
+// converts with a single C-level copy.
+using DepthArrayU16 =
+    py::ndarray<const uint16_t, py::ndim<2>, py::c_contig, py::device::cpu>;
+using DepthArrayF32 =
+    py::ndarray<const float, py::ndim<2>, py::c_contig, py::device::cpu>;
+
+// The returned view aliases the array's buffer: the array handle must
+// outlive the C++ call the view is passed to. Must be called with the GIL
+// held.
+inline Kompass::DepthImageView toDepthView(const DepthArrayU16 &a) {
+  return Kompass::DepthImageView(
+      Kompass::ByteSpan(reinterpret_cast<const uint8_t *>(a.data()),
+                        a.size() * sizeof(uint16_t)),
+      static_cast<int>(a.shape(0)), static_cast<int>(a.shape(1)),
+      PointFieldType::UINT16);
+}
+
+inline Kompass::DepthImageView toDepthView(const DepthArrayF32 &a) {
+  return Kompass::DepthImageView(
+      Kompass::ByteSpan(reinterpret_cast<const uint8_t *>(a.data()),
+                        a.size() * sizeof(float)),
+      static_cast<int>(a.shape(0)), static_cast<int>(a.shape(1)),
+      PointFieldType::FLOAT32);
+}
+
 // Extracts one PointCloudView from a Python cloud element. An element is a dict
 // (extra keys are ignored), or None, which yields an empty view. The element's
 // byte buffer crosses zero-copy. Its owner handle is appended to

--- a/src/kompass_cpp/bindings/bindings.h
+++ b/src/kompass_cpp/bindings/bindings.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "datatypes/path.h"
 #include "datatypes/sensors.h"
 #include "datatypes/span.h"
 #include <nanobind/eigen/dense.h>
@@ -11,8 +12,10 @@
 
 namespace py = nanobind;
 
+// ---------------------------------------------------------------------------
 // Submodule binder entry points, one per bindings_*.cpp; called from
 // NB_MODULE in bindings.cpp
+// ---------------------------------------------------------------------------
 void bindings_types(py::module_ &);
 void bindings_config(py::module_ &);
 void bindings_control(py::module_ &);
@@ -22,6 +25,10 @@ void bindings_planning(py::module_ &);
 void bindings_vision(py::module_ &);
 void bindings_mapping_gpu(py::module_ &);
 void bindings_utils_gpu(py::module_ &);
+
+// ---------------------------------------------------------------------------
+// PointCloud2-style byte buffers
+// ---------------------------------------------------------------------------
 
 // Zero-copy input type for PointCloud2-style byte buffers: accepts numpy
 // uint8 arrays (including read-only np.frombuffer views) and Python
@@ -34,6 +41,10 @@ using ByteArray =
 inline Kompass::ByteSpan toSpan(const ByteArray &a) {
   return Kompass::ByteSpan(a.data(), a.size());
 }
+
+// ---------------------------------------------------------------------------
+// Aligned depth images
+// ---------------------------------------------------------------------------
 
 // Zero-copy input types for aligned depth images: a 2-D C-contiguous
 // (rows, cols) numpy array, uint16 (depth in millimetres, ROS 16UC1) or
@@ -62,6 +73,34 @@ inline Kompass::DepthImageView toDepthView(const DepthArrayF32 &a) {
       static_cast<int>(a.shape(0)), static_cast<int>(a.shape(1)),
       PointFieldType::FLOAT32);
 }
+
+// ---------------------------------------------------------------------------
+// Zero-Copy N,3 setup (mostly for world-frame Pointcloud (pc.xyz) consumers)
+// ---------------------------------------------------------------------------
+
+// Nx3 cartesian points (row-major so a numpy (N, 3) float32 array maps
+// zero-copy); float64 or non-contiguous input converts with one copy
+using RowMatrixX3f = Eigen::Matrix<float, Eigen::Dynamic, 3, Eigen::RowMajor>;
+
+// The Nx3 float32 buffer is reinterpreted as a Span of points with NO
+// per-point build, which requires Path::Point (Eigen::Vector3f) to stay 3
+// packed floats
+static_assert(sizeof(Path::Point) == 3 * sizeof(float),
+              "Path::Point must be 3 packed floats for the zero-copy "
+              "Span reinterpret in the cloud bindings");
+
+// The returned span aliases the Ref's buffer: the Ref (and the numpy array
+// behind it) must outlive the C++ call the span is passed to.
+inline Kompass::Span<Path::Point>
+toPointSpan(const Eigen::Ref<const RowMatrixX3f> &cloud) {
+  return Kompass::Span<Path::Point>(
+      reinterpret_cast<const Path::Point *>(cloud.data()),
+      static_cast<size_t>(cloud.rows()));
+}
+
+// ---------------------------------------------------------------------------
+// Multi-sensor PointCloud2 batches (dict elements -> PointCloudViews)
+// ---------------------------------------------------------------------------
 
 // Extracts one PointCloudView from a Python cloud element. An element is a dict
 // (extra keys are ignored), or None, which yields an empty view. The element's

--- a/src/kompass_cpp/bindings/bindings_control.cpp
+++ b/src/kompass_cpp/bindings/bindings_control.cpp
@@ -132,10 +132,11 @@ void bindings_control(py::module_ &m) {
       .def("get_vy_cmd", &Control::Follower::getLinearVelocityCmdY)
       .def("get_omega_cmd", &Control::Follower::getAngularVelocityCmd)
       .def("get_steer_cmd", &Control::Follower::getSteeringAngleCmd)
-      .def("get_tracked_target", &Control::Follower::getTrackedTarget,
-           py::rv_policy::reference_internal)
+      .def("get_tracked_target", &Control::Follower::getTrackedTarget)
+      // NOTE: set_current_path/clear_current_path destroy the referenced Path,
+      // so return by copy to ensure no dangling pointers on python side
       .def("get_current_path", &Control::Follower::getCurrentPath,
-           py::rv_policy::reference_internal)
+           py::rv_policy::copy)
       .def("get_path_length", &Control::Follower::getPathLength)
       .def("has_path", &Control::Follower::hasPath);
 
@@ -292,6 +293,21 @@ void bindings_control(py::module_ &m) {
              return self.computeVelocityCommandsSet<Kompass::Span<Path::Point>>(
                  vel, points);
            })
+      .def(
+          "compute_velocity_commands",
+          // Overload for direct laserscan arrays. 1 copy of ranges/angles
+          // into the LaserScan, made after the GIL release
+          [](Control::DWA &self, const Control::Velocity2D &vel,
+             Eigen::Ref<const Eigen::VectorXf> ranges,
+             Eigen::Ref<const Eigen::VectorXf> angles)
+              -> Control::TrajSearchResult {
+            py::gil_scoped_release release;
+            const Control::LaserScan scan{Eigen::VectorXf(ranges),
+                                          Eigen::VectorXf(angles)};
+            return self.computeVelocityCommandsSet<Control::LaserScan>(vel,
+                                                                       scan);
+          },
+          py::arg("vel"), py::arg("ranges"), py::arg("angles"))
       .def("add_custom_cost",
            &Control::DWA::addCustomCost) // Custom cost function for DWA planner
                                          // of type (f(Trajectory2D, Path::Path)
@@ -313,6 +329,18 @@ void bindings_control(py::module_ &m) {
                              const Control::LaserScan &, const bool &>(
                &Control::DWA::debugVelocitySearch<Control::LaserScan>),
            py::call_guard<py::gil_scoped_release>())
+      .def("debug_velocity_search",
+           // Overload for direct laserscan arrays. 1 copy of ranges/angles
+           // into the LaserScan, made after the GIL release
+           [](Control::DWA &self, const Control::Velocity2D &vel,
+              Eigen::Ref<const Eigen::VectorXf> ranges,
+              Eigen::Ref<const Eigen::VectorXf> angles, const bool drop) {
+             py::gil_scoped_release release;
+             const Control::LaserScan scan{Eigen::VectorXf(ranges),
+                                           Eigen::VectorXf(angles)};
+             return self.debugVelocitySearch<Control::LaserScan>(vel, scan,
+                                                                 drop);
+           })
       .def("set_resolution", &Control::DWA::resetOctreeResolution);
 
   // Vision Follower

--- a/src/kompass_cpp/bindings/bindings_control.cpp
+++ b/src/kompass_cpp/bindings/bindings_control.cpp
@@ -20,6 +20,20 @@ using namespace Kompass;
 // zero-copy); float64 or non-contiguous input converts with one copy
 using RowMatrixX3f = Eigen::Matrix<float, Eigen::Dynamic, 3, Eigen::RowMajor>;
 
+// The Nx3 float32 buffer. For the cloud entries below to reinterpret it as a
+// Span with NO per-point build. Path::Point (Eigen::Vector3f) must stay 3
+// packed floats
+static_assert(sizeof(Path::Point) == 3 * sizeof(float),
+              "Path::Point must be 3 packed floats for the zero-copy "
+              "Span reinterpret in the cloud bindings");
+
+inline Kompass::Span<Path::Point>
+toPointSpan(const Eigen::Ref<const RowMatrixX3f> &cloud) {
+  return Kompass::Span<Path::Point>(
+      reinterpret_cast<const Path::Point *>(cloud.data()),
+      static_cast<size_t>(cloud.rows()));
+}
+
 namespace {
 // Private to file. The depth-image follower entries accept uint16 (mm) or
 // float32 (m) arrays. Templated functions with per dtype bindings below.
@@ -237,14 +251,10 @@ void bindings_control(py::module_ &m) {
           "execute",
           [](Control::PurePursuit &self, const double dt,
              Eigen::Ref<const RowMatrixX3f> cloud) {
-            std::vector<Path::Point> points;
-            points.reserve(cloud.rows());
-            for (Eigen::Index i = 0; i < cloud.rows(); ++i) {
-              points.emplace_back(cloud(i, 0), cloud(i, 1), cloud(i, 2));
-            }
-            // Solve without the GIL (conversion above still holds it)
+            // Zero-copy reinterpret
+            const auto points = toPointSpan(cloud);
             py::gil_scoped_release release;
-            return self.execute<std::vector<Path::Point>>(dt, points);
+            return self.execute<Kompass::Span<Path::Point>>(dt, points);
           },
           "Execute Pure Pursuit with PointCloud obstacle avoidance",
           py::arg("delta_time"), py::arg("point_cloud"));
@@ -294,14 +304,10 @@ void bindings_control(py::module_ &m) {
            [](Control::DWA &self, const Control::Velocity2D &vel,
               Eigen::Ref<const RowMatrixX3f> cloud)
                -> Control::TrajSearchResult {
-             std::vector<Path::Point> points;
-             points.reserve(cloud.rows());
-             for (Eigen::Index i = 0; i < cloud.rows(); ++i) {
-               points.emplace_back(cloud(i, 0), cloud(i, 1), cloud(i, 2));
-             }
-             // Solve without the GIL (conversion above still holds it)
+             // Zero-copy reinterpret
+             const auto points = toPointSpan(cloud);
              py::gil_scoped_release release;
-             return self.computeVelocityCommandsSet<std::vector<Path::Point>>(
+             return self.computeVelocityCommandsSet<Kompass::Span<Path::Point>>(
                  vel, points);
            })
       .def("add_custom_cost",
@@ -313,13 +319,10 @@ void bindings_control(py::module_ &m) {
            // Overload for Nx3 cartesian points
            [](Control::DWA &self, const Control::Velocity2D &vel,
               Eigen::Ref<const RowMatrixX3f> cloud, const bool drop) {
-             std::vector<Path::Point> points;
-             points.reserve(cloud.rows());
-             for (Eigen::Index i = 0; i < cloud.rows(); ++i) {
-               points.emplace_back(cloud(i, 0), cloud(i, 1), cloud(i, 2));
-             }
+             // Zero-copy reinterpret
+             const auto points = toPointSpan(cloud);
              py::gil_scoped_release release;
-             return self.debugVelocitySearch<std::vector<Path::Point>>(
+             return self.debugVelocitySearch<Kompass::Span<Path::Point>>(
                  vel, points, drop);
            })
       .def("debug_velocity_search",

--- a/src/kompass_cpp/bindings/bindings_control.cpp
+++ b/src/kompass_cpp/bindings/bindings_control.cpp
@@ -179,8 +179,10 @@ void bindings_control(py::module_ &m) {
       .def(py::init<Control::Stanley::StanleyParameters>(),
            "Init Stanley follower with custom config")
       .def("compute_velocity_commands",
-           &Control::Stanley::computeVelocityCommand)
-      .def("execute", &Control::Stanley::execute)
+           &Control::Stanley::computeVelocityCommand,
+           py::call_guard<py::gil_scoped_release>())
+      .def("execute", &Control::Stanley::execute,
+           py::call_guard<py::gil_scoped_release>())
       .def("set_robot_wheelbase", &Control::Stanley::setWheelBase);
 
   py::class_<Control::PID, Control::Controller>(m_control, "PID")
@@ -215,12 +217,13 @@ void bindings_control(py::module_ &m) {
            (Control::Controller::Result (Control::PurePursuit::*)(
                const Path::State, const double))&Control::PurePursuit::execute,
            "Execute Pure Pursuit control step with state update",
-           py::arg("current_position"), py::arg("delta_time"))
+           py::arg("current_position"), py::arg("delta_time"),
+           py::call_guard<py::gil_scoped_release>())
       .def("execute",
            (Control::Controller::Result (Control::PurePursuit::*)(
                const double))&Control::PurePursuit::execute,
            "Execute Pure Pursuit control step (uses internal state)",
-           py::arg("delta_time"))
+           py::arg("delta_time"), py::call_guard<py::gil_scoped_release>())
       .def(
           "execute",
           [](Control::PurePursuit &self, const double dt,

--- a/src/kompass_cpp/bindings/bindings_control.cpp
+++ b/src/kompass_cpp/bindings/bindings_control.cpp
@@ -405,6 +405,28 @@ void bindings_control(py::module_ &m) {
            py::arg("aligned_depth_image"), py::arg("target_box_2d"),
            py::arg("robot_orientation") = 0.0)
       .def("get_errors", &Control::RGBDFollower::getErrors)
+      // NOTE:The C++ class also inherits RGBFollower (nanobind doesn't cover
+      // multiple inheritence), so the RGBFollower interface is re-bound here
+      // through lambdas as follows
+      .def(
+          "reset_target",
+          [](Control::RGBDFollower &self, const Bbox2D &tracking) {
+            self.resetTarget(tracking);
+          },
+          py::arg("tracking"))
+      .def("get_ctrl",
+           [](const Control::RGBDFollower &self)
+               -> const Control::TrajectoryVelocities2D & {
+             return self.getCtrl();
+           })
+      .def(
+          "run",
+          [](Control::RGBDFollower &self,
+             const std::optional<Bbox2D> &detection) {
+            return self.run(detection);
+          },
+          py::arg("detection") = py::none(),
+          py::call_guard<py::gil_scoped_release>())
       .def("get_tracking_ctrl",
            py::overload_cast<const std::vector<Bbox3D> &,
                              const Control::Velocity2D &>(

--- a/src/kompass_cpp/bindings/bindings_control.cpp
+++ b/src/kompass_cpp/bindings/bindings_control.cpp
@@ -20,6 +20,39 @@ using namespace Kompass;
 // zero-copy); float64 or non-contiguous input converts with one copy
 using RowMatrixX3f = Eigen::Matrix<float, Eigen::Dynamic, 3, Eigen::RowMajor>;
 
+namespace {
+// Private to file. The depth-image follower entries accept uint16 (mm) or
+// float32 (m) arrays. Templated functions with per dtype bindings below.
+template <typename DepthArray>
+bool setInitialTrackingAtPixel(Control::RGBDFollower &self, const int pixel_x,
+                               const int pixel_y, const DepthArray &depth,
+                               const std::vector<Bbox2D> &boxes,
+                               const float yaw) {
+  const auto view = toDepthView(depth);
+  py::gil_scoped_release release;
+  return self.setInitialTracking(pixel_x, pixel_y, view, boxes, yaw);
+}
+
+template <typename DepthArray>
+bool setInitialTrackingBox(Control::RGBDFollower &self, const DepthArray &depth,
+                           const Bbox2D &target_box, const float yaw) {
+  const auto view = toDepthView(depth);
+  py::gil_scoped_release release;
+  return self.setInitialTracking(view, target_box, yaw);
+}
+
+template <typename DepthArray>
+Control::TrajSearchResult getTrackingCtrlDepth(Control::RGBDFollower &self,
+                                               const DepthArray &depth,
+                                               const std::vector<Bbox2D> &boxes,
+                                               const Control::Velocity2D &vel) {
+  const auto view = toDepthView(depth);
+  // Solve without the GIL (argument conversions above still held it)
+  py::gil_scoped_release release;
+  return self.getTrackingCtrl(view, boxes, vel);
+}
+} // namespace
+
 // Control bindings submodule
 void bindings_control(py::module_ &m) {
   auto m_control = m.def_submodule("control", "Control module");
@@ -254,21 +287,20 @@ void bindings_control(py::module_ &m) {
                              const Control::LaserScan &>(
                &Control::DWA::computeVelocityCommandsSet<Control::LaserScan>),
            py::call_guard<py::gil_scoped_release>())
-      .def(
-          "compute_velocity_commands",
-          [](Control::DWA &self, const Control::Velocity2D &vel,
-             Eigen::Ref<const RowMatrixX3f> cloud)
-              -> Control::TrajSearchResult {
-            std::vector<Path::Point> points;
-            points.reserve(cloud.rows());
-            for (Eigen::Index i = 0; i < cloud.rows(); ++i) {
-              points.emplace_back(cloud(i, 0), cloud(i, 1), cloud(i, 2));
-            }
-            // Solve without the GIL (conversion above still holds it)
-            py::gil_scoped_release release;
-            return self.computeVelocityCommandsSet<std::vector<Path::Point>>(
-                vel, points);
-          })
+      .def("compute_velocity_commands",
+           [](Control::DWA &self, const Control::Velocity2D &vel,
+              Eigen::Ref<const RowMatrixX3f> cloud)
+               -> Control::TrajSearchResult {
+             std::vector<Path::Point> points;
+             points.reserve(cloud.rows());
+             for (Eigen::Index i = 0; i < cloud.rows(); ++i) {
+               points.emplace_back(cloud(i, 0), cloud(i, 1), cloud(i, 2));
+             }
+             // Solve without the GIL (conversion above still holds it)
+             py::gil_scoped_release release;
+             return self.computeVelocityCommandsSet<std::vector<Path::Point>>(
+                 vel, points);
+           })
       .def("add_custom_cost",
            &Control::DWA::addCustomCost) // Custom cost function for DWA planner
                                          // of type (f(Trajectory2D, Path::Path)
@@ -309,8 +341,8 @@ void bindings_control(py::module_ &m) {
       .def("reset_target", &Control::RGBFollower::resetTarget)
       .def("get_ctrl", &Control::RGBFollower::getCtrl)
       .def("get_errors", &Control::RGBFollower::getErrors)
-      .def("run", &Control::RGBFollower::run,
-           py::arg("detection") = py::none());
+      .def("run", &Control::RGBFollower::run, py::arg("detection") = py::none(),
+           py::call_guard<py::gil_scoped_release>());
 
   // Vision DWA
   py::class_<Control::RGBDFollower::RGBDFollowerConfig,
@@ -340,18 +372,20 @@ void bindings_control(py::module_ &m) {
                &Control::RGBDFollower::setInitialTracking),
            py::arg("pixel_x"), py::arg("pixel_y"), py::arg("detected_boxes_3d"),
            py::arg("robot_orientation") = 0.0)
-      .def("set_initial_tracking",
-           py::overload_cast<const int, const int,
-                             const Eigen::MatrixX<unsigned short> &,
-                             const std::vector<Bbox2D> &, const float>(
-               &Control::RGBDFollower::setInitialTracking),
+      // Depth image binds as a zero-copy 2-D view (uint16 mm or float32 m,
+      // C-contiguous); one typed overload per dtype, sharing one template
+      .def("set_initial_tracking", &setInitialTrackingAtPixel<DepthArrayU16>,
            py::arg("pixel_x"), py::arg("pixel_y"),
            py::arg("aligned_depth_image"), py::arg("detected_boxes_2d"),
            py::arg("robot_orientation") = 0.0)
-      .def("set_initial_tracking",
-           py::overload_cast<const Eigen::MatrixX<unsigned short> &,
-                             const Bbox2D &, const float>(
-               &Control::RGBDFollower::setInitialTracking),
+      .def("set_initial_tracking", &setInitialTrackingAtPixel<DepthArrayF32>,
+           py::arg("pixel_x"), py::arg("pixel_y"),
+           py::arg("aligned_depth_image"), py::arg("detected_boxes_2d"),
+           py::arg("robot_orientation") = 0.0)
+      .def("set_initial_tracking", &setInitialTrackingBox<DepthArrayU16>,
+           py::arg("aligned_depth_image"), py::arg("target_box_2d"),
+           py::arg("robot_orientation") = 0.0)
+      .def("set_initial_tracking", &setInitialTrackingBox<DepthArrayF32>,
            py::arg("aligned_depth_image"), py::arg("target_box_2d"),
            py::arg("robot_orientation") = 0.0)
       .def("get_errors", &Control::RGBDFollower::getErrors)
@@ -359,12 +393,12 @@ void bindings_control(py::module_ &m) {
            py::overload_cast<const std::vector<Bbox3D> &,
                              const Control::Velocity2D &>(
                &Control::RGBDFollower::getTrackingCtrl),
-           py::arg("detected_boxes_3d"), py::arg("robot_velocity"))
-      .def("get_tracking_ctrl",
-           py::overload_cast<const Eigen::MatrixX<unsigned short> &,
-                             const std::vector<Bbox2D> &,
-                             const Control::Velocity2D &>(
-               &Control::RGBDFollower::getTrackingCtrl),
+           py::arg("detected_boxes_3d"), py::arg("robot_velocity"),
+           py::call_guard<py::gil_scoped_release>())
+      .def("get_tracking_ctrl", &getTrackingCtrlDepth<DepthArrayU16>,
+           py::arg("aligned_depth_image"), py::arg("detected_boxes_2d"),
+           py::arg("robot_velocity"))
+      .def("get_tracking_ctrl", &getTrackingCtrlDepth<DepthArrayF32>,
            py::arg("aligned_depth_image"), py::arg("detected_boxes_2d"),
            py::arg("robot_velocity"));
 }

--- a/src/kompass_cpp/bindings/bindings_control.cpp
+++ b/src/kompass_cpp/bindings/bindings_control.cpp
@@ -16,24 +16,6 @@
 
 using namespace Kompass;
 
-// Nx3 cartesian points (row-major so a numpy (N, 3) float32 array maps
-// zero-copy); float64 or non-contiguous input converts with one copy
-using RowMatrixX3f = Eigen::Matrix<float, Eigen::Dynamic, 3, Eigen::RowMajor>;
-
-// The Nx3 float32 buffer. For the cloud entries below to reinterpret it as a
-// Span with NO per-point build. Path::Point (Eigen::Vector3f) must stay 3
-// packed floats
-static_assert(sizeof(Path::Point) == 3 * sizeof(float),
-              "Path::Point must be 3 packed floats for the zero-copy "
-              "Span reinterpret in the cloud bindings");
-
-inline Kompass::Span<Path::Point>
-toPointSpan(const Eigen::Ref<const RowMatrixX3f> &cloud) {
-  return Kompass::Span<Path::Point>(
-      reinterpret_cast<const Path::Point *>(cloud.data()),
-      static_cast<size_t>(cloud.rows()));
-}
-
 namespace {
 // Private to file. The depth-image follower entries accept uint16 (mm) or
 // float32 (m) arrays. Templated functions with per dtype bindings below.

--- a/src/kompass_cpp/bindings/bindings_gpu.cpp
+++ b/src/kompass_cpp/bindings/bindings_gpu.cpp
@@ -30,7 +30,7 @@ void bindings_mapping_gpu(py::module_ &m) {
 
       .def(
           "scan_to_grid",
-          [](Mapping::LocalMapperGPU &self, ByteArray data, int point_step,
+          [](Mapping::LocalMapperGPU &self, const ByteArray &data, int point_step,
              int row_step, int height, int width, int x_offset, int y_offset,
              int z_offset) -> Eigen::MatrixXi & {
             py::gil_scoped_release release;
@@ -88,7 +88,7 @@ void bindings_utils_gpu(py::module_ &m) {
 
       .def(
           "check",
-          [](CriticalZoneCheckerGPU &self, ByteArray data, int point_step,
+          [](CriticalZoneCheckerGPU &self, const ByteArray &data, int point_step,
              int row_step, int height, int width, int x_offset, int y_offset,
              int z_offset, bool forward) {
             py::gil_scoped_release release;

--- a/src/kompass_cpp/bindings/bindings_gpu.cpp
+++ b/src/kompass_cpp/bindings/bindings_gpu.cpp
@@ -25,7 +25,8 @@ void bindings_mapping_gpu(py::module_ &m) {
                              Eigen::Ref<const Eigen::VectorXf>>(
                &Mapping::LocalMapperGPU::scanToGrid),
            "Convert laser scan data to occupancy grid", py::arg("angles"),
-           py::arg("ranges"), py::rv_policy::reference_internal)
+           py::arg("ranges"), py::rv_policy::reference_internal,
+           py::call_guard<py::gil_scoped_release>())
 
       .def(
           "scan_to_grid",
@@ -82,7 +83,8 @@ void bindings_utils_gpu(py::module_ &m) {
       .def("check",
            py::overload_cast<Eigen::Ref<const Eigen::VectorXf>, const bool>(
                &CriticalZoneCheckerGPU::check),
-           py::arg("ranges"), py::arg("forward"))
+           py::arg("ranges"), py::arg("forward"),
+           py::call_guard<py::gil_scoped_release>())
 
       .def(
           "check",

--- a/src/kompass_cpp/bindings/bindings_mapping.cpp
+++ b/src/kompass_cpp/bindings/bindings_mapping.cpp
@@ -43,7 +43,8 @@ void bindings_mapping(py::module_ &m) {
                              Eigen::Ref<const Eigen::VectorXf>>(
                &Mapping::LocalMapper::scanToGrid),
            "Convert laser scan data to occupancy grid", py::arg("angles"),
-           py::arg("ranges"), py::rv_policy::reference_internal)
+           py::arg("ranges"), py::rv_policy::reference_internal,
+           py::call_guard<py::gil_scoped_release>())
 
       .def(
           "scan_to_grid",
@@ -82,7 +83,8 @@ void bindings_mapping(py::module_ &m) {
                &Mapping::LocalMapper::scanToGridBayesian),
            "Convert laser scan data to occupancy grid, with bayesian update",
            py::arg("angles"), py::arg("ranges"),
-           py::rv_policy::reference_internal)
+           py::rv_policy::reference_internal,
+           py::call_guard<py::gil_scoped_release>())
 
       .def(
           "scan_to_grid_bayesian",
@@ -104,7 +106,8 @@ void bindings_mapping(py::module_ &m) {
       .def("get_previous_grid_in_current_pose",
            &Mapping::LocalMapper::getPreviousGridInCurrentPose,
            py::arg("current_position_in_previous_pose"),
-           py::arg("current_orientation_in_previous_pose"));
+           py::arg("current_orientation_in_previous_pose"),
+           py::call_guard<py::gil_scoped_release>());
 
 #if GPU
   bindings_mapping_gpu(m_mapping);

--- a/src/kompass_cpp/bindings/bindings_mapping.cpp
+++ b/src/kompass_cpp/bindings/bindings_mapping.cpp
@@ -48,7 +48,7 @@ void bindings_mapping(py::module_ &m) {
 
       .def(
           "scan_to_grid",
-          [](Mapping::LocalMapper &self, ByteArray data, int point_step,
+          [](Mapping::LocalMapper &self, const ByteArray &data, int point_step,
              int row_step, int height, int width, int x_offset, int y_offset,
              int z_offset) -> Eigen::MatrixXi & {
             py::gil_scoped_release release;
@@ -88,7 +88,7 @@ void bindings_mapping(py::module_ &m) {
 
       .def(
           "scan_to_grid_bayesian",
-          [](Mapping::LocalMapper &self, ByteArray data, int point_step,
+          [](Mapping::LocalMapper &self, const ByteArray &data, int point_step,
              int row_step, int height, int width, int x_offset, int y_offset,
              int z_offset) {
             py::gil_scoped_release release;

--- a/src/kompass_cpp/bindings/bindings_mapping.cpp
+++ b/src/kompass_cpp/bindings/bindings_mapping.cpp
@@ -9,7 +9,10 @@ using namespace Kompass;
 // Mapping bindings submodule
 void bindings_mapping(py::module_ &m) {
   auto m_mapping = m.def_submodule("mapping", "Local Mapping module");
-  py::enum_<Mapping::OccupancyType>(m_mapping, "OCCUPANCY_TYPE")
+  // is_arithmetic -> enum.IntEnum. The values are the grid-cell semantics
+  // and Python consumers use them as integers. Single source of truth
+  py::enum_<Mapping::OccupancyType>(m_mapping, "OCCUPANCY_TYPE",
+                                    py::is_arithmetic())
       .value("UNEXPLORED", Mapping::OccupancyType::UNEXPLORED)
       .value("EMPTY", Mapping::OccupancyType::EMPTY)
       .value("OCCUPIED", Mapping::OccupancyType::OCCUPIED);

--- a/src/kompass_cpp/bindings/bindings_planning.cpp
+++ b/src/kompass_cpp/bindings/bindings_planning.cpp
@@ -1,5 +1,5 @@
-#include "planning/ompl.h"
 #include "bindings.h"
+#include "planning/ompl.h"
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/vector.h>
 using namespace Kompass;
@@ -20,7 +20,8 @@ void bindings_planning(py::module_ &m) {
            py::arg("goal_x"), py::arg("goal_y"), py::arg("goal_yaw"),
            py::arg("map_3d"))
       .def("solve", &Planning::OMPL2DGeometricPlanner::solve,
-           py::arg("planning_timeout") = 1.0)
+           py::arg("planning_timeout") = 1.0,
+           py::call_guard<py::gil_scoped_release>())
       .def("get_solution", &Planning::OMPL2DGeometricPlanner::getPath)
       .def("set_space_bounds_from_map",
            &Planning::OMPL2DGeometricPlanner::setSpaceBoundsFromMap,

--- a/src/kompass_cpp/bindings/bindings_planning.cpp
+++ b/src/kompass_cpp/bindings/bindings_planning.cpp
@@ -15,10 +15,21 @@ void bindings_planning(py::module_ &m) {
                     const ompl::geometric::SimpleSetup &, const float>(),
            py::arg("robot_shape"), py::arg("robot_dimensions"),
            py::arg("ompl_setup"), py::arg("map_resolution") = 0.01)
-      .def("setup_problem", &Planning::OMPL2DGeometricPlanner::setupProblem,
-           py::arg("start_x"), py::arg("start_y"), py::arg("start_yaw"),
-           py::arg("goal_x"), py::arg("goal_y"), py::arg("goal_yaw"),
-           py::arg("map_3d"))
+      .def(
+          "setup_problem",
+          [](Planning::OMPL2DGeometricPlanner &self, const double start_x,
+             const double start_y, const double start_yaw, const double goal_x,
+             const double goal_y, const double goal_yaw,
+             Eigen::Ref<const RowMatrixX3f> map_3d) {
+            // Zero-copy reinterpret
+            const auto points = toPointSpan(map_3d);
+            py::gil_scoped_release release;
+            self.setupProblem(start_x, start_y, start_yaw, goal_x, goal_y,
+                              goal_yaw, points);
+          },
+          py::arg("start_x"), py::arg("start_y"), py::arg("start_yaw"),
+          py::arg("goal_x"), py::arg("goal_y"), py::arg("goal_yaw"),
+          py::arg("map_3d"))
       .def("solve", &Planning::OMPL2DGeometricPlanner::solve,
            py::arg("planning_timeout") = 1.0,
            py::call_guard<py::gil_scoped_release>())

--- a/src/kompass_cpp/bindings/bindings_types.cpp
+++ b/src/kompass_cpp/bindings/bindings_types.cpp
@@ -94,11 +94,11 @@ void bindings_types(py::module_ &m) {
            "Initialize from Eigen vectors", py::arg("vx"), py::arg("vy"),
            py::arg("omega"))
       .def_ro("vx", &Control::TrajectoryVelocities2D::vx,
-              py::rv_policy::reference_internal, "Speed on x-axis (m/s)")
+              "Speed on x-axis (m/s)")
       .def_ro("vy", &Control::TrajectoryVelocities2D::vy,
-              py::rv_policy::reference_internal, "Speed on y-axis (m/s)")
+              "Speed on y-axis (m/s)")
       .def_ro("omega", &Control::TrajectoryVelocities2D::omega,
-              py::rv_policy::reference_internal, "Angular velocity (rad/s)")
+              "Angular velocity (rad/s)")
       // Exposes 'length' as (numPointsPerTrajectory_ - 1)
       .def_prop_rw(
           "length",
@@ -117,12 +117,9 @@ void bindings_types(py::module_ &m) {
 
   py::class_<Control::TrajectoryPath>(m_types, "TrajectoryPath")
       .def(py::init<>())
-      .def_ro("x", &Control::TrajectoryPath::x,
-              py::rv_policy::reference_internal)
-      .def_ro("y", &Control::TrajectoryPath::y,
-              py::rv_policy::reference_internal)
-      .def_ro("z", &Control::TrajectoryPath::z,
-              py::rv_policy::reference_internal);
+      .def_ro("x", &Control::TrajectoryPath::x)
+      .def_ro("y", &Control::TrajectoryPath::y)
+      .def_ro("z", &Control::TrajectoryPath::z);
 
   py::class_<Control::Trajectory2D>(m_types, "Trajectory")
       .def(py::init<>())

--- a/src/kompass_cpp/bindings/bindings_utils.cpp
+++ b/src/kompass_cpp/bindings/bindings_utils.cpp
@@ -12,7 +12,13 @@ using namespace Kompass;
 
 py::ndarray<py::numpy, float, py::shape<-1, 3>, py::c_contig>
 read_pcd_py(const std::string &filename) {
-  auto result = readPCD(filename);
+  // NOTE: The capsule/ndarray construction below is Python C-API and needs the
+  // GIL (a call_guard on the def would segfault)
+  auto result = [&] {
+    // File I/O + parse without the GIL.
+    py::gil_scoped_release release;
+    return readPCD(filename);
+  }();
 
   if (!result) {
     throw std::runtime_error("Failed to read PCD file: " + filename);
@@ -36,7 +42,6 @@ read_pcd_py(const std::string &filename) {
 
   return arr;
 }
-
 
 // Utils submodule
 void bindings_utils(py::module_ &m) {
@@ -62,7 +67,8 @@ void bindings_utils(py::module_ &m) {
       .def("check",
            py::overload_cast<Eigen::Ref<const Eigen::VectorXf>, const bool>(
                &CriticalZoneChecker::check),
-           py::arg("ranges"), py::arg("forward"))
+           py::arg("ranges"), py::arg("forward"),
+           py::call_guard<py::gil_scoped_release>())
 
       .def(
           "check",
@@ -70,8 +76,8 @@ void bindings_utils(py::module_ &m) {
              int row_step, int height, int width, int x_offset, int y_offset,
              int z_offset, bool forward) {
             py::gil_scoped_release release;
-            return self.check(toSpan(data), point_step, row_step, height,
-                              width, x_offset, y_offset, z_offset, forward);
+            return self.check(toSpan(data), point_step, row_step, height, width,
+                              x_offset, y_offset, z_offset, forward);
           },
           py::arg("data"), py::arg("point_step"), py::arg("row_step"),
           py::arg("height"), py::arg("width"), py::arg("x_offset"),
@@ -171,6 +177,7 @@ void bindings_utils(py::module_ &m) {
   m_utils.def("read_pcd_to_occupancy_grid", &readPCDToOccupancyGrid,
               py::arg("filename"), py::arg("grid_resolution"),
               py::arg("z_ground_limit"), py::arg("robot_height"),
+              py::call_guard<py::gil_scoped_release>(),
               "Convert PCD file to an occupancy grid (zero-copy return).");
 
 #if GPU

--- a/src/kompass_cpp/bindings/bindings_utils.cpp
+++ b/src/kompass_cpp/bindings/bindings_utils.cpp
@@ -72,7 +72,7 @@ void bindings_utils(py::module_ &m) {
 
       .def(
           "check",
-          [](CriticalZoneChecker &self, ByteArray data, int point_step,
+          [](CriticalZoneChecker &self, const ByteArray &data, int point_step,
              int row_step, int height, int width, int x_offset, int y_offset,
              int z_offset, bool forward) {
             py::gil_scoped_release release;
@@ -106,7 +106,7 @@ void bindings_utils(py::module_ &m) {
   // numpy arrays)
   m_utils.def(
       "pointcloud_to_laserscan_from_raw",
-      [](ByteArray data, int point_step, int row_step, int height, int width,
+      [](const ByteArray &data, int point_step, int row_step, int height, int width,
          int x_offset, int y_offset, int z_offset, double max_range,
          double min_z, double max_z, double angle_step,
          const Eigen::Vector3f &position, const Eigen::Vector4f &rotation,
@@ -140,7 +140,7 @@ void bindings_utils(py::module_ &m) {
   // Overload using num_bins (Returns: ranges as a float32 numpy array)
   m_utils.def(
       "pointcloud_to_laserscan_from_raw",
-      [](ByteArray data, int point_step, int row_step, int height, int width,
+      [](const ByteArray &data, int point_step, int row_step, int height, int width,
          int x_offset, int y_offset, int z_offset, double max_range,
          double min_z, double max_z, int num_bins,
          const Eigen::Vector3f &position, const Eigen::Vector4f &rotation,

--- a/src/kompass_cpp/bindings/bindings_vision.cpp
+++ b/src/kompass_cpp/bindings/bindings_vision.cpp
@@ -9,6 +9,44 @@
 
 using namespace Kompass;
 
+namespace {
+// Private to file
+
+inline Path::State makeState(const float x, const float y, const float yaw,
+                             const float speed) {
+  Path::State state;
+  state.x = x;
+  state.y = y;
+  state.yaw = yaw;
+  state.speed = speed;
+  return state;
+}
+
+// The depth image accepts uint16 (mm) or float32 (m) arrays and the input is
+// either 2D boxes or a PointsOfInterest set. The detection pass runs without
+// the GIL
+template <typename DepthArray, typename InputT>
+std::vector<Bbox3D>
+compute3dDetections(DepthDetector &self, const DepthArray &depth_img,
+                    const InputT &input, float robot_x, float robot_y,
+                    float robot_yaw, float robot_speed) {
+  const auto view = toDepthView(depth_img);
+  const auto state = makeState(robot_x, robot_y, robot_yaw, robot_speed);
+  std::vector<Bbox3D> out;
+  {
+    py::gil_scoped_release release;
+    if constexpr (std::is_same_v<InputT, PointsOfInterest>) {
+      self.updatePOIs(view, input, state);
+    } else {
+      self.updateBoxes(view, input, state);
+    }
+    out = self.get3dDetections();
+  }
+  return out;
+}
+
+} // namespace
+
 void bindings_vision(py::module_ &m) {
   auto m_vision = m.def_submodule("vision", "Vision and Detection module");
 
@@ -39,42 +77,23 @@ void bindings_vision(py::module_ &m) {
           "Initialize with camera translation and rotation (Vector4f as [x, y, "
           "z, w]).")
 
-      // --- Converter Function ---
-      .def(
-          "compute_3d_detections",
-          [](DepthDetector &self,
-             const Eigen::MatrixX<unsigned short> &depth_img,
-             const std::vector<Bbox2D> &input, float robot_x, float robot_y,
-             float robot_yaw, float robot_speed) {
-            Path::State state;
-            state.x = robot_x;
-            state.y = robot_y;
-            state.yaw = robot_yaw;
-            state.speed = robot_speed;
-
-            self.updateBoxes(depth_img, input,
-                             std::optional<Path::State>(state));
-            return self.get3dDetections();
-          },
-          py::arg("depth_img"), py::arg("input"), py::arg("robot_x"),
-          py::arg("robot_y"), py::arg("robot_yaw"), py::arg("robot_speed"))
-
-      .def(
-          "compute_3d_detections",
-          [](DepthDetector &self,
-             const Eigen::MatrixX<unsigned short> &depth_img,
-             const PointsOfInterest &input, float robot_x,
-             float robot_y, float robot_yaw, float robot_speed) {
-            Path::State state;
-            state.x = robot_x;
-            state.y = robot_y;
-            state.yaw = robot_yaw;
-            state.speed = robot_speed;
-
-            self.updatePOIs(depth_img, input,
-                            std::optional<Path::State>(state));
-            return self.get3dDetections();
-          },
-          py::arg("depth_img"), py::arg("input"), py::arg("robot_x"),
-          py::arg("robot_y"), py::arg("robot_yaw"), py::arg("robot_speed"));
+      // --- Converter Functions ---
+      // Zero-copy depth view (uint16 mm / float32 m, C-contiguous); one
+      // typed overload per dtype x input kind, all sharing one template
+      .def("compute_3d_detections",
+           &compute3dDetections<DepthArrayU16, std::vector<Bbox2D>>,
+           py::arg("depth_img"), py::arg("input"), py::arg("robot_x"),
+           py::arg("robot_y"), py::arg("robot_yaw"), py::arg("robot_speed"))
+      .def("compute_3d_detections",
+           &compute3dDetections<DepthArrayF32, std::vector<Bbox2D>>,
+           py::arg("depth_img"), py::arg("input"), py::arg("robot_x"),
+           py::arg("robot_y"), py::arg("robot_yaw"), py::arg("robot_speed"))
+      .def("compute_3d_detections",
+           &compute3dDetections<DepthArrayU16, PointsOfInterest>,
+           py::arg("depth_img"), py::arg("input"), py::arg("robot_x"),
+           py::arg("robot_y"), py::arg("robot_yaw"), py::arg("robot_speed"))
+      .def("compute_3d_detections",
+           &compute3dDetections<DepthArrayF32, PointsOfInterest>,
+           py::arg("depth_img"), py::arg("input"), py::arg("robot_x"),
+           py::arg("robot_y"), py::arg("robot_yaw"), py::arg("robot_speed"));
 }

--- a/src/kompass_cpp/bindings/bindings_vision.cpp
+++ b/src/kompass_cpp/bindings/bindings_vision.cpp
@@ -50,6 +50,14 @@ compute3dDetections(DepthDetector &self, const DepthArray &depth_img,
 void bindings_vision(py::module_ &m) {
   auto m_vision = m.def_submodule("vision", "Vision and Detection module");
 
+  py::enum_<DepthDetector::CameraFrameConvention>(m_vision,
+                                                  "CameraFrameConvention")
+      .value("OPTICAL", DepthDetector::CameraFrameConvention::Optical,
+             "x right, y down, z into the image (REP 103 optical). What ROS "
+             "Image/CameraInfo headers name and TF resolves.")
+      .value("BODY_ALIGNED", DepthDetector::CameraFrameConvention::BodyAligned,
+             "x forward, y left, z up (REP 103 body).");
+
   py::class_<DepthDetector>(m_vision, "DepthDetector")
       // --- Constructor ---
       .def(
@@ -59,7 +67,8 @@ void bindings_vision(py::module_ &m) {
              const Eigen::Vector4f &camera_in_body_rotation,
              const Eigen::Vector2f &focal_length,
              const Eigen::Vector2f &principal_point,
-             const float depth_conversion_factor) {
+             const float depth_conversion_factor,
+             const DepthDetector::CameraFrameConvention convention) {
             // Map Vector4f [x, y, z, w] to Eigen::Quaternionf (w, x, y, z)
             Eigen::Quaternionf quat(camera_in_body_rotation(3),  // w
                                     camera_in_body_rotation(0),  // x
@@ -69,13 +78,16 @@ void bindings_vision(py::module_ &m) {
             // Placement new to initialize the Python object
             new (t) DepthDetector(depth_range, camera_in_body_translation, quat,
                                   focal_length, principal_point,
-                                  depth_conversion_factor);
+                                  depth_conversion_factor, convention);
           },
           py::arg("depth_range"), py::arg("camera_in_body_translation"),
           py::arg("camera_in_body_rotation"), py::arg("focal_length"),
           py::arg("principal_point"), py::arg("depth_conversion_factor") = 1e-3,
+          py::arg("convention") = DepthDetector::CameraFrameConvention::Optical,
           "Initialize with camera translation and rotation (Vector4f as [x, y, "
-          "z, w]).")
+          "z, w]). The pose is read in the optical convention by default, "
+          "which is what a ROS TF lookup against an Image/CameraInfo frame_id "
+          "gives; pass BODY_ALIGNED for a pose already in robot axes.")
 
       // --- Converter Functions ---
       // Zero-copy depth view (uint16 mm / float32 m, C-contiguous); one

--- a/src/kompass_cpp/kompass_cpp/include/controllers/follower.h
+++ b/src/kompass_cpp/kompass_cpp/include/controllers/follower.h
@@ -60,7 +60,7 @@ public:
       // derivation.
       addParameter("curvature_horizon_tolerance",
                    Parameter(1.5, 0.5, 1000.0)); // [m] max chord-arc
-                                                   // deviation on curved paths
+                                                 // deviation on curved paths
     }
   };
 
@@ -158,7 +158,7 @@ public:
     return currentPath->totalPathLength() > 0.0;
   }
 
-  const Path::Path getCurrentPath() const;
+  const Path::Path &getCurrentPath() const;
 
   /**
    * @brief Calculates an exponential speed factor [0, 1] based on path

--- a/src/kompass_cpp/kompass_cpp/include/controllers/rgb_follower.h
+++ b/src/kompass_cpp/kompass_cpp/include/controllers/rgb_follower.h
@@ -74,9 +74,9 @@ public:
 
   void resetTarget(const Bbox2D &tracking);
 
-  bool run(const std::optional<Bbox2D> tracking);
+  bool run(const std::optional<Bbox2D> &tracking);
 
-  const TrajectoryVelocities2D getCtrl() const;
+  const TrajectoryVelocities2D &getCtrl() const;
 
   Eigen::Vector2f getErrors() const {
     return Eigen::Vector2f(dist_error_, orientation_error_);
@@ -99,6 +99,9 @@ protected:
 private:
   RGBFollowerConfig config_;
   TrajectoryVelocities2D out_vel_;
+  // Search/wait outputs built once at construction and reused every tick
+  TrajectoryVelocities2D search_vel_;
+  TrajectoryVelocities2D wait_vel_;
 
   void trackTarget(const Bbox2D &tracking);
   //

--- a/src/kompass_cpp/kompass_cpp/include/controllers/rgb_follower.h
+++ b/src/kompass_cpp/kompass_cpp/include/controllers/rgb_follower.h
@@ -4,7 +4,6 @@
 #include "datatypes/parameter.h"
 #include "datatypes/tracking.h"
 #include "datatypes/trajectory.h"
-#include <memory>
 #include <optional>
 #include <queue>
 
@@ -88,7 +87,9 @@ protected:
   double recorded_search_time_ = 0.0, recorded_wait_time_ = 0.0;
   std::queue<Eigen::Vector3d> search_commands_queue_;
   Eigen::Vector3d search_command_;
-  std::unique_ptr<Bbox2D> last_tracking_ = nullptr;
+  // Last seen tracking
+  Bbox2D last_tracking_;
+  bool has_last_tracking_ = false;
   float dist_error_ = 0.0f, orientation_error_ = 0.0f;
 
   void generateSearchCommands(float total_rotation, float search_radius,

--- a/src/kompass_cpp/kompass_cpp/include/controllers/rgbd_follower.h
+++ b/src/kompass_cpp/kompass_cpp/include/controllers/rgbd_follower.h
@@ -140,8 +140,13 @@ public:
     return this->getTrackingCtrl(tracked_pose, current_vel);
   };
 
+  /**
+   * Depth-image variant. The image crosses as a non-owning zero-copy view
+   * (UINT16 millimetres or FLOAT32 metres, row-major) and is only read for
+   * the duration of the call.
+   */
   Control::TrajSearchResult
-  getTrackingCtrl(const Eigen::MatrixX<unsigned short> &aligned_depth_img,
+  getTrackingCtrl(const DepthImageView &aligned_depth_img,
                   const std::vector<Bbox2D> &detected_boxes_2d,
                   const Velocity2D &current_vel) {
     if (!detector_) {
@@ -163,10 +168,10 @@ public:
       } else {
         detector_->updateBoxes(aligned_depth_img, detected_boxes_2d);
       }
-      auto boxes_3d = detector_->get3dDetections();
-      if (boxes_3d) {
+      const auto &boxes_3d = detector_->get3dDetections();
+      if (!boxes_3d.empty()) {
         // Update the tracker with the detected boxes
-        bool tracking_updated = tracker_->updateTracking(boxes_3d.value());
+        bool tracking_updated = tracker_->updateTracking(boxes_3d);
         if (!tracking_updated) {
           LOG_WARNING(
               "Tracker failed to update target with the detected boxes");
@@ -204,15 +209,13 @@ public:
    * @return true
    * @return false
    */
-  bool
-  setInitialTracking(const int pose_x_img, const int pose_y_img,
-                     const Eigen::MatrixX<unsigned short> &aligned_depth_image,
-                     const std::vector<Bbox2D> &detected_boxes_2d,
-                     const float yaw = 0.0);
+  bool setInitialTracking(const int pose_x_img, const int pose_y_img,
+                          const DepthImageView &aligned_depth_image,
+                          const std::vector<Bbox2D> &detected_boxes_2d,
+                          const float yaw = 0.0);
 
-  bool
-  setInitialTracking(const Eigen::MatrixX<unsigned short> &aligned_depth_image,
-                     const Bbox2D &target_box_2d, const float yaw = 0.0);
+  bool setInitialTracking(const DepthImageView &aligned_depth_image,
+                          const Bbox2D &target_box_2d, const float yaw = 0.0);
 
   Eigen::Vector2f getErrors() const {
     return Eigen::Vector2f(dist_error_, orientation_error_);

--- a/src/kompass_cpp/kompass_cpp/include/datatypes/sensors.h
+++ b/src/kompass_cpp/kompass_cpp/include/datatypes/sensors.h
@@ -139,6 +139,43 @@ struct PointCloudView {
 };
 
 /**
+ * @brief Non-owning view of an aligned depth image: a C-contiguous
+ * ROW-MAJOR (rows x cols) pixel buffer plus its encoding. Expected encodings:
+ * UINT16 (depth in millimetres, ROS 16UC1) and FLOAT32 (depth in metres, ROS
+ * 32FC1); the consumer resolves the value scale from the encoding.
+ */
+struct DepthImageView {
+  ByteSpan data{};
+  int rows = 0;
+  int cols = 0;
+  PointFieldType field_type = PointFieldType::UINT16;
+
+  DepthImageView() = default;
+  DepthImageView(ByteSpan data, const int rows, const int cols,
+                 const PointFieldType field_type = PointFieldType::UINT16)
+      : data(data), rows(rows), cols(cols), field_type(field_type),
+        elem_size_(elementSizeOf(field_type)) {}
+
+  bool empty() const { return rows <= 0 || cols <= 0 || data.size() == 0; }
+
+  /// The buffer must hold at least rows * cols pixels of the declared type
+  bool sizeValid() const {
+    return data.size() >= static_cast<std::size_t>(rows) * cols * elem_size_;
+  }
+
+  /// Raw pixel value at (row, col), cast to float. Bounds are upto the caller
+  /// to set
+  float at(const int row, const int col) const {
+    return load_and_cast_val(
+        data.data(), (static_cast<std::size_t>(row) * cols + col) * elem_size_,
+        field_type);
+  }
+
+private:
+  int elem_size_ = 2; // elementSizeOf(field_type), hoisted at construction
+};
+
+/**
  * Shared prologue of every batched cloud call. The batch must hold exactly one
  * view per configured sensor (positional pairing), and every non-empty view
  * must carry valid offsets.

--- a/src/kompass_cpp/kompass_cpp/include/datatypes/span.h
+++ b/src/kompass_cpp/kompass_cpp/include/datatypes/span.h
@@ -21,6 +21,9 @@ public:
   constexpr size_t size() const { return size_; }
   constexpr bool empty() const { return size_ == 0; }
   constexpr const T &operator[](size_t i) const { return data_[i]; }
+  // Iterators so a Span works in range-for and templated consumers
+  constexpr const T *begin() const { return data_; }
+  constexpr const T *end() const { return data_ + size_; }
 
 private:
   const T *data_ = nullptr;

--- a/src/kompass_cpp/kompass_cpp/include/datatypes/tracking.h
+++ b/src/kompass_cpp/kompass_cpp/include/datatypes/tracking.h
@@ -62,10 +62,6 @@ struct Bbox2D {
 
   Bbox2D() {};
 
-  Bbox2D(const Bbox2D &box)
-      : top_corner(box.top_corner), size(box.size), timestamp(box.timestamp),
-        label(box.label), img_size(box.img_size) {};
-
   Bbox2D(const Eigen::Vector2i top_corner, const Eigen::Vector2i size,
          const float timestamp = 0.0, const std::string &label = "",
          const Eigen::Vector2i img_size = {640, 480})
@@ -152,12 +148,6 @@ struct Bbox3D {
   std::string label = "";
 
   Bbox3D() {};
-
-  Bbox3D(const Bbox3D &box)
-      : center(box.center), size(box.size),
-        center_img_frame(box.center_img_frame),
-        size_img_frame(box.size_img_frame), pc_points(box.pc_points),
-        timestamp(box.timestamp), label(box.label) {};
 
   Bbox3D(const Eigen::Vector3f &center, const Eigen::Vector3f &size,
          const Eigen::Vector2i center_img_frame,

--- a/src/kompass_cpp/kompass_cpp/include/datatypes/tracking.h
+++ b/src/kompass_cpp/kompass_cpp/include/datatypes/tracking.h
@@ -19,10 +19,6 @@ struct PointsOfInterest {
 
   PointsOfInterest() {};
 
-  PointsOfInterest(const PointsOfInterest &poi)
-      : Points2D(poi.Points2D), timestamp(poi.timestamp), label(poi.label),
-        img_size(poi.img_size), vel(poi.vel) {};
-
   PointsOfInterest(const std::vector<Eigen::Vector2i> &points,
                    const Eigen::Vector2i &img_size = {640, 480},
                    const float timestamp = 0.0, const std::string &label = "")

--- a/src/kompass_cpp/kompass_cpp/include/planning/ompl.h
+++ b/src/kompass_cpp/kompass_cpp/include/planning/ompl.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "datatypes/span.h"
 #include "utils/collision_check.h"
 #include <fcl/fcl.h>
 #include <ompl/base/Cost.h>
@@ -32,11 +33,11 @@ public:
    * @param goal_x
    * @param goal_y
    * @param goal_yaw
-   * @param map_3d
+   * @param map_3d Map PointCloud in the world frame.
    */
   void setupProblem(double start_x, double start_y, double start_yaw,
                     double goal_x, double goal_y, double goal_yaw,
-                    const std::vector<Eigen::Vector3f> &map_3d);
+                    Span<Path::Point> map_3d);
   /**
    * @brief Solve the planning problem
    *

--- a/src/kompass_cpp/kompass_cpp/include/utils/collision_check.h
+++ b/src/kompass_cpp/kompass_cpp/include/utils/collision_check.h
@@ -160,7 +160,7 @@ public:
         }
       }
     }
-    // -- CASE 2: PointCloud Input (Vector of Points, world frame) --
+    // -- CASE 2: PointCloud Input (Span of Points, world frame) --
     else {
       // Already world coordinates -> the octree needs no further placement
       sensor_tf_world_ = Eigen::Isometry3f::Identity();

--- a/src/kompass_cpp/kompass_cpp/include/utils/cost_evaluator.h
+++ b/src/kompass_cpp/kompass_cpp/include/utils/cost_evaluator.h
@@ -3,6 +3,7 @@
 #include "datatypes/control.h"
 #include "datatypes/parameter.h"
 #include "datatypes/path.h"
+#include "datatypes/span.h"
 #include "datatypes/trajectory.h"
 #include "utils/transformation.h"
 #include <array>
@@ -208,7 +209,7 @@ public:
    * @param max_sensor_range                  Sensor's max valid range [m].
    * @param max_obstacle_cost_range_multiple  See the LaserScan overload.
    */
-  void setPointScan(const std::vector<Path::Point> &cloud,
+  void setPointScan(Span<Path::Point> cloud,
                     [[maybe_unused]] const Path::State &current_state,
                     const float max_sensor_range,
                     const float max_obstacle_cost_range_multiple = 3.0) {
@@ -216,7 +217,7 @@ public:
     obstaclePointsY.clear();
     maxObstaclesDist = max_sensor_range / max_obstacle_cost_range_multiple;
 
-    for (auto &point : cloud) {
+    for (const auto &point : cloud) {
       obstaclePointsX.emplace_back(point.x());
       obstaclePointsY.emplace_back(point.y());
     }

--- a/src/kompass_cpp/kompass_cpp/include/utils/trajectory_sampler.h
+++ b/src/kompass_cpp/kompass_cpp/include/utils/trajectory_sampler.h
@@ -4,6 +4,7 @@
 #include "datatypes/control.h"
 #include "datatypes/parameter.h"
 #include "datatypes/path.h"
+#include "datatypes/span.h"
 #include "datatypes/trajectory.h"
 #include "threadpool.h"
 #include <cmath>
@@ -118,7 +119,7 @@ public:
   std::unique_ptr<TrajectorySamples2D>
   generateTrajectories(const Velocity2D &current_vel,
                        const Path::State &current_pose,
-                       const std::vector<Path::Point> &cloud);
+                       Span<Path::Point> cloud);
 
   /**
    * @brief Reset the resolution of the obstacles Octree
@@ -163,8 +164,9 @@ protected:
 
 private:
   double time_step_{0.0};
-  double max_time_{0.0};       // current (possibly per-cycle-adapted) rollout horizon
-  double base_max_time_{0.0};  // constructor-provided upper bound; setter clamps to this
+  double max_time_{0.0}; // current (possibly per-cycle-adapted) rollout horizon
+  double base_max_time_{
+      0.0}; // constructor-provided upper bound; setter clamps to this
   double control_time_{0.0};
   int lin_samples_max_;
   int lin_samples_x_; // split of lin_samples_max_ used for the vx axis

--- a/src/kompass_cpp/kompass_cpp/include/vision/depth_detector.h
+++ b/src/kompass_cpp/kompass_cpp/include/vision/depth_detector.h
@@ -22,10 +22,10 @@
 #pragma once
 
 #include "datatypes/path.h"
+#include "datatypes/sensors.h"
 #include "datatypes/tracking.h"
 #include <Eigen/Dense>
 #include <Eigen/src/Geometry/Transform.h>
-#include <memory>
 #include <optional>
 #include <vector>
 
@@ -46,27 +46,35 @@ public:
                 const Eigen::Vector2f &principal_point,
                 const float depth_conversion_factor = 1e-3);
 
+  /**
+   * NOTE: Non owning zero-copy view of the depth image. UINT16 pixels are
+   * scaled by the configured depth_conversion_factor (mm -> m by default);
+   * FLOAT32 pixels are taken as metres. Non-finite pixels are rejected by the
+   * min/max range gate.
+   */
   void
-  updateBoxes(const Eigen::MatrixX<unsigned short> &aligned_depth_img,
+  updateBoxes(const DepthImageView &aligned_depth_img,
               const std::vector<Bbox2D> &detections,
               const std::optional<Path::State> &robot_state = std::nullopt);
 
-  void updatePOIs(const Eigen::MatrixX<unsigned short> &aligned_depth_img,
+  void updatePOIs(const DepthImageView &aligned_depth_img,
                   const PointsOfInterest &pois,
                   const std::optional<Path::State> &robot_state = std::nullopt);
 
-  std::optional<std::vector<Bbox3D>> get3dDetections() const;
+  /// Result of the last update; empty when no box converted.
+  const std::vector<Bbox3D> &get3dDetections() const { return boxes_; }
 
 private:
   float cx_, cy_, fx_, fy_; // Depth Image camera intrinsics
   float minDepth_, maxDepth_, depthConversionFactor_;
-  Eigen::MatrixX<unsigned short> alignedDepthImg_;
   Eigen::Isometry3f camera_in_body_tf_, body_in_world_tf_;
-  std::unique_ptr<std::vector<Bbox3D>> boxes_;
+  std::vector<Bbox3D> boxes_;
 
-  std::optional<Bbox3D> convert2Dboxto3Dbox(const Bbox2D &box2d);
+  std::optional<Bbox3D> convert2Dboxto3Dbox(const DepthImageView &depth,
+                                            const Bbox2D &box2d);
 
-  std::optional<Bbox3D> convertPOIto3Dbox(const PointsOfInterest &poi);
+  std::optional<Bbox3D> convertPOIto3Dbox(const DepthImageView &depth,
+                                          const PointsOfInterest &poi);
 
   static void calculateMAD(const std::vector<float> &depthValues, float &median,
                            float &mad);

--- a/src/kompass_cpp/kompass_cpp/include/vision/depth_detector.h
+++ b/src/kompass_cpp/kompass_cpp/include/vision/depth_detector.h
@@ -33,18 +33,43 @@ namespace Kompass {
 
 class DepthDetector {
 public:
+  /**
+   * @brief Axis convention the camera pose handed to the constructor is
+   * expressed in.
+   *
+   * ROS names a camera's optical frame in the header of every Image and
+   * CameraInfo message, and that is the frame TF can resolve, so `Optical` is
+   * the default: a pose looked up straight out of the ROS graph is correct
+   * with no further handling. `BodyAligned` is for callers that have already
+   * turned the pose into robot axes themselves.
+   *
+   * The two differ by the fixed REP 103 quarter rotation, so passing the wrong
+   * one puts every detection 90 degrees off.
+   */
+  enum class CameraFrameConvention {
+    Optical,    ///< x right, y down, z into the image (REP 103 optical)
+    BodyAligned ///< x forward, y left, z up (REP 103 body)
+  };
+
   DepthDetector(const Eigen::Vector2f &depth_range,
                 const Eigen::Vector3f &camera_in_body_translation,
                 const Eigen::Quaternionf &camera_in_body_rotation,
                 const Eigen::Vector2f &focal_length,
                 const Eigen::Vector2f &principal_point,
-                const float depth_conversion_factor = 1e-3);
+                const float depth_conversion_factor = 1e-3,
+                const CameraFrameConvention convention =
+                    CameraFrameConvention::Optical);
 
   DepthDetector(const Eigen::Vector2f &depth_range,
                 const Eigen::Isometry3f &camera_in_body_tf,
                 const Eigen::Vector2f &focal_length,
                 const Eigen::Vector2f &principal_point,
-                const float depth_conversion_factor = 1e-3);
+                const float depth_conversion_factor = 1e-3,
+                const CameraFrameConvention convention =
+                    CameraFrameConvention::Optical);
+
+  /// REP 103 rotation taking optical axes to body-aligned ones.
+  static const Eigen::Quaternionf &opticalToBodyAligned();
 
   /**
    * NOTE: Non owning zero-copy view of the depth image. UINT16 pixels are

--- a/src/kompass_cpp/kompass_cpp/include/vision/depth_detector.h
+++ b/src/kompass_cpp/kompass_cpp/include/vision/depth_detector.h
@@ -70,16 +70,22 @@ private:
   Eigen::Isometry3f camera_in_body_tf_, body_in_world_tf_;
   std::vector<Bbox3D> boxes_;
 
+  // Per-box scratch, refilled for every converted box. Keep the
+  // allocated capacity, so it grows to the largest box seen.
+  std::vector<float> depth_values_; // in-range depth values (metres)
+  std::vector<float> mad_scratch_; // absolute deviations from the median
+
   std::optional<Bbox3D> convert2Dboxto3Dbox(const DepthImageView &depth,
                                             const Bbox2D &box2d);
 
   std::optional<Bbox3D> convertPOIto3Dbox(const DepthImageView &depth,
                                           const PointsOfInterest &poi);
 
-  static void calculateMAD(const std::vector<float> &depthValues, float &median,
-                           float &mad);
+  void calculateMAD(std::vector<float> &depthValues, float &median, float &mad);
 
-  static float getMedian(const std::vector<float> &values);
+  /// Median via nth_element selection (O(n)).
+  /// for even n the result averages the two middle order statistics
+  static float getMedian(std::vector<float> &values);
 };
 
 } // namespace Kompass

--- a/src/kompass_cpp/kompass_cpp/include/vision/tracker.h
+++ b/src/kompass_cpp/kompass_cpp/include/vision/tracker.h
@@ -31,7 +31,9 @@ public:
 
   bool updateTracking(const std::vector<Bbox3D> &detected_boxes);
 
-  std::optional<TrackedBbox3D> getRawTracking() const;
+  /// Non-owning view of the raw tracked box (nullptr when uninitialized).
+  /// Valid until the next setInitialTracking call
+  const TrackedBbox3D *getRawTracking() const { return trackedBox_.get(); }
 
   std::optional<Eigen::MatrixXf> getTrackedState() const;
 
@@ -42,6 +44,9 @@ private:
   std::string trackedLabel_;
   std::unique_ptr<TrackedBbox3D> trackedBox_;
   std::unique_ptr<LinearSSKalmanFilter> stateKalmanFilter_;
+  // Kalman measurement scratch. Fixed Size: StateSize x 1, set once
+  // in the ctor and never resized.
+  Eigen::MatrixXf measurement_;
 
   FeaturesVector extractFeatures(const TrackedBbox3D &bBox) const;
 

--- a/src/kompass_cpp/kompass_cpp/src/controllers/follower.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/controllers/follower.cpp
@@ -62,7 +62,7 @@ Follower::Target Follower::getTrackedTarget() const {
   return *currentTrackedTarget_;
 }
 
-const Path::Path Follower::getCurrentPath() const { return *currentPath; }
+const Path::Path &Follower::getCurrentPath() const { return *currentPath; }
 
 void Follower::clearCurrentPath() {
   // Delete old current path before setting new values

--- a/src/kompass_cpp/kompass_cpp/src/controllers/rgb_follower.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/controllers/rgb_follower.cpp
@@ -17,6 +17,10 @@ RGBFollower::RGBFollower(const ControlType robotCtrlType,
   config_ = config;
   rotate_in_place_ = (robotCtrlType == ControlType::DIFFERENTIAL_DRIVE ||
                        robotCtrlType == ControlType::OMNI);
+  // Reusable search/wait outputs (getCtrl must not allocate per tick)
+  search_vel_ = TrajectoryVelocities2D(2);
+  wait_vel_ = TrajectoryVelocities2D(2);
+  wait_vel_.add(0, 0.0, 0.0, 0.0);
 }
 
 void RGBFollower::resetTarget(const Bbox2D &target) {
@@ -98,7 +102,7 @@ void RGBFollower::getFindTargetCmds(const int last_direction) {
                          target_searchtimeout_part);
 }
 
-bool RGBFollower::run(const std::optional<Bbox2D> target) {
+bool RGBFollower::run(const std::optional<Bbox2D> &target) {
   // Check if tracking has a value
   if (target.has_value()) {
     // clear all
@@ -126,6 +130,9 @@ bool RGBFollower::run(const std::optional<Bbox2D> target) {
       }
       search_command_ = search_commands_queue_.front();
       search_commands_queue_.pop();
+      // Write the command into the reusable output for getCtrl()
+      search_vel_.add(0, search_command_.x(), search_command_.y(),
+                      search_command_.z());
       recorded_search_time_ += config_.control_time_step();
       return true;
     } else {
@@ -221,26 +228,20 @@ void RGBFollower::trackTarget(const Bbox2D &target) {
   return;
 }
 
-const TrajectoryVelocities2D RGBFollower::getCtrl() const {
+const TrajectoryVelocities2D &RGBFollower::getCtrl() const {
   if (recorded_search_time_ <= 0.0 && recorded_wait_time_ <= 0.0) {
     return out_vel_;
   }
-  // If search is on
+  // If search is on (search_vel_ was filled in run())
   else if (recorded_search_time_ > 0.0) {
-    TrajectoryVelocities2D _search(2);
     LOG_DEBUG(
         "Number of search commands remaining: ", search_commands_queue_.size(),
         "recorded search time: ", recorded_search_time_);
-    _search.add(0, search_command_.x(), search_command_.y(),
-                search_command_.z());
-    return _search;
+    return search_vel_;
   }
   // If search not active -> wait till timeout
   else {
-    // send 0.0 to wait
-    TrajectoryVelocities2D _wait(2);
-    _wait.add(0, 0.0, 0.0, 0.0);
-    return _wait;
+    return wait_vel_;
   }
 }
 

--- a/src/kompass_cpp/kompass_cpp/src/controllers/rgb_follower.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/controllers/rgb_follower.cpp
@@ -5,7 +5,6 @@
 #include "utils/logger.h"
 #include <algorithm>
 #include <cmath>
-#include <memory>
 
 namespace Kompass {
 namespace Control {
@@ -110,7 +109,8 @@ bool RGBFollower::run(const std::optional<Bbox2D> &target) {
     recorded_search_time_ = 0.0;
     // Access the TrackingData object
     const auto &data = target.value();
-    last_tracking_ = std::make_unique<Bbox2D>(data);
+    last_tracking_ = data;
+    has_last_tracking_ = true;
     // Track the target
     trackTarget(data);
     return true;
@@ -120,11 +120,11 @@ bool RGBFollower::run(const std::optional<Bbox2D> &target) {
     if (recorded_search_time_ < config_.target_search_timeout()) {
       if (search_commands_queue_.empty()) {
         int last_direction = 1;
-        if (last_tracking_ != nullptr) {
-          auto last_center = last_tracking_->getCenter();
+        if (has_last_tracking_) {
+          auto last_center = last_tracking_.getCenter();
           last_direction =
               ((last_center.x() - last_center.y() / 2.0) > 0.0) ? 1 : -1;
-          last_tracking_ = nullptr;
+          has_last_tracking_ = false;
         }
         getFindTargetCmds(last_direction);
       }
@@ -143,7 +143,7 @@ bool RGBFollower::run(const std::optional<Bbox2D> &target) {
   } else {
     if (recorded_wait_time_ < config_.target_wait_timeout()) {
       LOG_DEBUG("Target lost, waiting to get tracked target again ...");
-      last_tracking_ = nullptr;
+      has_last_tracking_ = false;
       // Do nothing and wait
       recorded_wait_time_ += config_.control_time_step();
       return true;

--- a/src/kompass_cpp/kompass_cpp/src/controllers/rgbd_follower.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/controllers/rgbd_follower.cpp
@@ -195,7 +195,7 @@ bool RGBDFollower::setInitialTracking(const DepthImageView &aligned_depth_image,
 }
 
 void RGBDFollower::refreshTargetGeometry() {
-  if (auto raw = tracker_->getRawTracking()) {
+  if (const auto *raw = tracker_->getRawTracking()) {
     const auto &sz = raw->box.size;
     currentTargetRadius_ = 0.5f * std::max(sz.x(), sz.y());
   }

--- a/src/kompass_cpp/kompass_cpp/src/controllers/rgbd_follower.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/controllers/rgbd_follower.cpp
@@ -146,7 +146,7 @@ bool RGBDFollower::setInitialTracking(const int pose_x_img,
 
 bool RGBDFollower::setInitialTracking(
     const int pose_x_img, const int pose_y_img,
-    const Eigen::MatrixX<unsigned short> &aligned_depth_image,
+    const DepthImageView &aligned_depth_image,
     const std::vector<Bbox2D> &detected_boxes, const float yaw) {
 
   std::unique_ptr<Bbox2D> target_box;
@@ -168,9 +168,9 @@ bool RGBDFollower::setInitialTracking(
   return setInitialTracking(aligned_depth_image, *target_box, yaw);
 }
 
-bool RGBDFollower::setInitialTracking(
-    const Eigen::MatrixX<unsigned short> &aligned_depth_image,
-    const Bbox2D &target_box_2d, const float yaw) {
+bool RGBDFollower::setInitialTracking(const DepthImageView &aligned_depth_image,
+                                      const Bbox2D &target_box_2d,
+                                      const float yaw) {
   if (!detector_) {
     throw std::runtime_error(
         "DepthDetector is not initialized with the camera intrinsics. Call "
@@ -182,12 +182,12 @@ bool RGBDFollower::setInitialTracking(
   } else {
     detector_->updateBoxes(aligned_depth_image, {target_box_2d});
   }
-  auto boxes_3d = detector_->get3dDetections();
-  if (!boxes_3d || boxes_3d->empty()) {
+  const auto &boxes_3d = detector_->get3dDetections();
+  if (boxes_3d.empty()) {
     LOG_DEBUG("Failed to get 3D box from 2D target box");
     return false;
   }
-  const bool ok = tracker_->setInitialTracking(boxes_3d.value()[0], yaw);
+  const bool ok = tracker_->setInitialTracking(boxes_3d[0], yaw);
   if (ok) {
     refreshTargetGeometry();
   }

--- a/src/kompass_cpp/kompass_cpp/src/controllers/rgbd_follower.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/controllers/rgbd_follower.cpp
@@ -54,11 +54,14 @@ void RGBDFollower::setCameraIntrinsics(const float focal_length_x,
                                        const float focal_length_y,
                                        const float principal_point_x,
                                        const float principal_point_y) {
+  // The mount pose comes from a TF lookup against the frame the depth
+  // Image/CameraInfo names, which ROS always expresses in optical axes.
   detector_ = std::make_unique<DepthDetector>(
       config_.depth_range(), vision_sensor_tf_,
       Eigen::Vector2f{focal_length_x, focal_length_y},
       Eigen::Vector2f{principal_point_x, principal_point_y},
-      config_.depth_conversion_factor());
+      config_.depth_conversion_factor(),
+      DepthDetector::CameraFrameConvention::Optical);
 }
 
 Velocity2D RGBDFollower::getPureTrackingCtrl(const TrackedPose2D &tracking_pose,

--- a/src/kompass_cpp/kompass_cpp/src/controllers/rgbd_follower.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/controllers/rgbd_follower.cpp
@@ -66,12 +66,11 @@ void RGBDFollower::setCameraIntrinsics(const float focal_length_x,
 
 Velocity2D RGBDFollower::getPureTrackingCtrl(const TrackedPose2D &tracking_pose,
                                              const bool update_global_error) {
-  float distance, psi, gamma = 0.0f;
+  float range, psi, gamma = 0.0f;
   if (track_velocity_) {
     // World frame: target bearing must be measured from the robot's body,
     // not from the world origin.
-    distance = tracking_pose.distance(currentState.x, currentState.y, 0.0) -
-               robot_radius_ - currentTargetRadius_;
+    range = tracking_pose.distance(currentState.x, currentState.y, 0.0);
     psi = Angle::normalizeToMinusPiPlusPi(
         std::atan2(tracking_pose.y() - currentState.y,
                    tracking_pose.x() - currentState.x) -
@@ -79,14 +78,17 @@ Velocity2D RGBDFollower::getPureTrackingCtrl(const TrackedPose2D &tracking_pose,
     gamma =
         Angle::normalizeToMinusPiPlusPi(tracking_pose.yaw() - currentState.yaw);
   } else {
-    distance = tracking_pose.distance(0.0, 0.0, 0.0) - robot_radius_ -
-               currentTargetRadius_;
+    range = tracking_pose.distance(0.0, 0.0, 0.0);
     psi = Angle::normalizeToMinusPiPlusPi(
         std::atan2(tracking_pose.y(), tracking_pose.x()));
   }
-  // Floor distance to avoid division by zero in the omega formula below
+  // Gap between the two bodies' surfaces: what the standoff is controlled
+  // against. Floored at zero because a target inside the combined radii is
+  // as close as "touching" gets, not a negative separation.
   constexpr float kMinDistance = 0.001f;
-  distance = std::max(distance, kMinDistance);
+  float distance = std::max(
+      static_cast<float>(range - robot_radius_ - currentTargetRadius_),
+      kMinDistance);
 
   float distance_error = config_.target_distance() - distance;
   // target_orientation is the bearing-to-target to maintain in the robot
@@ -118,12 +120,22 @@ Velocity2D RGBDFollower::getPureTrackingCtrl(const TrackedPose2D &tracking_pose,
       v = 0.0;
     }
     followingVel.setVx(v);
-    double omega;
 
-    omega = (track_velocity_ * tracking_pose.v() * sin_diff / distance +
-             v * sin(psi) / distance -
-             config_.K_omega() * ctrl_limits_.omegaParams.maxOmega *
-                 tanh(angle_error));
+    constexpr float kMinRange = 0.1f;
+    const double ff_range = std::max(range, kMinRange);
+    double omega_ff =
+        (track_velocity_ * tracking_pose.v() * sin_diff + v * std::sin(psi)) /
+        ff_range;
+
+    // Backstop for whatever the floor above cannot cover: the feedforward
+    // alone must never be able to saturate the command, since the feedback
+    // term is what actually steers toward the target.
+    omega_ff = std::clamp(omega_ff, -0.5 * ctrl_limits_.omegaParams.maxOmega,
+                          0.5 * ctrl_limits_.omegaParams.maxOmega);
+
+    double omega = omega_ff - config_.K_omega() *
+                                  ctrl_limits_.omegaParams.maxOmega *
+                                  std::tanh(angle_error);
 
     omega = std::clamp(omega, -ctrl_limits_.omegaParams.maxOmega,
                        ctrl_limits_.omegaParams.maxOmega);

--- a/src/kompass_cpp/kompass_cpp/src/planning/ompl.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/planning/ompl.cpp
@@ -19,10 +19,10 @@ OMPL2DGeometricPlanner::OMPL2DGeometricPlanner(
 
 OMPL2DGeometricPlanner::~OMPL2DGeometricPlanner() {}
 
-void OMPL2DGeometricPlanner::setupProblem(
-    double start_x, double start_y, double start_yaw, double goal_x,
-    double goal_y, double goal_yaw,
-    const std::vector<Eigen::Vector3f> &map_3d) {
+void OMPL2DGeometricPlanner::setupProblem(double start_x, double start_y,
+                                          double start_yaw, double goal_x,
+                                          double goal_y, double goal_yaw,
+                                          Span<Path::Point> map_3d) {
   setup_->clear();
   // The planning map is already in the world frame, and this checker is built
   // with an identity sensor mount, so an identity capture pose makes the

--- a/src/kompass_cpp/kompass_cpp/src/utils/trajectory_sampler.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/utils/trajectory_sampler.cpp
@@ -328,7 +328,7 @@ TrajectorySampler::generateTrajectories(const Velocity2D &current_vel,
 std::unique_ptr<TrajectorySamples2D>
 TrajectorySampler::generateTrajectories(const Velocity2D &current_vel,
                                         const Path::State &current_pose,
-                                        const std::vector<Path::Point> &cloud) {
+                                        Span<Path::Point> cloud) {
   collChecker->updateState(current_pose);
   // Pin the cloud to the pose it was captured at (see the LaserScan overload)
   collChecker->updateSensorData(cloud, current_pose);

--- a/src/kompass_cpp/kompass_cpp/src/vision/depth_detector.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/vision/depth_detector.cpp
@@ -2,6 +2,7 @@
 #include "datatypes/tracking.h"
 #include "utils/logger.h"
 #include "utils/transformation.h"
+#include <algorithm>
 #include <optional>
 #include <vector>
 
@@ -80,35 +81,38 @@ DepthDetector::convert2Dboxto3Dbox(const DepthImageView &depth,
                               ? 1.0f
                               : depthConversionFactor_;
   float depth_meters;
-  // All depth values in the 2D box within the range of interest. Non-finite
-  // pixels (NaN padding in float images) -> rejected
-  std::vector<float> depth_values;
-  depth_values.reserve(static_cast<std::size_t>(y_limits(1) - y_limits(0) + 1) *
-                       (x_limits(1) - x_limits(0) + 1));
+  // All depth values in the 2D box within the range of interest.
+  // NaN padding in float images -> rejected.
+  depth_values_.clear();
+  depth_values_.reserve(
+      static_cast<std::size_t>(y_limits(1) - y_limits(0) + 1) *
+      (x_limits(1) - x_limits(0) + 1));
   for (int row_idx = y_limits(0); row_idx <= y_limits(1); ++row_idx) {
     for (int col_idx = x_limits(0); col_idx <= x_limits(1); ++col_idx) {
       depth_meters = depth.at(row_idx, col_idx) * to_meters;
       if (depth_meters <= maxDepth_ && depth_meters >= minDepth_) {
-        depth_values.push_back(depth_meters);
+        depth_values_.push_back(depth_meters);
       }
     }
   }
-  if (depth_values.size() <= 1) {
+  if (depth_values_.size() <= 1) {
     LOG_WARNING("Could not get any depth values for 2D bounding box at ",
                 box2d.top_corner.x(), ", ", box2d.top_corner.y());
     return std::nullopt;
   }
   float medianDepth, madDepth;
-  calculateMAD(depth_values, medianDepth, madDepth);
+  calculateMAD(depth_values_, medianDepth, madDepth);
 
   // Get min and max depth
   float minimum_d = maxDepth_, maximum_d = minDepth_;
-  for (auto depth : depth_values) {
-    if ((depth < minimum_d) && (depth >= medianDepth - 1.5 * madDepth)) {
-      minimum_d = depth;
+  for (auto depth_val : depth_values_) {
+    if ((depth_val < minimum_d) &&
+        (depth_val >= medianDepth - 1.5 * madDepth)) {
+      minimum_d = depth_val;
     }
-    if ((depth > maximum_d) && (depth <= medianDepth + 1.5 * madDepth)) {
-      maximum_d = depth;
+    if ((depth_val > maximum_d) &&
+        (depth_val <= medianDepth + 1.5 * madDepth)) {
+      maximum_d = depth_val;
     }
   }
 
@@ -152,24 +156,31 @@ DepthDetector::convertPOIto3Dbox(const DepthImageView &depth,
   return convert2Dboxto3Dbox(depth, box2d);
 }
 
-float DepthDetector::getMedian(const std::vector<float> &values) {
-  auto sorted_value = values;
-  std::sort(sorted_value.begin(), sorted_value.end());
-  const auto n = sorted_value.size();
-  if (n % 2 == 0) {
-    return 0.5f * (sorted_value[n / 2 - 1] + sorted_value[n / 2]);
+float DepthDetector::getMedian(std::vector<float> &values) {
+  const auto n = values.size();
+  const auto mid = values.begin() + n / 2;
+  // Selection: *mid becomes the n/2-th order statistic and everything left of
+  // it is <= *mid
+  std::nth_element(values.begin(), mid, values.end());
+  const float upper = *mid;
+  if (n % 2 == 0) { // for even elements
+    // The lower middle is the largest element of the left partition.
+    // Equivalent to sorted[n/2 - 1]
+    const float lower = *std::max_element(values.begin(), mid);
+    return 0.5f * (lower + upper);
   }
-  return sorted_value[n / 2];
+  return upper; // for odd elements
 }
 
-void DepthDetector::calculateMAD(const std::vector<float> &depthValues,
-                                 float &median, float &mad) {
+void DepthDetector::calculateMAD(std::vector<float> &depthValues, float &median,
+                                 float &mad) {
   median = getMedian(depthValues);
 
-  std::vector<float> deviations;
+  // resize and fill member scratch
+  mad_scratch_.resize(depthValues.size());
   for (size_t i = 0; i < depthValues.size(); ++i) {
-    deviations.push_back(std::abs(depthValues[i] - median));
+    mad_scratch_[i] = std::abs(depthValues[i] - median);
   }
-  mad = getMedian(deviations);
+  mad = getMedian(mad_scratch_);
 }
 } // namespace Kompass

--- a/src/kompass_cpp/kompass_cpp/src/vision/depth_detector.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/vision/depth_detector.cpp
@@ -8,30 +8,48 @@
 
 namespace Kompass {
 
+const Eigen::Quaternionf &DepthDetector::opticalToBodyAligned() {
+  // Takes (x right, y down, z forward) to (x forward, y left, z up).
+  // Eigen's quaternion constructor is (w, x, y, z).
+  static const Eigen::Quaternionf kOpticalToBody{0.5f, -0.5f, 0.5f, -0.5f};
+  return kOpticalToBody;
+}
+
 DepthDetector::DepthDetector(const Eigen::Vector2f &depth_range,
                              const Eigen::Vector3f &camera_in_body_translation,
                              const Eigen::Quaternionf &camera_in_body_rotation,
                              const Eigen::Vector2f &focal_length,
                              const Eigen::Vector2f &principal_point,
-                             const float depth_conversion_factor)
+                             const float depth_conversion_factor,
+                             const CameraFrameConvention convention)
     : DepthDetector(depth_range,
                     getTransformation(camera_in_body_rotation,
                                       camera_in_body_translation),
-                    focal_length, principal_point, depth_conversion_factor) {}
+                    focal_length, principal_point, depth_conversion_factor,
+                    convention) {}
 
 DepthDetector::DepthDetector(
     const Eigen::Vector2f &depth_range,
     const Eigen::Isometry3f &camera_in_body_tf,
     const Eigen::Vector2f &focal_length, const Eigen::Vector2f &principal_point,
-    const float depth_conversion_factor) { // Range of interest for depth values
-                                           // in meters
+    const float depth_conversion_factor,
+    const CameraFrameConvention convention) { // Range of interest for depth
+                                              // values in meters
   minDepth_ = depth_range(0);
   maxDepth_ = depth_range(1);
   // Factor to convert depth image data to meters (in ROS2 its given in mm ->
   // depthConversionFactor = 1e-3)
   depthConversionFactor_ = depth_conversion_factor;
-  // Set camera tf
-  camera_in_body_tf_ = camera_in_body_tf;
+  // Set camera tf.
+  //
+  // Projection below turns the optical axes into body-aligned ones before
+  // applying this transform, so a pose given in the optical convention has
+  // that fixed quarter rotation taken back out here. Without this the
+  // rotation lands twice and every detection is 90 degrees off.
+  camera_in_body_tf_ =
+      convention == CameraFrameConvention::Optical
+          ? camera_in_body_tf * Eigen::Isometry3f(opticalToBodyAligned().conjugate())
+          : camera_in_body_tf;
 
   // Set camera  intrinsic parameters
   fx_ = focal_length.x();

--- a/src/kompass_cpp/kompass_cpp/src/vision/depth_detector.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/vision/depth_detector.cpp
@@ -2,7 +2,6 @@
 #include "datatypes/tracking.h"
 #include "utils/logger.h"
 #include "utils/transformation.h"
-#include <memory>
 #include <optional>
 #include <vector>
 
@@ -42,56 +41,53 @@ DepthDetector::DepthDetector(
   body_in_world_tf_ = Eigen::Isometry3f::Identity();
 }
 
-std::optional<std::vector<Bbox3D>> DepthDetector::get3dDetections() const {
-  if (boxes_) {
-    return *boxes_;
-  }
-  return std::nullopt;
-}
-
-void DepthDetector::updateBoxes(
-    const Eigen::MatrixX<unsigned short> &aligned_depth_img,
-    const std::vector<Bbox2D> &detections,
-    const std::optional<Path::State> &robot_state) {
+void DepthDetector::updateBoxes(const DepthImageView &aligned_depth_img,
+                                const std::vector<Bbox2D> &detections,
+                                const std::optional<Path::State> &robot_state) {
   if (robot_state.has_value()) {
     body_in_world_tf_ = getTransformation(robot_state.value());
   }
-  alignedDepthImg_ = aligned_depth_img;
-  boxes_ = std::make_unique<std::vector<Bbox3D>>();
+  boxes_.clear();
   for (const auto &box2d : detections) {
-    auto converted_box = convert2Dboxto3Dbox(box2d);
+    auto converted_box = convert2Dboxto3Dbox(aligned_depth_img, box2d);
     if (converted_box) {
-      boxes_->push_back(converted_box.value());
+      boxes_.push_back(std::move(converted_box.value()));
     }
   }
 }
 
-void DepthDetector::updatePOIs(
-    const Eigen::MatrixX<unsigned short> &aligned_depth_img,
-    const PointsOfInterest &poi,
-    const std::optional<Path::State> &robot_state) {
+void DepthDetector::updatePOIs(const DepthImageView &aligned_depth_img,
+                               const PointsOfInterest &poi,
+                               const std::optional<Path::State> &robot_state) {
   if (robot_state.has_value()) {
     body_in_world_tf_ = getTransformation(robot_state.value());
   }
-  alignedDepthImg_ = aligned_depth_img;
-  boxes_ = std::make_unique<std::vector<Bbox3D>>();
-  auto converted_box = convertPOIto3Dbox(poi);
+  boxes_.clear();
+  auto converted_box = convertPOIto3Dbox(aligned_depth_img, poi);
   if (converted_box) {
-    boxes_->push_back(converted_box.value());
+    boxes_.push_back(std::move(converted_box.value()));
   }
 }
 
-std::optional<Bbox3D> DepthDetector::convert2Dboxto3Dbox(const Bbox2D &box2d) {
+std::optional<Bbox3D>
+DepthDetector::convert2Dboxto3Dbox(const DepthImageView &depth,
+                                   const Bbox2D &box2d) {
   Bbox3D box3d(box2d);
   Eigen::Vector2i x_limits = box2d.getXLimits();
   Eigen::Vector2i y_limits = box2d.getYLimits();
+  // FLOAT32 pixels are metres already; UINT16 scale by the configured factor
+  const float to_meters = depth.field_type == PointFieldType::FLOAT32
+                              ? 1.0f
+                              : depthConversionFactor_;
   float depth_meters;
-  // All depth values in the 2D box within the range of interest
+  // All depth values in the 2D box within the range of interest. Non-finite
+  // pixels (NaN padding in float images) -> rejected
   std::vector<float> depth_values;
+  depth_values.reserve(static_cast<std::size_t>(y_limits(1) - y_limits(0) + 1) *
+                       (x_limits(1) - x_limits(0) + 1));
   for (int row_idx = y_limits(0); row_idx <= y_limits(1); ++row_idx) {
     for (int col_idx = x_limits(0); col_idx <= x_limits(1); ++col_idx) {
-      depth_meters =
-          alignedDepthImg_(row_idx, col_idx) * depthConversionFactor_;
+      depth_meters = depth.at(row_idx, col_idx) * to_meters;
       if (depth_meters <= maxDepth_ && depth_meters >= minDepth_) {
         depth_values.push_back(depth_meters);
       }
@@ -142,7 +138,6 @@ std::optional<Bbox3D> DepthDetector::convert2Dboxto3Dbox(const Bbox2D &box2d) {
   // Register center in the world frame
   box3d.center = camera_in_world_tf * center_in_camera_frame;
 
-
   // Transform size from camera frame to world frame
   Eigen::Matrix3f abs_rotation = camera_in_world_tf.linear().cwiseAbs();
   box3d.size = abs_rotation * size_camera_frame;
@@ -151,9 +146,10 @@ std::optional<Bbox3D> DepthDetector::convert2Dboxto3Dbox(const Bbox2D &box2d) {
 }
 
 std::optional<Bbox3D>
-DepthDetector::convertPOIto3Dbox(const PointsOfInterest &poi) {
+DepthDetector::convertPOIto3Dbox(const DepthImageView &depth,
+                                 const PointsOfInterest &poi) {
   Bbox2D box2d(poi);
-  return convert2Dboxto3Dbox(box2d);
+  return convert2Dboxto3Dbox(depth, box2d);
 }
 
 float DepthDetector::getMedian(const std::vector<float> &values) {

--- a/src/kompass_cpp/kompass_cpp/src/vision/tracker.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/vision/tracker.cpp
@@ -38,6 +38,7 @@ FeatureBasedBboxTracker::FeatureBasedBboxTracker(const float &time_step,
 
   stateKalmanFilter_ = std::make_unique<LinearSSKalmanFilter>(StateSize, 1);
   stateKalmanFilter_->setup(A, B, Err, H, Err);
+  measurement_.resize(StateSize, 1);
 }
 
 bool FeatureBasedBboxTracker::setInitialTracking(const TrackedBbox3D &bBox) {
@@ -75,14 +76,14 @@ bool FeatureBasedBboxTracker::setInitialTracking(const Bbox3D &bBox,
 bool FeatureBasedBboxTracker::setInitialTracking(
     const int &pose_x_img, const int &pose_y_img,
     const std::vector<Bbox3D> &detected_boxes, const float yaw) {
-  std::unique_ptr<Bbox3D> target_box;
   // Find a detected box containing the point
-  for (auto box : detected_boxes) {
+  const Bbox3D *target_box = nullptr;
+  for (const auto &box : detected_boxes) {
     auto limits_x = box.getXLimitsImg();
     if (pose_x_img >= limits_x(0) and pose_x_img <= limits_x(1)) {
       auto limits_y = box.getYLimitsImg();
       if (pose_y_img >= limits_y(0) and pose_y_img <= limits_y(1)) {
-        target_box = std::make_unique<Bbox3D>(box);
+        target_box = &box;
         break;
       }
     }
@@ -102,26 +103,26 @@ bool FeatureBasedBboxTracker::trackerInitialized() const {
 }
 
 void FeatureBasedBboxTracker::updateTrackedBoxState(const int numberSteps) {
-  Eigen::MatrixXf measurement;
-  measurement.resize(StateSize, 1);
-  measurement(0) = trackedBox_->box.center.x();
-  measurement(1) = trackedBox_->box.center.y();
-  measurement(2) = trackedBox_->yaw();
-  measurement(3) = trackedBox_->vel.x();
-  measurement(4) = trackedBox_->vel.y();
-  measurement(5) = trackedBox_->omega();
-  measurement(6) = trackedBox_->acc.x();
-  measurement(7) = trackedBox_->acc.y();
-  measurement(8) = trackedBox_->ang_acc();
-  stateKalmanFilter_->estimate(measurement, numberSteps);
+  // Fill the ctor-sized member scratch
+  measurement_(0) = trackedBox_->box.center.x();
+  measurement_(1) = trackedBox_->box.center.y();
+  measurement_(2) = trackedBox_->yaw();
+  measurement_(3) = trackedBox_->vel.x();
+  measurement_(4) = trackedBox_->vel.y();
+  measurement_(5) = trackedBox_->omega();
+  measurement_(6) = trackedBox_->acc.x();
+  measurement_(7) = trackedBox_->acc.y();
+  measurement_(8) = trackedBox_->ang_acc();
+  stateKalmanFilter_->estimate(measurement_, numberSteps);
 }
 
 bool FeatureBasedBboxTracker::updateTracking(
     const std::vector<Bbox3D> &detected_boxes) {
-  std::vector<Bbox3D> label_boxes;
-  for(auto box : detected_boxes) {
-    if(box.label == trackedLabel_) {
-      label_boxes.push_back(box);
+  // each candidate carries a pc_points vector and a label string
+  std::vector<const Bbox3D *> label_boxes;
+  for (const auto &box : detected_boxes) {
+    if (box.label == trackedLabel_) {
+      label_boxes.push_back(&box);
     }
   }
   if (label_boxes.empty()) {
@@ -130,13 +131,13 @@ bool FeatureBasedBboxTracker::updateTracking(
   }
 
   float max_similarity_score = 0.0f; // Similarity score
-  Bbox3D * found_box;
-  float dt = label_boxes[0].timestamp - trackedBox_->box.timestamp;
+  const Bbox3D *found_box = nullptr;
+  float dt = label_boxes[0]->timestamp - trackedBox_->box.timestamp;
 
   if(label_boxes.size() == 1) {
     // Only one box detected, so it is the same
     max_similarity_score = 1.0f;
-    found_box = &label_boxes[0];
+    found_box = label_boxes[0];
   }
   else{
     // Compute similarity score and find box
@@ -149,8 +150,8 @@ bool FeatureBasedBboxTracker::updateTracking(
     FeaturesVector detected_boxes_feature_vec;
     size_t similar_box_idx = 0, count = 0;
 
-    for (auto box : label_boxes) {
-      detected_boxes_feature_vec = extractFeatures(box);
+    for (const Bbox3D *box : label_boxes) {
+      detected_boxes_feature_vec = extractFeatures(*box);
       FeaturesVector error_vec = detected_boxes_feature_vec - ref_box_features;
       // Error vector normalization
       for (int i = 0; i < error_vec.size(); ++i) {
@@ -166,7 +167,7 @@ bool FeatureBasedBboxTracker::updateTracking(
       }
       count++;
     }
-    found_box = &label_boxes[similar_box_idx];
+    found_box = label_boxes[similar_box_idx];
   }
 
   if (max_similarity_score > minAcceptedSimilarityScore_) {
@@ -210,13 +211,6 @@ FeatureBasedBboxTracker::extractFeatures(const Bbox3D &bBox) const {
   return features_vec;
 }
 
-std::optional<TrackedBbox3D> FeatureBasedBboxTracker::getRawTracking() const {
-  if (trackedBox_) {
-    return *trackedBox_;
-  }
-  return std::nullopt;
-}
-
 std::optional<Eigen::MatrixXf>
 FeatureBasedBboxTracker::getTrackedState() const {
   if (trackedBox_) {
@@ -240,13 +234,13 @@ Eigen::Vector3f FeatureBasedBboxTracker::computePointsStdDev(
   // compute the mean in each direction
   auto size = std::max(int(pc_points.size() - 1), 1);
   Eigen::Vector3f mean = Eigen::Vector3f::Zero();
-  for (auto point : pc_points) {
+  for (const auto &point : pc_points) {
     mean += point;
   }
   mean /= size;
   // Compute the variance
   Eigen::Vector3f variance = Eigen::Vector3f::Zero();
-  for (auto point : pc_points) {
+  for (const auto &point : pc_points) {
     auto diff = point - mean;
     variance += diff.cwiseProduct(diff);
   }

--- a/src/kompass_cpp/tests/vision_follower_fixture_test.cpp
+++ b/src/kompass_cpp/tests/vision_follower_fixture_test.cpp
@@ -80,20 +80,23 @@ std::vector<FixtureCase> discover_fixtures() {
   return out;
 }
 
-Eigen::MatrixX<unsigned short> load_depth_png(const fs::path &png_path) {
+cv::Mat load_depth_png(const fs::path &png_path) {
   cv::Mat raw = cv::imread(png_path.string(), cv::IMREAD_UNCHANGED);
   BOOST_REQUIRE_MESSAGE(!raw.empty(),
                         "Could not load depth.png at " << png_path.string());
   BOOST_REQUIRE_MESSAGE(raw.type() == CV_16UC1,
                         "depth.png must be 16-bit single-channel: "
                             << png_path.string());
-  Eigen::MatrixX<unsigned short> depth(raw.rows, raw.cols);
-  for (int r = 0; r < raw.rows; ++r) {
-    for (int c = 0; c < raw.cols; ++c) {
-      depth(r, c) = raw.at<unsigned short>(r, c);
-    }
-  }
-  return depth;
+  BOOST_REQUIRE(raw.isContinuous());
+  return raw;
+}
+
+// Zero-copy view over the row-major cv::Mat buffer (16UC1 = uint16 mm).
+// The Mat must outlive every use of the view
+DepthImageView depth_view(const cv::Mat &img) {
+  return DepthImageView(
+      ByteSpan(img.ptr<uint8_t>(), img.total() * img.elemSize()), img.rows,
+      img.cols, PointFieldType::UINT16);
 }
 
 std::vector<Bbox2D> parse_detections(const json &case_json) {
@@ -160,7 +163,8 @@ void run_one_fixture(const FixtureCase &fx) {
   json case_json;
   in >> case_json;
 
-  auto depth = load_depth_png(fx.dir / "depth.png");
+  const cv::Mat depth_mat = load_depth_png(fx.dir / "depth.png");
+  const auto depth = depth_view(depth_mat);
   auto detections = parse_detections(case_json);
   auto controller = build_controller(case_json);
 

--- a/src/kompass_cpp/tests/vision_follower_test.cpp
+++ b/src/kompass_cpp/tests/vision_follower_test.cpp
@@ -171,13 +171,12 @@ struct RGBDFollowerTestConfig {
       LOG_ERROR("Could not open or find the image");
     }
 
-    // Create an Eigen matrix of type int from the OpenCV Mat
-    auto depth_image = Eigen::MatrixX<unsigned short>(cv_img.rows, cv_img.cols);
-    for (int i = 0; i < cv_img.rows; ++i) {
-      for (int j = 0; j < cv_img.cols; ++j) {
-        depth_image(i, j) = cv_img.at<unsigned short>(i, j);
-      }
-    }
+    // Zero-copy view over the row-major cv::Mat buffer (16UC1 = uint16 mm).
+    // The Mat owns the pixels and outlives every use of the view below
+    BOOST_REQUIRE(cv_img.isContinuous());
+    const DepthImageView depth_image(
+        ByteSpan(cv_img.ptr<uint8_t>(), cv_img.total() * cv_img.elemSize()),
+        cv_img.rows, cv_img.cols, PointFieldType::UINT16);
 
     controller->setCameraIntrinsics(focal_length.x(), focal_length.y(),
                                     principal_point.x(), principal_point.y());

--- a/src/kompass_cpp/tests/vision_tracking_test.cpp
+++ b/src/kompass_cpp/tests/vision_tracking_test.cpp
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE(test_Vision_Tracker) {
   while (step < config.maxSteps) {
     // Sed detected boxes and ask tracker to update
     config.tracker->updateTracking(config.detected_boxes);
-    auto measured_track = config.tracker->getRawTracking();
+    const auto *measured_track = config.tracker->getRawTracking();
     auto tracked_state = config.tracker->getTrackedState();
     if (tracked_state) {
       auto mat = tracked_state->col(0);

--- a/tests/test_depth_detector.py
+++ b/tests/test_depth_detector.py
@@ -61,8 +61,9 @@ def synthetic_depth_image(camera_params, center_bbox_2d):
     and the area exactly inside the 2D bounding box is 3000mm (3.0 meters).
     """
     h, w = camera_params["img_shape"]
-    # Force column-major layout to match Eigen's default MatrixX layout
-    img = np.zeros((h, w), dtype=np.uint16, order="F")
+    # C-contiguous, the native layout of every camera driver: this is the
+    # zero-copy fast path through the bindings
+    img = np.zeros((h, w), dtype=np.uint16)
 
     tl_x, tl_y = center_bbox_2d.top_left_corner
     w_box, h_box = center_bbox_2d.size
@@ -151,7 +152,7 @@ def synthetic_depth_image_poi(camera_params, center_poi):
     bounding box that Bbox2D(PointsOfInterest) computes.
     """
     h, w = camera_params["img_shape"]
-    img = np.zeros((h, w), dtype=np.uint16, order="F")
+    img = np.zeros((h, w), dtype=np.uint16)
 
     # Use the first point as reference for the fill region
     px, py_ = center_poi.points_2d[0]
@@ -230,7 +231,7 @@ def test_poi_multipoint_robot_frame(detector, camera_params):
     )
 
     # Build depth image filling a generous region around the cluster
-    img = np.zeros((img_h, img_w), dtype=np.uint16, order="F")
+    img = np.zeros((img_h, img_w), dtype=np.uint16)
     margin = 80
     img[cy - margin : cy + margin, cx - margin : cx + margin] = 3000
 
@@ -246,3 +247,43 @@ def test_poi_multipoint_robot_frame(detector, camera_params):
     assert box3d.center[0] == pytest.approx(3.0, abs=0.05)
     assert box3d.center[1] == pytest.approx(0.0, abs=0.1)
     assert box3d.center[2] == pytest.approx(0.0, abs=0.1)
+
+
+def test_compute_3d_float32_metres_matches_uint16_mm(
+    detector, synthetic_depth_image, center_bbox_2d
+):
+    """A float32 depth image in METRES must produce the same 3D detection as
+    its uint16-millimetres twin: the binding dispatches on the dtype and no
+    conversion pass is needed anywhere (zero-copy for both encodings)."""
+    img_f32 = synthetic_depth_image.astype(np.float32) * 1e-3  # mm -> m
+    assert img_f32.flags.c_contiguous
+
+    result_u16 = detector.compute_3d_detections(
+        synthetic_depth_image, [center_bbox_2d], 0.0, 0.0, 0.0, 0.0
+    )
+    result_f32 = detector.compute_3d_detections(
+        img_f32, [center_bbox_2d], 0.0, 0.0, 0.0, 0.0
+    )
+
+    assert len(result_u16) == 1 and len(result_f32) == 1
+    for axis in range(3):
+        assert result_f32[0].center[axis] == pytest.approx(
+            result_u16[0].center[axis], abs=1e-5
+        )
+        assert result_f32[0].size[axis] == pytest.approx(
+            result_u16[0].size[axis], abs=1e-5
+        )
+
+
+def test_compute_3d_float32_nan_pixels_are_rejected(
+    detector, camera_params, center_bbox_2d
+):
+    """NaN padding in float depth images dies in the min/max range gate: a
+    box whose region is all-NaN yields no detection instead of garbage."""
+    h, w = camera_params["img_shape"]
+    img = np.full((h, w), np.nan, dtype=np.float32)
+
+    results = detector.compute_3d_detections(
+        img, [center_bbox_2d], 0.0, 0.0, 0.0, 0.0
+    )
+    assert len(results) == 0

--- a/tests/test_depth_detector.py
+++ b/tests/test_depth_detector.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from kompass_core.vision import DepthDetector
+from kompass_core.vision import CameraFrameConvention, DepthDetector
 from kompass_core.datatypes import Bbox2D, PointsOfInterest
 
 # -----------------------------------------------------------------------------
@@ -18,20 +18,31 @@ def camera_params():
     }
 
 
+#: REP 103 rotation from optical axes (x right, y down, z forward) to body
+#: ones (x forward, y left, z up), as (x, y, z, w).
+OPTICAL_TO_BODY = np.array([-0.5, 0.5, -0.5, 0.5], dtype=np.float32)
+
+
 @pytest.fixture
-def identity_transform():
+def forward_facing_camera():
+    """A camera at the body origin looking straight ahead.
+
+    Poses are read in the optical convention by default -- the frame a ROS
+    Image or CameraInfo names in its header -- so a camera whose view direction
+    is the body's forward axis carries the fixed REP 103 turn as its rotation.
+    """
     return {
         "translation": np.array([0.0, 0.0, 0.0], dtype=np.float32),
-        "rotation": np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32),
+        "rotation": OPTICAL_TO_BODY,
     }
 
 
 @pytest.fixture
-def detector(camera_params, identity_transform):
+def detector(camera_params, forward_facing_camera):
     return DepthDetector(
         camera_params["depth_range"],
-        identity_transform["translation"],
-        identity_transform["rotation"],
+        forward_facing_camera["translation"],
+        forward_facing_camera["rotation"],
         camera_params["focal_length"],
         camera_params["principal_point"],
         1e-3,
@@ -287,3 +298,102 @@ def test_compute_3d_float32_nan_pixels_are_rejected(
         img, [center_bbox_2d], 0.0, 0.0, 0.0, 0.0
     )
     assert len(results) == 0
+
+
+# -----------------------------------------------------------------------------
+# Camera frame convention
+# -----------------------------------------------------------------------------
+
+
+def test_optical_pose_places_a_target_dead_ahead_on_the_forward_axis(
+    camera_params, center_bbox_2d, synthetic_depth_image
+):
+    """A camera pose taken straight from a ROS TF lookup must put a target
+    centred in the image in front of the robot, not off to one side.
+
+    Regression: the pose was read as body-aligned while the projection had
+    already turned the optical axes into body ones, so the REP 103 quarter
+    rotation landed twice. A person standing dead ahead came back ~90 degrees
+    to the right, which drove the vision follower to turn away and lose them.
+    """
+    # A real mount: 0.32 m ahead of base_link, 0.30 m up, tilted ~23 deg down.
+    # This is the optical frame's pose, which is what TF resolves for the
+    # frame_id a depth CameraInfo carries.
+    translation = np.array([0.32, 0.0, 0.30], dtype=np.float32)
+    rotation = np.array(
+        [-0.5839669, 0.5936764, -0.38588133, 0.3970222], dtype=np.float32
+    )
+
+    detector = DepthDetector(
+        camera_params["depth_range"],
+        translation,
+        rotation,
+        camera_params["focal_length"],
+        camera_params["principal_point"],
+        1e-3,
+        CameraFrameConvention.OPTICAL,
+    )
+    box = detector.compute_3d_detections(
+        synthetic_depth_image, [center_bbox_2d], 0.0, 0.0, 0.0, 0.0
+    )[0]
+
+    bearing = np.arctan2(box.center[1], box.center[0])
+    assert abs(bearing) < np.deg2rad(2.0), (
+        f"target centred in the image came back at {np.rad2deg(bearing):.1f} deg"
+    )
+    # Forward of the robot, and further than the camera itself
+    assert box.center[0] > translation[0]
+
+
+def test_body_aligned_pose_is_still_honoured(
+    camera_params, center_bbox_2d, synthetic_depth_image
+):
+    """Callers that already turned the pose into robot axes can say so and
+    keep the previous behaviour."""
+    detector = DepthDetector(
+        camera_params["depth_range"],
+        np.array([0.0, 0.0, 0.0], dtype=np.float32),
+        np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32),  # identity: FLU mount
+        camera_params["focal_length"],
+        camera_params["principal_point"],
+        1e-3,
+        CameraFrameConvention.BODY_ALIGNED,
+    )
+    box = detector.compute_3d_detections(
+        synthetic_depth_image, [center_bbox_2d], 0.0, 0.0, 0.0, 0.0
+    )[0]
+
+    assert box.center[0] == pytest.approx(3.0, abs=0.05)
+    assert box.center[1] == pytest.approx(0.0, abs=0.05)
+    assert box.center[2] == pytest.approx(0.0, abs=0.05)
+
+
+def test_the_two_conventions_differ_by_the_rep103_turn(
+    camera_params, center_bbox_2d, synthetic_depth_image
+):
+    """Reading an optical pose as body-aligned is exactly the bug: the result
+    is the correct one rotated by the REP 103 quarter turn."""
+    translation = np.array([0.0, 0.0, 0.0], dtype=np.float32)
+    rotation = OPTICAL_TO_BODY
+
+    def centre(convention):
+        detector = DepthDetector(
+            camera_params["depth_range"],
+            translation,
+            rotation,
+            camera_params["focal_length"],
+            camera_params["principal_point"],
+            1e-3,
+            convention,
+        )
+        return np.asarray(
+            detector.compute_3d_detections(
+                synthetic_depth_image, [center_bbox_2d], 0.0, 0.0, 0.0, 0.0
+            )[0].center
+        )
+
+    # Optical: the turn is applied once -> depth lands on forward
+    assert centre(CameraFrameConvention.OPTICAL)[0] == pytest.approx(3.0, abs=0.05)
+    # Body-aligned: applied twice -> depth lands on -y, a clean 90 deg off
+    doubled = centre(CameraFrameConvention.BODY_ALIGNED)
+    assert doubled[1] == pytest.approx(-3.0, abs=0.05)

--- a/tests/test_vision_follower.py
+++ b/tests/test_vision_follower.py
@@ -138,3 +138,25 @@ def test_vision_follower_fixture(case_dir: Path) -> None:
         f"{case_dir.name}: omega={omega} outside "
         f"[{exp['omega_min']}, {exp['omega_max']}]"
     )
+
+
+def test_rgbd_follower_exposes_rgb_follower_interface() -> None:
+    """The C++ RGBDFollower also inherits RGBFollower; nanobind registers a
+    single base (Follower), so the RGBFollower interface is re-bound on the
+    RGBDFollower binding and must stay reachable from Python."""
+    case = _load_case(_discover_fixtures()[0])
+    follower = _make_follower(case)
+    planner = follower._planner
+
+    box = Bbox2D(
+        top_left_corner=np.array([300, 220], dtype=np.int32),
+        size=np.array([40, 40], dtype=np.int32),
+    )
+    box.set_img_size(np.array([640, 480], dtype=np.int32))
+
+    planner.reset_target(box)
+    assert isinstance(planner.run(box), bool)
+    assert isinstance(planner.run(None), bool)
+    # get_ctrl returns the velocities the RGB control path produced
+    assert planner.get_ctrl() is not None
+    assert planner.get_errors() is not None

--- a/tests/test_vision_follower.py
+++ b/tests/test_vision_follower.py
@@ -160,3 +160,95 @@ def test_rgbd_follower_exposes_rgb_follower_interface() -> None:
     # get_ctrl returns the velocities the RGB control path produced
     assert planner.get_ctrl() is not None
     assert planner.get_errors() is not None
+
+
+# ---------------------------------------------------------------------------
+# Close-target regression: the bearing-hold feedforward must not run away
+# ---------------------------------------------------------------------------
+
+#: Depth camera on the front of a box-shaped robot, tilted ~23 degrees down.
+#: The tilt matters: it mixes the target's visible height into the body-x
+#: extent, which is what inflates the target radius.
+_TILTED_MOUNT = (-0.5839669, 0.5936764, -0.38588133, 0.3970222)
+
+
+def _close_target_follower() -> VisionRGBDFollower:
+    robot = Robot(
+        robot_type=RobotType.DIFFERENTIAL_DRIVE,
+        # A real chassis: the circumradius is 0.357 m, so a target closer than
+        # that is inside the robot's own footprint circle
+        geometry_type=RobotGeometry.Type.BOX,
+        geometry_params=np.array([0.61, 0.37, 0.4]),
+    )
+    ctrl_limits = RobotCtrlLimits(
+        vx_limits=LinearCtrlLimits(max_vel=1.5, max_acc=3.0, max_decel=3.0),
+        omega_limits=AngularCtrlLimits(
+            max_omega=2.5, max_acc=2.5, max_decel=2.5, max_ang=np.pi / 2
+        ),
+    )
+    config = VisionRGBDFollowerConfig(
+        control_time_step=0.1,
+        target_distance=0.5,
+        _use_local_coordinates=True,
+        camera_position_to_robot=np.array([0.0, 0.0, 0.3], dtype=np.float32),
+        camera_rotation_to_robot=np.array(_TILTED_MOUNT, dtype=np.float32),
+    )
+    return VisionRGBDFollower(
+        robot=robot,
+        ctrl_limits=ctrl_limits,
+        config=config,
+        camera_focal_length=[500.0, 500.0],
+        camera_principal_point=[320.0, 240.0],
+    )
+
+
+def _close_target_frame():
+    """A person 0.45 m away, filling the frame and a little to the left.
+
+    At that range the target radius plus the robot's own radius exceeds the
+    range, so the surface-to-surface gap collapses to its floor -- the state
+    that used to detonate the omega feedforward.
+    """
+    depth = np.zeros((480, 640), dtype=np.uint16)
+    x0, y0, w, h = 60, 0, 400, 480
+    depth[y0 : y0 + h, x0 : x0 + w] = 450  # mm
+
+    box = Bbox2D()
+    box.top_left_corner = np.array([x0, y0], dtype=np.int32)
+    box.size = np.array([w, h], dtype=np.int32)
+    box.img_size = np.array([640, 480], dtype=np.int32)
+    return depth, box, (x0 + w // 2, y0 + h // 2)
+
+
+def test_close_target_does_not_saturate_omega() -> None:
+    """A target inside the robot's own radius must not rail the rotation.
+
+    Regression: the bearing-hold feedforward divided by the surface-to-surface
+    gap rather than the range to the target. That gap floors at 1 mm as soon as
+    the target is within the combined radii, turning the term into a ~1000x
+    gain that pinned omega to the limit and drove the robot round until it lost
+    the person. `rotation_gain` cannot damp it -- the gain scales only the
+    feedback term, so turning it down makes matters worse by removing the one
+    term pulling back.
+    """
+    follower = _close_target_follower()
+    depth, box, (click_x, click_y) = _close_target_frame()
+    state = RobotState(x=0.0, y=0.0, yaw=0.0, speed=0.0)
+
+    assert follower.set_initial_tracking_image(
+        current_state=state,
+        pose_x_img=click_x,
+        pose_y_img=click_y,
+        detected_boxes=[box],
+        aligned_depth_image=depth,
+    )
+    assert follower.loop_step(
+        current_state=state, detections_2d=[box], depth_image=depth
+    )
+
+    omega = follower.angular_control[0]
+    max_omega = 2.5
+    assert abs(omega) < 0.5 * max_omega, (
+        f"omega={omega} on a close target: the feedforward is running away "
+        f"(limit is {max_omega})"
+    )

--- a/tests/test_zero_copy_boundary.py
+++ b/tests/test_zero_copy_boundary.py
@@ -9,8 +9,15 @@ would be 10-100x the metadata cost) blows the ratio immediately.
 
 CPU classes are used on purpose: no JIT warm-up noise, and the binding
 boundary under test is the same code for the GPU classes.
+
+The vision guards use image-size scaling instead: the depth detector and
+follower only read pixels inside the (fixed-size) target box, so a
+zero-copy boundary costs the same on a VGA image and on one with 4x the
+pixels. Any hidden full-image copy or dtype/layout conversion scales with
+the image area and blows the ratio.
 """
 
+import itertools
 import time
 
 import numpy as np
@@ -18,6 +25,19 @@ import numpy as np
 from kompass_cpp.mapping import LocalMapper as LocalMapperCpp
 from kompass_cpp.types import RobotGeometry, SensorConfig, SensorInputType
 from kompass_cpp.utils import CriticalZoneChecker
+
+from kompass_core.control import VisionRGBDFollower, VisionRGBDFollowerConfig
+from kompass_core.datatypes import Bbox2D
+from kompass_core.models import (
+    AngularCtrlLimits,
+    LinearCtrlLimits,
+    Robot,
+    RobotCtrlLimits,
+    RobotGeometry as CoreRobotGeometry,
+    RobotState,
+    RobotType,
+)
+from kompass_core.vision import DepthDetector
 
 _PC_STRIDE = 16  # 16B points (x, y, z, pad)
 _N_POINTS = 100_000
@@ -122,4 +142,149 @@ def test_mapper_batched_n1_within_noise_of_single_cloud():
     assert ratio < _MAX_RATIO, (
         f"batched N=1 scan_to_grid() costs {ratio:.2f}x the single-cloud "
         "entry: the binding boundary is doing per-point work"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Vision depth boundary
+# ---------------------------------------------------------------------------
+
+_BOX_SIZE = 40  # px, target box shared by both image sizes
+_BOX_CORNER = (300, 220)  # inside VGA and the 4x image alike
+
+
+def _depth_image(rows: int, cols: int) -> np.ndarray:
+    """C-contiguous uint16 depth (the zero-copy fast path): background 0
+    (invalid), the target box filled with 3000mm."""
+    img = np.zeros((rows, cols), dtype=np.uint16)
+    x0, y0 = _BOX_CORNER
+    img[y0 : y0 + _BOX_SIZE, x0 : x0 + _BOX_SIZE] = 3000
+    return img
+
+
+def _target_box(img_w: int, img_h: int) -> Bbox2D:
+    box = Bbox2D(
+        top_left_corner=np.array(_BOX_CORNER, dtype=np.int32),
+        size=np.array([_BOX_SIZE, _BOX_SIZE], dtype=np.int32),
+    )
+    box.set_img_size(np.array([img_w, img_h], dtype=np.int32))
+    return box
+
+
+def test_depth_detector_boundary_does_not_scale_with_image_size():
+    detector = DepthDetector(
+        np.array([0.1, 10.0], dtype=np.float32),  # depth range
+        np.array([0.0, 0.0, 0.0], dtype=np.float32),  # camera translation
+        np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32),  # camera rotation
+        np.array([500.0, 500.0], dtype=np.float32),  # focal length
+        np.array([320.0, 240.0], dtype=np.float32),  # principal point
+        1e-3,  # mm -> m
+    )
+    small = _depth_image(480, 640)
+    big = _depth_image(960, 1280)  # 4x the pixels, same box content
+
+    # Same box pixels -> identical 3D result regardless of image size, and
+    # a read-only buffer (np.frombuffer-style input) must be accepted as-is
+    res_small = detector.compute_3d_detections(
+        small, [_target_box(640, 480)], 0.0, 0.0, 0.0, 0.0
+    )
+    res_big = detector.compute_3d_detections(
+        big, [_target_box(1280, 960)], 0.0, 0.0, 0.0, 0.0
+    )
+    np.testing.assert_allclose(res_small[0].center, res_big[0].center)
+    read_only = small.copy()
+    read_only.setflags(write=False)
+    res_ro = detector.compute_3d_detections(
+        read_only, [_target_box(640, 480)], 0.0, 0.0, 0.0, 0.0
+    )
+    np.testing.assert_allclose(res_ro[0].center, res_small[0].center)
+
+    small_box, big_box = _target_box(640, 480), _target_box(1280, 960)
+    ratio = _median_ratio(
+        lambda: detector.compute_3d_detections(
+            small, [small_box], 0.0, 0.0, 0.0, 0.0
+        ),
+        lambda: detector.compute_3d_detections(big, [big_box], 0.0, 0.0, 0.0, 0.0),
+    )
+    assert ratio < _MAX_RATIO, (
+        f"compute_3d_detections on a 4x-pixel image costs {ratio:.2f}x the "
+        "VGA call: the depth boundary is doing per-pixel (full image) work"
+    )
+
+
+def _tracking_depth_image(rows: int, cols: int) -> np.ndarray:
+    """Materialized (non-lazy) pages so a copy regression costs a real
+    memcpy: 60m background (rejected by the 10m range gate), 3m target box."""
+    img = np.full((rows, cols), 60000, dtype=np.uint16)
+    x0, y0 = _BOX_CORNER
+    img[y0 : y0 + _BOX_SIZE, x0 : x0 + _BOX_SIZE] = 3000
+    return img
+
+
+def test_rgbd_follower_boundary_does_not_scale_with_image_size():
+    # NOTE: the timed calls run the REAL tracking path (a detection per
+    # call, advancing timestamps). The no-detections wait path is not a
+    # usable timing subject: its internal state machine alternates between
+    # a cheap and an expensive tick, which interleaved A/B timing folds
+    # into a bogus ratio.
+    robot = Robot(
+        robot_type=RobotType.DIFFERENTIAL_DRIVE,
+        geometry_type=CoreRobotGeometry.Type.CYLINDER,
+        geometry_params=np.array([0.1, 0.4]),
+    )
+    ctrl_limits = RobotCtrlLimits(
+        vx_limits=LinearCtrlLimits(max_vel=1.5, max_acc=3.0, max_decel=3.0),
+        omega_limits=AngularCtrlLimits(
+            max_omega=2.5, max_acc=2.5, max_decel=2.5, max_ang=np.pi / 2
+        ),
+    )
+    follower = VisionRGBDFollower(
+        robot=robot,
+        ctrl_limits=ctrl_limits,
+        config=VisionRGBDFollowerConfig(
+            control_time_step=0.1,
+            _use_local_coordinates=True,
+            depth_conversion_factor=1e-3,
+            min_depth=0.1,
+            max_depth=10.0,
+        ),
+        camera_focal_length=[500.0, 500.0],
+        camera_principal_point=[320.0, 240.0],
+    )
+    small = _tracking_depth_image(480, 640)
+    big = _tracking_depth_image(960, 1280)  # 4x the pixels, same box
+    state = RobotState(x=0.0, y=0.0, yaw=0.0, speed=0.0)
+
+    x0, y0 = _BOX_CORNER
+    assert follower.set_initial_tracking_image(
+        current_state=state,
+        pose_x_img=x0 + _BOX_SIZE // 2,
+        pose_y_img=y0 + _BOX_SIZE // 2,
+        detected_boxes=[_target_box(640, 480)],
+        aligned_depth_image=small,
+    )
+
+    clock = itertools.count(1)
+
+    def detection(img_w: int, img_h: int) -> list:
+        # Fresh timestamp per call: the tracker needs dt > 0
+        box = _target_box(img_w, img_h)
+        box.timestamp = next(clock) * 0.1
+        return [box]
+
+    ratio = _median_ratio(
+        lambda: follower.loop_step(
+            current_state=state,
+            detections_2d=detection(640, 480),
+            depth_image=small,
+        ),
+        lambda: follower.loop_step(
+            current_state=state,
+            detections_2d=detection(1280, 960),
+            depth_image=big,
+        ),
+    )
+    assert ratio < _MAX_RATIO, (
+        f"loop_step with a 4x-pixel depth image costs {ratio:.2f}x the VGA "
+        "call: the depth boundary is doing per-pixel (full image) work"
     )


### PR DESCRIPTION
## Why

After #47, the vision-based followers (`RGBFollower` / `VisionRGBDFollower`) were the worst remaining boundary in the codebase: the depth image crossed by value as a column-major `Eigen::MatrixX<unsigned short>`, costing ~3 full-image copies plus a C→F transpose per tick at VGA, and the detector then copied it again into a member. The producer side paid an extra float→mm scale, uint16 cast, and Fortran-order repack per message purely to feed that signature. No vision binding released the GIL. A broad audit of all bindings found more of the same elsewhere: missing GIL releases (including the blocking GPU laserscan calls), per-tick `std::vector<Path::Point>` rebuilds from Nx3 numpy buffers, and the OMPL planner's element-wise map crossing.

## What changed

- **Zero-copy depth boundary**: new `DepthImageView` (non-owning span view over a 2-D C-contiguous buffer with a `PointFieldType` dtype tag). Dual bindings accept raw camera buffers as-is — uint16 (millimetres, ROS `16UC1`/`mono16`) or float32 (metres, `32FC1`) — with **no normalization pass anywhere**: the scale rides the existing `depth_conversion_factor` (uint16 default `1e-3`; float32 read as metres), NaN dies in the detector's existing range gate. All vision entries release the GIL. `DepthDetector` and both follower APIs take the view; the detector's owned image copy is gone.
- **Vision internals**: MAD median via `nth_element` (bit-identical to the sort-based result), member scratch buffers with grow-only capacity, tracker copy/alloc hygiene (const-ref loops, pointer-based candidate selection, `getRawTracking` returns a pointer), deleted hand-written copy constructors that silently suppressed moves — one of which (`Bbox2D`) was dropping the `vel` field on copy. `RGBFollower` takes `const std::optional<Bbox2D>&`, builds search/wait velocities once in the constructor, and reuses the last-tracking storage.
- **Broad bindings sweep**: GIL releases on the blocking GPU laserscan `scan_to_grid`/`check`, CPU mapper and checker laserscan paths, Stanley, PurePursuit, OMPL `solve`, and `read_pcd*`. Nx3 float32 cloud buffers now reinterpret as `Span<Path::Point>` (12-byte layout `static_assert`) in DWA / PurePursuit / `debug_velocity_search` and OMPL `setup_problem` — the per-call point-vector builds are gone and the octree build runs without the GIL. New direct `DWA.compute_velocity_commands(vel, ranges, angles)` overload builds the `LaserScan` C++-side after the GIL release (one copy, no per-tick Python wrapper object); `dwa.py` uses it. `ByteArray` args by const reference; `Follower::getCurrentPath` returns `const Path::Path&` (bound with `rv_policy::copy` — the follower destroys the path on `set_current_path`, so a Python-held reference would dangle); inert/redundant `rv_policy` annotations dropped; `OCCUPANCY_TYPE` bound as `enum.IntEnum` (`is_arithmetic`) and made the single source of truth — the duplicated Python enum in `datatypes/obstacles.py` is replaced by a re-export of the binding.
- **API completeness** (closes #53): the C++ `RGBDFollower` inherits both `Follower` and `RGBFollower`, but nanobind registers a single base (`Follower`, the larger and load-bearing surface). The `RGBFollower` interface (`reset_target`, `get_ctrl`, `run`) is now re-bound on the `RGBDFollower` binding through lambdas (a base member pointer would not cast — the registered Python base chain does not include `RGBFollower`), with a binding-level test covering all four inherited methods.
- **Camera pose convention** (closes #49): `DepthDetector` now takes a `CameraFrameConvention` — `OPTICAL` (the default) or `BODY_ALIGNED`. The detector's projection converts optical axes to body-aligned ones internally, so a mount pose resolved from TF against an Image/CameraInfo `frame_id` — which ROS always expresses in **optical** axes — carried the REP 103 quarter turn twice, putting every detection 90° off. Optical-convention poses now have that fixed turn conjugated back out at construction; body-aligned poses pass through untouched. The enum is bound as `kompass_cpp.vision.CameraFrameConvention`, `RGBDFollower` builds its detector with explicit `OPTICAL` (its pose always comes from that TF lookup), and `VisionRGBDFollowerConfig` documents both extrinsics as the optical frame's pose with the REP 103 turn as the default rotation (net default behavior unchanged). Covered by tests: a real tilted mount placing a dead-ahead target on the forward axis, body-aligned passthrough, and the double-turn failure mode.
- **Bearing-hold feedforward fix**: the omega feedforward divided by the surface gap (center range − robot radius − target radius, floored at 1 mm), so a close target drove it to saturation. It now divides by the center range (floored at 0.1 m) and is clamped to ±0.5·`maxOmega` so the feedforward alone can never saturate the command — the feedback term is what steers. Close-target regression test added.
- **Robustness**: `loop_step` guards `depth_image=None` (debug log + `return False` instead of a swallowed `TypeError` logged as a solver failure every tick).
- **Guards**: image-size-scaling ratio tests in `test_zero_copy_boundary.py` (a zero-copy boundary must cost the same at VGA and 4× the pixels; a hidden copy blows the ratio) plus read-only-buffer acceptance; `test_depth_detector.py` switched to C-order images — the real camera layout — killing the `order="F"` papering; C++/Python fixture parity unchanged.

## Performance (VGA 640×480 uint16, 5 boxes, median of 60, before → after)

| Path | before | after | |
|---|---|---|---|
| RGBD follower `loop_step` (C-order input) | 0.66–0.80 ms | 0.100 ms | 6.6–8× |
| `DepthDetector.compute_3d_detections` | 0.44–0.53 ms | 0.091 ms | 4.9–5.9× |

The fast path is now C-order (the native camera layout); F-order input pays one conversion copy — the exact inverse of the old signature. The GIL releases are a concurrency win on top: ROS executor threads keep running through mapper/checker/planner/vision compute.
