### PR TITLE
Point cloud input for vision depth lifting (3D LiDAR fusion)

### DIFF
--- a/build_dependencies/build_gpu_wheel.sh
+++ b/build_dependencies/build_gpu_wheel.sh
@@ -196,6 +196,7 @@ $PYTHON -m pip install patchelf "scikit-build-core>=0.8" "nanobind>=1.8,<2.9.2" 
 # Use acpp as compiler; point CMake at Conan-generated find modules for OMPL/FCL
 # Use CMAKE_PREFIX_PATH instead of CMAKE_TOOLCHAIN_FILE to avoid Conan
 # overriding the build generator (Ninja vs Make conflict with scikit-build)
+export CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)"
 CXX=acpp SKBUILD_CMAKE_ARGS="-DCMAKE_PREFIX_PATH=$CONAN_BUILD_DIR" \
     $PYTHON -m pip wheel --no-build-isolation -w dist/ .
 

--- a/build_dependencies/install_gpu.sh
+++ b/build_dependencies/install_gpu.sh
@@ -442,6 +442,7 @@ python3 -m pip uninstall -y kompass-core
 
 # Build and Install
 # SKBUILD_CMAKE_ARGS is already set if we are in legacy mode
+export CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)"
 CXX=$CLANG_EXECUTABLE_PATH python3 -m pip install --no-build-isolation .
 
 # Clean up source files if not required

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,6 @@ build-dir = "build/{wheel_tag}"
 wheel.py-api = "cp312"
 # Min cmake version
 cmake.version = ">=3.5.0"
-# Fast build
-build.tool-args = ["-j8"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"
@@ -131,4 +129,4 @@ manylinux-aarch64-image = "manylinux_2_28"
 
 [tool.cibuildwheel.linux]
 before-all = "bash build_dependencies/install_linux.sh"
-environment = { SKBUILD_CMAKE_DEFINE = "CMAKE_TOOLCHAIN_FILE=/project/conan_build/conan_toolchain.cmake" }
+environment = { SKBUILD_CMAKE_DEFINE = "CMAKE_TOOLCHAIN_FILE=/project/conan_build/conan_toolchain.cmake", CMAKE_BUILD_PARALLEL_LEVEL = "$(nproc)" }

--- a/src/kompass_core/control/dvz.py
+++ b/src/kompass_core/control/dvz.py
@@ -94,6 +94,8 @@ class DVZ(FollowerTemplate):
 
         self._dvz_linear: float = 0.0
         self._dvz_angular: float = 0.0
+        # Angular commands below the robot's minimum are treated as no rotation
+        self.__min_angular = ctrl_limits.omega_limits.min_omega
 
         generator_config = StanleyConfig(
             heading_gain=config.heading_gain, cross_track_gain=config.cross_track_gain
@@ -232,8 +234,7 @@ class DVZ(FollowerTemplate):
         """
         if (
             self._robot.robot_type != RobotType.ACKERMANN
-            and abs(self._dvz_angular)
-            > self.__reference_cmd_generator._config.min_angular_vel
+            and abs(self._dvz_angular) > self.__min_angular
         ):
             if (
                 abs(self.orientation_error)
@@ -258,8 +259,7 @@ class DVZ(FollowerTemplate):
         """
         if (
             self._robot.robot_type != RobotType.ACKERMANN
-            and abs(self._dvz_angular)
-            > self.__reference_cmd_generator._config.min_angular_vel
+            and abs(self._dvz_angular) > self.__min_angular
         ):
             if (
                 abs(self.orientation_error)
@@ -283,8 +283,7 @@ class DVZ(FollowerTemplate):
         """
         if (
             self._robot.robot_type != RobotType.ACKERMANN
-            and abs(self._dvz_angular)
-            > self.__reference_cmd_generator._config.min_angular_vel
+            and abs(self._dvz_angular) > self.__min_angular
         ):
             if (
                 abs(self.orientation_error)

--- a/src/kompass_core/control/dwa.py
+++ b/src/kompass_core/control/dwa.py
@@ -87,6 +87,11 @@ class DWAConfig(FollowerConfig):
       - `True`
       - To drop the entire sample once a collision is detected (True), or maintain the first collision-free segment of the sample (if False)
 
+    * - allow_reverse
+      - `bool`
+      - `True`
+      - Whether reversing (negative forward velocity) samples are generated. Set to `False` for robots that should only be driven forward.
+
     ```
     """
 
@@ -131,6 +136,8 @@ class DWAConfig(FollowerConfig):
     )
 
     drop_samples: bool = field(default=True)
+
+    allow_reverse: bool = field(default=True)
 
     def __attrs_post_init__(self):
         """Attrs post init"""
@@ -240,6 +247,7 @@ class DWA(FollowerTemplate):
             sensor_rotation_robot=self._config.proximity_sensor_rotation_to_robot,
             octree_resolution=self._config.octree_resolution,
             cost_weights=self._config.costs_weights.to_kompass_cpp(),
+            allow_reverse=self._config.allow_reverse,
             max_num_threads=self._config.max_num_threads,
         )
 

--- a/src/kompass_core/control/rgb_follower.py
+++ b/src/kompass_core/control/rgb_follower.py
@@ -30,7 +30,6 @@ class VisionRGBFollowerConfig(BaseAttrs):
         target_search_radius (float): Radius used for searching the target (m).
         rotation_gain (float): Proportional gain for angular control.
         speed_gain (float): Proportional gain for linear speed control.
-        min_vel (float): Minimum linear velocity allowed during target following (m/s).
         enable_search (bool): Whether to activate search behavior when the target is lost.
     """
 
@@ -64,9 +63,6 @@ class VisionRGBFollowerConfig(BaseAttrs):
     )
     speed_gain: float = field(
         default=0.7, validator=base_validators.in_range(min_value=1e-9, max_value=10.0)
-    )
-    min_vel: float = field(
-        default=0.1, validator=base_validators.in_range(min_value=1e-9, max_value=1e9)
     )
     enable_search: bool = field(default=True)
 

--- a/src/kompass_core/control/rgbd_follower.py
+++ b/src/kompass_core/control/rgbd_follower.py
@@ -446,6 +446,8 @@ class VisionRGBDFollower(ControllerTemplate):
         # Init the following result
         self._result = SamplingControlResult()
         self._end_of_ctrl_horizon: int = max(self._config.control_horizon, 1)
+        # Becomes True once the core tracker holds an initial target
+        self._tracking_initialized = False
         logging.info("RGBDFollower CONTROLLER IS READY")
 
     def set_camera_intrinsics(self, fx: float, fy: float, cx: float, cy: float) -> None:
@@ -473,6 +475,14 @@ class VisionRGBDFollower(ControllerTemplate):
         :type sensor: SensorConfig
         """
         self._planner.set_point_cloud_sensor(sensor)
+
+    def _note_initial_tracking(self, ok: bool) -> bool:
+        """Record a successful initial tracking so later ticks without depth
+        are treated as observation gaps. A failed re-initialization leaves the
+        core tracker (and the flag) as it was."""
+        if ok:
+            self._tracking_initialized = True
+        return ok
 
     def set_initial_tracking_2d_target(
         self,
@@ -557,11 +567,17 @@ class VisionRGBDFollower(ControllerTemplate):
             yaw = current_state.yaw if current_state else 0.0
             if isinstance(depth_source, dict):
                 # point cloud
-                return self._planner.set_initial_tracking(
-                    **depth_source, target_box_2d=target_box, robot_orientation=yaw
+                return self._note_initial_tracking(
+                    self._planner.set_initial_tracking(
+                        **depth_source,
+                        target_box_2d=target_box,
+                        robot_orientation=yaw,
+                    )
                 )
             # depth image
-            return self._planner.set_initial_tracking(depth_source, target_box, yaw)
+            return self._note_initial_tracking(
+                self._planner.set_initial_tracking(depth_source, target_box, yaw)
+            )
 
         except Exception as e:
             logging.error(f"Could not set initial tracking state: {e}")
@@ -659,16 +675,20 @@ class VisionRGBDFollower(ControllerTemplate):
                 yaw = current_state.yaw if current_state else 0.0
                 if isinstance(depth_source, dict):
                     # point cloud
-                    return self._planner.set_initial_tracking(
-                        pose_x_img,
-                        pose_y_img,
-                        **depth_source,
-                        detected_boxes_2d=detected_boxes,
-                        robot_orientation=yaw,
+                    return self._note_initial_tracking(
+                        self._planner.set_initial_tracking(
+                            pose_x_img,
+                            pose_y_img,
+                            **depth_source,
+                            detected_boxes_2d=detected_boxes,
+                            robot_orientation=yaw,
+                        )
                     )
                 # depth image
-                return self._planner.set_initial_tracking(
-                    pose_x_img, pose_y_img, depth_source, detected_boxes, yaw
+                return self._note_initial_tracking(
+                    self._planner.set_initial_tracking(
+                        pose_x_img, pose_y_img, depth_source, detected_boxes, yaw
+                    )
                 )
             logging.error(
                 "Could not set initial tracking state: No detections are provided"
@@ -699,7 +719,10 @@ class VisionRGBDFollower(ControllerTemplate):
 
         The 2D detections are lifted to 3D through exactly one depth source:
         an aligned depth image or a point cloud given as its PointCloud2
-        layout. Without either the step is skipped.
+        layout. A tick without either counts as an observation gap once
+        tracking has started: the follower holds or searches per its
+        wait/search configuration and only reports failure when that recovery
+        is exhausted. Before tracking has started such a tick is skipped.
 
         In global mode (``_use_local_coordinates=False``) ``current_state`` is
         **mandatory** — it is used by the depth detector (world-frame
@@ -735,8 +758,8 @@ class VisionRGBDFollower(ControllerTemplate):
             y_offset=y_offset,
             z_offset=z_offset,
         )
-        if depth_source is None:
-            # No depth this tick, skip.
+        if depth_source is None and not self._tracking_initialized:
+            # No depth and no target to recover: nothing to do this tick.
             logging.debug(
                 "RGBDFollower loop_step called without a depth image or a point cloud"
             )
@@ -765,7 +788,13 @@ class VisionRGBDFollower(ControllerTemplate):
 
         try:
             robot_velocity = robot_cmd or self._last_cmd
-            if isinstance(depth_source, dict):
+            if depth_source is None:
+                # No depth this tick, report an observation gap so the
+                # follower's own wait/search recovery decides the outcome
+                self._result = self._planner.get_tracking_ctrl(
+                    [], robot_velocity
+                )
+            elif isinstance(depth_source, dict):
                 # point cloud
                 self._result = self._planner.get_tracking_ctrl(
                     **depth_source,

--- a/src/kompass_core/control/rgbd_follower.py
+++ b/src/kompass_core/control/rgbd_follower.py
@@ -446,8 +446,6 @@ class VisionRGBDFollower(ControllerTemplate):
         # Init the following result
         self._result = SamplingControlResult()
         self._end_of_ctrl_horizon: int = max(self._config.control_horizon, 1)
-        # Becomes True once the core tracker holds an initial target
-        self._tracking_initialized = False
         logging.info("RGBDFollower CONTROLLER IS READY")
 
     def set_camera_intrinsics(self, fx: float, fy: float, cx: float, cy: float) -> None:
@@ -475,14 +473,6 @@ class VisionRGBDFollower(ControllerTemplate):
         :type sensor: SensorConfig
         """
         self._planner.set_point_cloud_sensor(sensor)
-
-    def _note_initial_tracking(self, ok: bool) -> bool:
-        """Record a successful initial tracking so later ticks without depth
-        are treated as observation gaps. A failed re-initialization leaves the
-        core tracker (and the flag) as it was."""
-        if ok:
-            self._tracking_initialized = True
-        return ok
 
     def set_initial_tracking_2d_target(
         self,
@@ -567,17 +557,11 @@ class VisionRGBDFollower(ControllerTemplate):
             yaw = current_state.yaw if current_state else 0.0
             if isinstance(depth_source, dict):
                 # point cloud
-                return self._note_initial_tracking(
-                    self._planner.set_initial_tracking(
-                        **depth_source,
-                        target_box_2d=target_box,
-                        robot_orientation=yaw,
-                    )
+                return self._planner.set_initial_tracking(
+                    **depth_source, target_box_2d=target_box, robot_orientation=yaw
                 )
             # depth image
-            return self._note_initial_tracking(
-                self._planner.set_initial_tracking(depth_source, target_box, yaw)
-            )
+            return self._planner.set_initial_tracking(depth_source, target_box, yaw)
 
         except Exception as e:
             logging.error(f"Could not set initial tracking state: {e}")
@@ -675,20 +659,16 @@ class VisionRGBDFollower(ControllerTemplate):
                 yaw = current_state.yaw if current_state else 0.0
                 if isinstance(depth_source, dict):
                     # point cloud
-                    return self._note_initial_tracking(
-                        self._planner.set_initial_tracking(
-                            pose_x_img,
-                            pose_y_img,
-                            **depth_source,
-                            detected_boxes_2d=detected_boxes,
-                            robot_orientation=yaw,
-                        )
+                    return self._planner.set_initial_tracking(
+                        pose_x_img,
+                        pose_y_img,
+                        **depth_source,
+                        detected_boxes_2d=detected_boxes,
+                        robot_orientation=yaw,
                     )
                 # depth image
-                return self._note_initial_tracking(
-                    self._planner.set_initial_tracking(
-                        pose_x_img, pose_y_img, depth_source, detected_boxes, yaw
-                    )
+                return self._planner.set_initial_tracking(
+                    pose_x_img, pose_y_img, depth_source, detected_boxes, yaw
                 )
             logging.error(
                 "Could not set initial tracking state: No detections are provided"
@@ -719,10 +699,6 @@ class VisionRGBDFollower(ControllerTemplate):
 
         The 2D detections are lifted to 3D through exactly one depth source:
         an aligned depth image or a point cloud given as its PointCloud2
-        layout. A tick without either counts as an observation gap once
-        tracking has started: the follower holds or searches per its
-        wait/search configuration and only reports failure when that recovery
-        is exhausted. Before tracking has started such a tick is skipped.
 
         In global mode (``_use_local_coordinates=False``) ``current_state`` is
         **mandatory** — it is used by the depth detector (world-frame
@@ -758,8 +734,8 @@ class VisionRGBDFollower(ControllerTemplate):
             y_offset=y_offset,
             z_offset=z_offset,
         )
-        if depth_source is None and not self._tracking_initialized:
-            # No depth and no target to recover: nothing to do this tick.
+        if depth_source is None:
+            # No depth this tick, skip.
             logging.debug(
                 "RGBDFollower loop_step called without a depth image or a point cloud"
             )
@@ -788,13 +764,7 @@ class VisionRGBDFollower(ControllerTemplate):
 
         try:
             robot_velocity = robot_cmd or self._last_cmd
-            if depth_source is None:
-                # No depth this tick, report an observation gap so the
-                # follower's own wait/search recovery decides the outcome
-                self._result = self._planner.get_tracking_ctrl(
-                    [], robot_velocity
-                )
-            elif isinstance(depth_source, dict):
+            if isinstance(depth_source, dict):
                 # point cloud
                 self._result = self._planner.get_tracking_ctrl(
                     **depth_source,

--- a/src/kompass_core/control/rgbd_follower.py
+++ b/src/kompass_core/control/rgbd_follower.py
@@ -7,15 +7,52 @@ from kompass_cpp.control import (
 )
 from kompass_cpp.types import (
     Bbox2D,
+    SensorConfig,
     Velocity2D,
     TrajectoryVelocities2D,
     TrajectoryPath,
 )
-from typing import Optional, List, Union
+from typing import Any, Dict, Optional, List, Union
 import numpy as np
 import logging
 from ._base_ import ControllerTemplate, FollowerConfig
 from ..models import Robot, RobotState, RobotCtrlLimits, RobotGeometry, RobotType
+
+
+def _depth_source(
+    depth_image: Optional[np.ndarray],
+    data: Optional[np.ndarray],
+    **layout: Optional[int],
+) -> Optional[Union[np.ndarray, Dict[str, Any]]]:
+    """Pick the one depth source a call was given. Depth image or PointCloud2
+    Passing both sources, or a cloud with layout fields missing, is an error.
+
+    :param depth_image: Aligned depth image, if any
+    :type depth_image: Optional[np.ndarray]
+    :param data: Raw PointCloud2 buffer, if any
+    :type data: Optional[np.ndarray]
+    :param layout: point_step, row_step, height, width, x_offset, y_offset,
+        z_offset of the cloud
+    :type layout: Optional[int]
+    :return: The depth image, the cloud keyword dict, or None when neither is
+        given
+    :rtype: Optional[Union[np.ndarray, Dict[str, Any]]]
+    """
+    if depth_image is not None and data is not None:
+        raise ValueError(
+            "Provide either a depth image or a point cloud as the depth source, "
+            "not both"
+        )
+    if depth_image is not None:
+        return depth_image
+    if data is None:
+        return None
+    missing = [name for name, value in layout.items() if value is None]
+    if missing:
+        raise ValueError(
+            f"Point cloud layout is incomplete, missing: {', '.join(missing)}"
+        )
+    return {"data": data, **layout}
 
 
 @define
@@ -425,13 +462,36 @@ class VisionRGBDFollower(ControllerTemplate):
         """
         self._planner.set_camera_intrinsics(fx, fy, cx, cy)
 
+    def set_point_cloud_sensor(self, sensor: SensorConfig) -> None:
+        """Describe the point cloud sensor used when detections are lifted
+        from a point cloud instead of a depth image.
+
+        Until this is called the cloud is taken as already expressed in the
+        body frame with FLOAT32 fields.
+
+        :param sensor: Mount pose and field encoding of the point cloud sensor
+        :type sensor: SensorConfig
+        """
+        self._planner.set_point_cloud_sensor(sensor)
+
     def set_initial_tracking_2d_target(
         self,
         current_state: RobotState,
         target_box: Bbox2D,
-        aligned_depth_image: np.ndarray,
+        aligned_depth_image: Optional[np.ndarray] = None,
+        *,
+        data: Optional[np.ndarray] = None,
+        point_step: Optional[int] = None,
+        row_step: Optional[int] = None,
+        height: Optional[int] = None,
+        width: Optional[int] = None,
+        x_offset: Optional[int] = None,
+        y_offset: Optional[int] = None,
+        z_offset: Optional[int] = None,
+        **_,
     ) -> bool:
-        """Set initial tracking from a single 2D target box and depth image.
+        """Set initial tracking from a single 2D target box and one depth
+        source: an aligned depth image or a point cloud.
 
         In global mode the robot state is used by the depth detector to project
         the 3D box into the world frame. In local mode the state is ignored
@@ -441,11 +501,50 @@ class VisionRGBDFollower(ControllerTemplate):
         :type current_state: RobotState
         :param target_box: 2D bounding box of the target
         :type target_box: Bbox2D
-        :param aligned_depth_image: Aligned depth image
-        :type aligned_depth_image: np.ndarray
+        :param aligned_depth_image: Aligned depth image (uint16 millimeters or
+            float32 meters)
+        :type aligned_depth_image: Optional[np.ndarray]
+        :param data: Raw PointCloud2 buffer of a point cloud, the alternative
+            depth source. The layout keywords mirror the sensor_msgs/PointCloud2
+            message and are the same the local mapper's
+            ``update_from_pointcloud`` takes, so a whole cloud container can
+            be splatted in (further fields are ignored). The points are in the
+            sensor frame described by ``set_point_cloud_sensor``.
+        :type data: Optional[np.ndarray]
+        :param point_step: Bytes per point
+        :type point_step: Optional[int]
+        :param row_step: Bytes per row
+        :type row_step: Optional[int]
+        :param height: Number of rows (1 for an unorganized cloud)
+        :type height: Optional[int]
+        :param width: Points per row
+        :type width: Optional[int]
+        :param x_offset: Byte offset of the x field in a point
+        :type x_offset: Optional[int]
+        :param y_offset: Byte offset of the y field in a point
+        :type y_offset: Optional[int]
+        :param z_offset: Byte offset of the z field in a point
+        :type z_offset: Optional[int]
         :return: Whether tracking was successfully initialized
         :rtype: bool
         """
+        depth_source = _depth_source(
+            aligned_depth_image,
+            data,
+            point_step=point_step,
+            row_step=row_step,
+            height=height,
+            width=width,
+            x_offset=x_offset,
+            y_offset=y_offset,
+            z_offset=z_offset,
+        )
+        if depth_source is None:
+            logging.error(
+                "Could not set initial tracking state: No depth image or point "
+                "cloud is provided"
+            )
+            return False
         try:
             if not self._config._use_local_coordinates:
                 # Global mode: detector needs the robot pose for world-frame projection
@@ -455,11 +554,14 @@ class VisionRGBDFollower(ControllerTemplate):
                     current_state.yaw,
                     current_state.speed,
                 )
-            return self._planner.set_initial_tracking(
-                aligned_depth_image,
-                target_box,
-                current_state.yaw if current_state else 0.0,
-            )
+            yaw = current_state.yaw if current_state else 0.0
+            if isinstance(depth_source, dict):
+                # point cloud
+                return self._planner.set_initial_tracking(
+                    **depth_source, target_box_2d=target_box, robot_orientation=yaw
+                )
+            # depth image
+            return self._planner.set_initial_tracking(depth_source, target_box, yaw)
 
         except Exception as e:
             logging.error(f"Could not set initial tracking state: {e}")
@@ -489,10 +591,21 @@ class VisionRGBDFollower(ControllerTemplate):
         pose_x_img: int,
         pose_y_img: int,
         detected_boxes: List[Bbox2D],
-        aligned_depth_image: np.ndarray,
+        aligned_depth_image: Optional[np.ndarray] = None,
+        *,
+        data: Optional[np.ndarray] = None,
+        point_step: Optional[int] = None,
+        row_step: Optional[int] = None,
+        height: Optional[int] = None,
+        width: Optional[int] = None,
+        x_offset: Optional[int] = None,
+        y_offset: Optional[int] = None,
+        z_offset: Optional[int] = None,
+        **_,
     ) -> bool:
         """Set initial tracking by selecting a pixel inside one of the 2D
-        detection boxes.
+        detection boxes, lifted through one depth source: an aligned depth
+        image or a point cloud.
 
         In global mode the robot state is used by the depth detector to project
         the 3D box into the world frame. In local mode the state is ignored
@@ -506,11 +619,33 @@ class VisionRGBDFollower(ControllerTemplate):
         :type pose_y_img: int
         :param detected_boxes: List of 2D detection bounding boxes
         :type detected_boxes: List[Bbox2D]
-        :param aligned_depth_image: Aligned depth image
-        :type aligned_depth_image: np.ndarray
+        :param aligned_depth_image: Aligned depth image (uint16 millimeters or
+            float32 meters)
+        :type aligned_depth_image: Optional[np.ndarray]
+        :param data: Raw PointCloud2 buffer of a point cloud, the alternative
+            depth source; the layout keywords are as in
+            ``set_initial_tracking_2d_target``
+        :type data: Optional[np.ndarray]
         :return: Whether tracking was successfully initialized
         :rtype: bool
         """
+        depth_source = _depth_source(
+            aligned_depth_image,
+            data,
+            point_step=point_step,
+            row_step=row_step,
+            height=height,
+            width=width,
+            x_offset=x_offset,
+            y_offset=y_offset,
+            z_offset=z_offset,
+        )
+        if depth_source is None:
+            logging.error(
+                "Could not set initial tracking state: No depth image or point "
+                "cloud is provided"
+            )
+            return False
         try:
             if not self._config._use_local_coordinates:
                 # Global mode: detector needs the robot pose for world-frame projection
@@ -521,12 +656,19 @@ class VisionRGBDFollower(ControllerTemplate):
                     current_state.speed,
                 )
             if any(detected_boxes):
+                yaw = current_state.yaw if current_state else 0.0
+                if isinstance(depth_source, dict):
+                    # point cloud
+                    return self._planner.set_initial_tracking(
+                        pose_x_img,
+                        pose_y_img,
+                        **depth_source,
+                        detected_boxes_2d=detected_boxes,
+                        robot_orientation=yaw,
+                    )
+                # depth image
                 return self._planner.set_initial_tracking(
-                    pose_x_img,
-                    pose_y_img,
-                    aligned_depth_image,
-                    detected_boxes,
-                    current_state.yaw if current_state else 0.0,
+                    pose_x_img, pose_y_img, depth_source, detected_boxes, yaw
                 )
             logging.error(
                 "Could not set initial tracking state: No detections are provided"
@@ -543,9 +685,21 @@ class VisionRGBDFollower(ControllerTemplate):
         current_state: Optional[RobotState] = None,
         detections_2d: Optional[List[Bbox2D]] = None,
         depth_image: Optional[np.ndarray] = None,
+        data: Optional[np.ndarray] = None,
+        point_step: Optional[int] = None,
+        row_step: Optional[int] = None,
+        height: Optional[int] = None,
+        width: Optional[int] = None,
+        x_offset: Optional[int] = None,
+        y_offset: Optional[int] = None,
+        z_offset: Optional[int] = None,
         **_,
     ) -> bool:
         """Run one iteration of the vision follower.
+
+        The 2D detections are lifted to 3D through exactly one depth source:
+        an aligned depth image or a point cloud given as its PointCloud2
+        layout. Without either the step is skipped.
 
         In global mode (``_use_local_coordinates=False``) ``current_state`` is
         **mandatory** — it is used by the depth detector (world-frame
@@ -560,14 +714,32 @@ class VisionRGBDFollower(ControllerTemplate):
         :type current_state: Optional[RobotState]
         :param detections_2d: 2D detection bounding boxes from the vision pipeline
         :type detections_2d: Optional[List[Bbox2D]]
-        :param depth_image: Aligned depth image
+        :param depth_image: Aligned depth image (uint16 millimeters or float32
+            meters)
         :type depth_image: Optional[np.ndarray]
+        :param data: Raw PointCloud2 buffer of a point cloud, the alternative
+            depth source; the layout keywords are as in
+            ``set_initial_tracking_2d_target``
+        :type data: Optional[np.ndarray]
         :return: Whether the planner found a valid solution
         :rtype: bool
         """
-        if depth_image is None:
+        depth_source = _depth_source(
+            depth_image,
+            data,
+            point_step=point_step,
+            row_step=row_step,
+            height=height,
+            width=width,
+            x_offset=x_offset,
+            y_offset=y_offset,
+            z_offset=z_offset,
+        )
+        if depth_source is None:
             # No depth this tick, skip.
-            logging.debug("RGBDFollower loop_step called without a depth image")
+            logging.debug(
+                "RGBDFollower loop_step called without a depth image or a point cloud"
+            )
             return False
 
         robot_cmd = None
@@ -592,9 +764,19 @@ class VisionRGBDFollower(ControllerTemplate):
             )
 
         try:
-            self._result = self._planner.get_tracking_ctrl(
-                depth_image, detections_2d, robot_cmd or self._last_cmd
-            )
+            robot_velocity = robot_cmd or self._last_cmd
+            if isinstance(depth_source, dict):
+                # point cloud
+                self._result = self._planner.get_tracking_ctrl(
+                    **depth_source,
+                    detected_boxes_2d=detections_2d,
+                    robot_velocity=robot_velocity,
+                )
+            else:
+                # depth image
+                self._result = self._planner.get_tracking_ctrl(
+                    depth_source, detections_2d, robot_velocity
+                )
 
         except Exception as e:
             logging.error(f"Could not find velocity command: {e}")

--- a/src/kompass_core/control/rgbd_follower.py
+++ b/src/kompass_core/control/rgbd_follower.py
@@ -362,21 +362,21 @@ class VisionRGBDFollower(ControllerTemplate):
     # Prepare detections + depth image
     bbox = Bbox2D(top_left_corner=np.array([200, 150]), size=np.array([50, 100]))
     bbox.set_img_size(np.array([640, 480]))
-    aligned_depth_image = np.zeros((480, 640), dtype=np.uint16)  # mm depth
+    depth_image = np.zeros((480, 640), dtype=np.uint16)  # mm depth
     robot_state = RobotState(x=0.0, y=0.0, yaw=0.0, speed=0.0)
 
     # Initialize target tracking
     controller.set_initial_tracking_2d_target(
         current_state=robot_state,
         target_box=bbox,
-        aligned_depth_image=aligned_depth_image,
+        depth_image=depth_image,
     )
 
     # Run one control step
     success = controller.loop_step(
         current_state=robot_state,
         detections_2d=[bbox],
-        depth_image=aligned_depth_image,
+        depth_image=depth_image,
     )
 
     # Access control outputs
@@ -478,7 +478,7 @@ class VisionRGBDFollower(ControllerTemplate):
         self,
         current_state: RobotState,
         target_box: Bbox2D,
-        aligned_depth_image: Optional[np.ndarray] = None,
+        depth_image: Optional[np.ndarray] = None,
         *,
         data: Optional[np.ndarray] = None,
         point_step: Optional[int] = None,
@@ -501,9 +501,9 @@ class VisionRGBDFollower(ControllerTemplate):
         :type current_state: RobotState
         :param target_box: 2D bounding box of the target
         :type target_box: Bbox2D
-        :param aligned_depth_image: Aligned depth image (uint16 millimeters or
+        :param depth_image: Aligned depth image (uint16 millimeters or
             float32 meters)
-        :type aligned_depth_image: Optional[np.ndarray]
+        :type depth_image: Optional[np.ndarray]
         :param data: Raw PointCloud2 buffer of a point cloud, the alternative
             depth source. The layout keywords mirror the sensor_msgs/PointCloud2
             message and are the same the local mapper's
@@ -529,7 +529,7 @@ class VisionRGBDFollower(ControllerTemplate):
         :rtype: bool
         """
         depth_source = _depth_source(
-            aligned_depth_image,
+            depth_image,
             data,
             point_step=point_step,
             row_step=row_step,
@@ -591,7 +591,7 @@ class VisionRGBDFollower(ControllerTemplate):
         pose_x_img: int,
         pose_y_img: int,
         detected_boxes: List[Bbox2D],
-        aligned_depth_image: Optional[np.ndarray] = None,
+        depth_image: Optional[np.ndarray] = None,
         *,
         data: Optional[np.ndarray] = None,
         point_step: Optional[int] = None,
@@ -619,9 +619,9 @@ class VisionRGBDFollower(ControllerTemplate):
         :type pose_y_img: int
         :param detected_boxes: List of 2D detection bounding boxes
         :type detected_boxes: List[Bbox2D]
-        :param aligned_depth_image: Aligned depth image (uint16 millimeters or
+        :param depth_image: Aligned depth image (uint16 millimeters or
             float32 meters)
-        :type aligned_depth_image: Optional[np.ndarray]
+        :type depth_image: Optional[np.ndarray]
         :param data: Raw PointCloud2 buffer of a point cloud, the alternative
             depth source; the layout keywords are as in
             ``set_initial_tracking_2d_target``
@@ -630,7 +630,7 @@ class VisionRGBDFollower(ControllerTemplate):
         :rtype: bool
         """
         depth_source = _depth_source(
-            aligned_depth_image,
+            depth_image,
             data,
             point_step=point_step,
             row_step=row_step,

--- a/src/kompass_core/control/stanley.py
+++ b/src/kompass_core/control/stanley.py
@@ -50,10 +50,6 @@ class StanleyConfig(FollowerConfig):
       - `float`
       - `0.1`
       - Maximum allowable distance error. Must be between `1e-9` and `1e9`.
-    * - min_angular_vel
-      - `float`
-      - `0.01`
-      - Minimum allowable angular velocity. Must be between `0.0` and `1e9`.
 
     ```
     """
@@ -85,10 +81,6 @@ class StanleyConfig(FollowerConfig):
 
     max_distance_error: float = field(
         default=0.1, validator=base_validators.in_range(min_value=1e-9, max_value=1e9)
-    )
-
-    min_angular_vel: float = field(
-        default=0.01, validator=base_validators.in_range(min_value=0.0, max_value=1e9)
     )
 
     def to_kompass_cpp(self) -> kompass_cpp.control.StanleyParameters:
@@ -152,6 +144,8 @@ class Stanley(FollowerTemplate):
         self._planner.set_angular_ctr_limits(ctrl_limits.omega_limits)
 
         self.__max_angular = ctrl_limits.omega_limits.max_omega
+        # Angular commands below the robot's minimum are treated as no rotation
+        self.__min_angular = ctrl_limits.omega_limits.min_omega
 
         # Init the following result
         self._result = kompass_cpp.control.FollowingResult()
@@ -205,7 +199,7 @@ class Stanley(FollowerTemplate):
 
         elif (
             self._robot.robot_type != RobotType.ACKERMANN
-            and abs(self._planner.get_omega_cmd()) > self._config.min_angular_vel
+            and abs(self._planner.get_omega_cmd()) > self.__min_angular
         ):
             if (
                 abs(self.orientation_error) > self._config.max_angle_error
@@ -230,7 +224,7 @@ class Stanley(FollowerTemplate):
 
         elif (
             self._robot.robot_type != RobotType.ACKERMANN
-            and abs(self._planner.get_omega_cmd()) > self._config.min_angular_vel
+            and abs(self._planner.get_omega_cmd()) > self.__min_angular
         ):
             if (
                 abs(self.orientation_error) > self._config.max_angle_error
@@ -255,7 +249,7 @@ class Stanley(FollowerTemplate):
 
         if (
             self._robot.robot_type != RobotType.ACKERMANN
-            and abs(self._planner.get_omega_cmd()) > self._config.min_angular_vel
+            and abs(self._planner.get_omega_cmd()) > self.__min_angular
         ):
             if (
                 abs(self.orientation_error) > self._config.max_angle_error

--- a/src/kompass_cpp/bindings/bindings.h
+++ b/src/kompass_cpp/bindings/bindings.h
@@ -48,8 +48,9 @@ inline Kompass::ByteSpan toSpan(const ByteArray &a) {
 
 // Zero-copy input types for aligned depth images: a 2-D C-contiguous
 // (rows, cols) numpy array, uint16 (depth in millimetres, ROS 16UC1) or
-// float32 (depth in metres, ROS 32FC1. Wrong-dtype or non-contiguous input
-// converts with a single C-level copy.
+// float32 (depth in metres, ROS 32FC1). Bound with noconvert so a wrong dtype
+// or a non-contiguous layout raises instead of being copied into the other
+// dtype's overload.
 using DepthArrayU16 =
     py::ndarray<const uint16_t, py::ndim<2>, py::c_contig, py::device::cpu>;
 using DepthArrayF32 =

--- a/src/kompass_cpp/bindings/bindings_control.cpp
+++ b/src/kompass_cpp/bindings/bindings_control.cpp
@@ -102,12 +102,14 @@ void bindings_control(py::module_ &m) {
   py::class_<Control::LinearVelocityControlParams>(
       m_control, "LinearVelocityControlParams")
       .def(py::init<const Control::LinearVelocityControlParams &>())
-      .def(py::init<double, double, double>(), py::arg("max_vel") = 0.0,
-           py::arg("max_acc") = 0.0, py::arg("max_decel") = 0.0)
+      .def(py::init<double, double, double, double>(),
+           py::arg("max_vel") = 0.0, py::arg("max_acc") = 0.0,
+           py::arg("max_decel") = 0.0, py::arg("min_vel") = 0.05)
       .def_rw("max_vel", &Control::LinearVelocityControlParams::maxVel)
       .def_rw("max_acc", &Control::LinearVelocityControlParams::maxAcceleration)
       .def_rw("max_decel",
-              &Control::LinearVelocityControlParams::maxDeceleration);
+              &Control::LinearVelocityControlParams::maxDeceleration)
+      .def_rw("min_vel", &Control::LinearVelocityControlParams::minVel);
 
   py::class_<Control::AngularVelocityControlParams>(
       m_control, "AngularVelocityControlParams")

--- a/src/kompass_cpp/bindings/bindings_control.cpp
+++ b/src/kompass_cpp/bindings/bindings_control.cpp
@@ -303,14 +303,16 @@ void bindings_control(py::module_ &m) {
                     double, double, int, int, CollisionChecker::ShapeType,
                     std::vector<float>, const Eigen::Vector3f &,
                     const Eigen::Vector4f &, double,
-                    Control::CostEvaluator::TrajectoryCostsWeights, int>(),
+                    Control::CostEvaluator::TrajectoryCostsWeights, bool,
+                    int>(),
            py::arg("control_limits"), py::arg("control_type"),
            py::arg("time_step"), py::arg("prediction_horizon"),
            py::arg("control_horizon"), py::arg("max_linear_samples"),
            py::arg("max_angular_samples"), py::arg("robot_shape_type"),
            py::arg("robot_dimensions"), py::arg("sensor_position_robot"),
            py::arg("sensor_rotation_robot"), py::arg("octree_resolution"),
-           py::arg("cost_weights"), py::arg("max_num_threads") = 1)
+           py::arg("cost_weights"), py::arg("allow_reverse") = true,
+           py::arg("max_num_threads") = 1)
 
       .def(py::init<Control::TrajectorySampler::TrajectorySamplerParameters,
                     Control::ControlLimitsParams, Control::ControlType,

--- a/src/kompass_cpp/bindings/bindings_control.cpp
+++ b/src/kompass_cpp/bindings/bindings_control.cpp
@@ -432,17 +432,17 @@ void bindings_control(py::module_ &m) {
       // C-contiguous); one typed overload per dtype, sharing one template
       .def("set_initial_tracking", &setInitialTrackingAtPixel<DepthArrayU16>,
            py::arg("pixel_x"), py::arg("pixel_y"),
-           py::arg("depth_image"), py::arg("detected_boxes_2d"),
+           py::arg("depth_image").noconvert(), py::arg("detected_boxes_2d"),
            py::arg("robot_orientation") = 0.0)
       .def("set_initial_tracking", &setInitialTrackingAtPixel<DepthArrayF32>,
            py::arg("pixel_x"), py::arg("pixel_y"),
-           py::arg("depth_image"), py::arg("detected_boxes_2d"),
+           py::arg("depth_image").noconvert(), py::arg("detected_boxes_2d"),
            py::arg("robot_orientation") = 0.0)
       .def("set_initial_tracking", &setInitialTrackingBox<DepthArrayU16>,
-           py::arg("depth_image"), py::arg("target_box_2d"),
+           py::arg("depth_image").noconvert(), py::arg("target_box_2d"),
            py::arg("robot_orientation") = 0.0)
       .def("set_initial_tracking", &setInitialTrackingBox<DepthArrayF32>,
-           py::arg("depth_image"), py::arg("target_box_2d"),
+           py::arg("depth_image").noconvert(), py::arg("target_box_2d"),
            py::arg("robot_orientation") = 0.0)
       .def("set_point_cloud_sensor",
            &Control::RGBDFollower::setPointCloudSensor, py::arg("sensor"),
@@ -492,10 +492,10 @@ void bindings_control(py::module_ &m) {
            py::call_guard<py::gil_scoped_release>())
       // Depth Array variants
       .def("get_tracking_ctrl", &getTrackingCtrlDepth<DepthArrayU16>,
-           py::arg("depth_image"), py::arg("detected_boxes_2d"),
+           py::arg("depth_image").noconvert(), py::arg("detected_boxes_2d"),
            py::arg("robot_velocity"))
       .def("get_tracking_ctrl", &getTrackingCtrlDepth<DepthArrayF32>,
-           py::arg("depth_image"), py::arg("detected_boxes_2d"),
+           py::arg("depth_image").noconvert(), py::arg("detected_boxes_2d"),
            py::arg("robot_velocity"))
       // Point-cloud variant
       .def("get_tracking_ctrl", &getTrackingCtrlCloud, py::arg("data"),

--- a/src/kompass_cpp/bindings/bindings_control.cpp
+++ b/src/kompass_cpp/bindings/bindings_control.cpp
@@ -114,15 +114,17 @@ void bindings_control(py::module_ &m) {
   py::class_<Control::AngularVelocityControlParams>(
       m_control, "AngularVelocityControlParams")
       .def(py::init<const Control::AngularVelocityControlParams &>())
-      .def(py::init<double, double, double, double>(),
+      .def(py::init<double, double, double, double, double>(),
            py::arg("max_ang") = M_PI, py::arg("max_omega") = 0.0,
-           py::arg("max_acc") = 0.0, py::arg("max_decel") = 0.0)
+           py::arg("max_acc") = 0.0, py::arg("max_decel") = 0.0,
+           py::arg("min_omega") = 0.05)
       .def_rw("max_ang", &Control::AngularVelocityControlParams::maxAngle)
       .def_rw("max_omega", &Control::AngularVelocityControlParams::maxOmega)
       .def_rw("max_acc",
               &Control::AngularVelocityControlParams::maxAcceleration)
       .def_rw("max_decel",
-              &Control::AngularVelocityControlParams::maxDeceleration);
+              &Control::AngularVelocityControlParams::maxDeceleration)
+      .def_rw("min_omega", &Control::AngularVelocityControlParams::minOmega);
 
   py::class_<Control::ControlLimitsParams>(m_control, "ControlLimitsParams")
       .def(py::init<>())

--- a/src/kompass_cpp/bindings/bindings_control.cpp
+++ b/src/kompass_cpp/bindings/bindings_control.cpp
@@ -432,17 +432,17 @@ void bindings_control(py::module_ &m) {
       // C-contiguous); one typed overload per dtype, sharing one template
       .def("set_initial_tracking", &setInitialTrackingAtPixel<DepthArrayU16>,
            py::arg("pixel_x"), py::arg("pixel_y"),
-           py::arg("aligned_depth_image"), py::arg("detected_boxes_2d"),
+           py::arg("depth_image"), py::arg("detected_boxes_2d"),
            py::arg("robot_orientation") = 0.0)
       .def("set_initial_tracking", &setInitialTrackingAtPixel<DepthArrayF32>,
            py::arg("pixel_x"), py::arg("pixel_y"),
-           py::arg("aligned_depth_image"), py::arg("detected_boxes_2d"),
+           py::arg("depth_image"), py::arg("detected_boxes_2d"),
            py::arg("robot_orientation") = 0.0)
       .def("set_initial_tracking", &setInitialTrackingBox<DepthArrayU16>,
-           py::arg("aligned_depth_image"), py::arg("target_box_2d"),
+           py::arg("depth_image"), py::arg("target_box_2d"),
            py::arg("robot_orientation") = 0.0)
       .def("set_initial_tracking", &setInitialTrackingBox<DepthArrayF32>,
-           py::arg("aligned_depth_image"), py::arg("target_box_2d"),
+           py::arg("depth_image"), py::arg("target_box_2d"),
            py::arg("robot_orientation") = 0.0)
       .def("set_point_cloud_sensor",
            &Control::RGBDFollower::setPointCloudSensor, py::arg("sensor"),
@@ -492,10 +492,10 @@ void bindings_control(py::module_ &m) {
            py::call_guard<py::gil_scoped_release>())
       // Depth Array variants
       .def("get_tracking_ctrl", &getTrackingCtrlDepth<DepthArrayU16>,
-           py::arg("aligned_depth_image"), py::arg("detected_boxes_2d"),
+           py::arg("depth_image"), py::arg("detected_boxes_2d"),
            py::arg("robot_velocity"))
       .def("get_tracking_ctrl", &getTrackingCtrlDepth<DepthArrayF32>,
-           py::arg("aligned_depth_image"), py::arg("detected_boxes_2d"),
+           py::arg("depth_image"), py::arg("detected_boxes_2d"),
            py::arg("robot_velocity"))
       // Point-cloud variant
       .def("get_tracking_ctrl", &getTrackingCtrlCloud, py::arg("data"),

--- a/src/kompass_cpp/bindings/bindings_control.cpp
+++ b/src/kompass_cpp/bindings/bindings_control.cpp
@@ -17,8 +17,10 @@
 using namespace Kompass;
 
 namespace {
-// Private to file. The depth-image follower entries accept uint16 (mm) or
-// float32 (m) arrays. Templated functions with per dtype bindings below.
+// Private to file.
+
+// The depth-image follower entries accept uint16 (mm) or float32 (m) arrays.
+// Templated functions with per dtype bindings below.
 template <typename DepthArray>
 bool setInitialTrackingAtPixel(Control::RGBDFollower &self, const int pixel_x,
                                const int pixel_y, const DepthArray &depth,
@@ -44,6 +46,44 @@ Control::TrajSearchResult getTrackingCtrlDepth(Control::RGBDFollower &self,
                                                const Control::Velocity2D &vel) {
   const auto view = toDepthView(depth);
   // Solve without the GIL (argument conversions above still held it)
+  py::gil_scoped_release release;
+  return self.getTrackingCtrl(view, boxes, vel);
+}
+
+// Point-cloud variants that take the raw byte buffer (zero-copy), plus the
+// layout integers
+bool setInitialTrackingAtPixelCloud(Control::RGBDFollower &self,
+                                    const int pixel_x, const int pixel_y,
+                                    const ByteArray &data, int point_step,
+                                    int row_step, int height, int width,
+                                    int x_offset, int y_offset, int z_offset,
+                                    const std::vector<Bbox2D> &boxes,
+                                    const float yaw) {
+  const PointCloudView view{toSpan(data), point_step, row_step, height,
+                            width,        x_offset,   y_offset, z_offset};
+  py::gil_scoped_release release;
+  return self.setInitialTracking(pixel_x, pixel_y, view, boxes, yaw);
+}
+
+bool setInitialTrackingBoxCloud(Control::RGBDFollower &self,
+                                const ByteArray &data, int point_step,
+                                int row_step, int height, int width,
+                                int x_offset, int y_offset, int z_offset,
+                                const Bbox2D &target_box, const float yaw) {
+  const PointCloudView view{toSpan(data), point_step, row_step, height,
+                            width,        x_offset,   y_offset, z_offset};
+  py::gil_scoped_release release;
+  return self.setInitialTracking(view, target_box, yaw);
+}
+
+Control::TrajSearchResult
+getTrackingCtrlCloud(Control::RGBDFollower &self, const ByteArray &data,
+                     int point_step, int row_step, int height, int width,
+                     int x_offset, int y_offset, int z_offset,
+                     const std::vector<Bbox2D> &boxes,
+                     const Control::Velocity2D &vel) {
+  const PointCloudView view{toSpan(data), point_step, row_step, height,
+                            width,        x_offset,   y_offset, z_offset};
   py::gil_scoped_release release;
   return self.getTrackingCtrl(view, boxes, vel);
 }
@@ -404,6 +444,23 @@ void bindings_control(py::module_ &m) {
       .def("set_initial_tracking", &setInitialTrackingBox<DepthArrayF32>,
            py::arg("aligned_depth_image"), py::arg("target_box_2d"),
            py::arg("robot_orientation") = 0.0)
+      .def("set_point_cloud_sensor",
+           &Control::RGBDFollower::setPointCloudSensor, py::arg("sensor"),
+           "Describes the point-cloud sensor: mount pose in the robot body "
+           "frame and encoding of its x/y/z fields, the same SensorConfig the "
+           "mapper takes. Identity mount with FLOAT32 fields until called.")
+      // Point cloud variants
+      .def("set_initial_tracking", &setInitialTrackingAtPixelCloud,
+           py::arg("pixel_x"), py::arg("pixel_y"), py::arg("data"),
+           py::arg("point_step"), py::arg("row_step"), py::arg("height"),
+           py::arg("width"), py::arg("x_offset"), py::arg("y_offset"),
+           py::arg("z_offset"), py::arg("detected_boxes_2d"),
+           py::arg("robot_orientation") = 0.0)
+      .def("set_initial_tracking", &setInitialTrackingBoxCloud, py::arg("data"),
+           py::arg("point_step"), py::arg("row_step"), py::arg("height"),
+           py::arg("width"), py::arg("x_offset"), py::arg("y_offset"),
+           py::arg("z_offset"), py::arg("target_box_2d"),
+           py::arg("robot_orientation") = 0.0)
       .def("get_errors", &Control::RGBDFollower::getErrors)
       // NOTE:The C++ class also inherits RGBFollower (nanobind doesn't cover
       // multiple inheritence), so the RGBFollower interface is re-bound here
@@ -433,10 +490,17 @@ void bindings_control(py::module_ &m) {
                &Control::RGBDFollower::getTrackingCtrl),
            py::arg("detected_boxes_3d"), py::arg("robot_velocity"),
            py::call_guard<py::gil_scoped_release>())
+      // Depth Array variants
       .def("get_tracking_ctrl", &getTrackingCtrlDepth<DepthArrayU16>,
            py::arg("aligned_depth_image"), py::arg("detected_boxes_2d"),
            py::arg("robot_velocity"))
       .def("get_tracking_ctrl", &getTrackingCtrlDepth<DepthArrayF32>,
            py::arg("aligned_depth_image"), py::arg("detected_boxes_2d"),
+           py::arg("robot_velocity"))
+      // Point-cloud variant
+      .def("get_tracking_ctrl", &getTrackingCtrlCloud, py::arg("data"),
+           py::arg("point_step"), py::arg("row_step"), py::arg("height"),
+           py::arg("width"), py::arg("x_offset"), py::arg("y_offset"),
+           py::arg("z_offset"), py::arg("detected_boxes_2d"),
            py::arg("robot_velocity"));
 }

--- a/src/kompass_cpp/bindings/bindings_types.cpp
+++ b/src/kompass_cpp/bindings/bindings_types.cpp
@@ -315,7 +315,7 @@ void bindings_types(py::module_ &m) {
       .def_rw("sample_count", &Bbox3D::sample_count,
               "Number of in-range pixels of an aligned depth image or cloud "
               "points projected into the 2D box. Zero for a box not produced "
-              "by the detector"
+              "by the detector")
       .def_rw("source_index", &Bbox3D::source_index,
               "Index of the 2D box, or points-of-interest set, in the "
               "detector input this box was lifted from. -1 for a box "

--- a/src/kompass_cpp/bindings/bindings_types.cpp
+++ b/src/kompass_cpp/bindings/bindings_types.cpp
@@ -311,5 +311,13 @@ void bindings_types(py::module_ &m) {
       .def_rw("size_img_frame", &Bbox3D::size_img_frame)
       .def_rw("pc_points", &Bbox3D::pc_points)
       .def_rw("timestamp", &Bbox3D::timestamp)
-      .def_rw("label", &Bbox3D::label);
+      .def_rw("label", &Bbox3D::label)
+      .def_rw("sample_count", &Bbox3D::sample_count,
+              "Number of in-range pixels of an aligned depth image or cloud "
+              "points projected into the 2D box. Zero for a box not produced "
+              "by the detector"
+      .def_rw("source_index", &Bbox3D::source_index,
+              "Index of the 2D box, or points-of-interest set, in the "
+              "detector input this box was lifted from. -1 for a box "
+              "not produced by the detector");
 }

--- a/src/kompass_cpp/bindings/bindings_vision.cpp
+++ b/src/kompass_cpp/bindings/bindings_vision.cpp
@@ -45,6 +45,31 @@ compute3dDetections(DepthDetector &self, const DepthArray &depth_img,
   return out;
 }
 
+// Point-cloud variant (raw byte buffer, zero-copy) and input is either 2D boxes
+// or a PointsOfInterest set. The detection pass runs without the GIL
+template <typename InputT>
+std::vector<Bbox3D>
+compute3dDetectionsCloud(DepthDetector &self, const ByteArray &data,
+                         int point_step, int row_step, int height, int width,
+                         int x_offset, int y_offset, int z_offset,
+                         const InputT &input, float robot_x, float robot_y,
+                         float robot_yaw, float robot_speed) {
+  const PointCloudView view{toSpan(data), point_step, row_step, height,
+                            width,        x_offset,   y_offset, z_offset};
+  const auto state = makeState(robot_x, robot_y, robot_yaw, robot_speed);
+  std::vector<Bbox3D> out;
+  {
+    py::gil_scoped_release release;
+    if constexpr (std::is_same_v<InputT, PointsOfInterest>) {
+      self.updatePOIs(view, input, state);
+    } else {
+      self.updateBoxes(view, input, state);
+    }
+    out = self.get3dDetections();
+  }
+  return out;
+}
+
 } // namespace
 
 void bindings_vision(py::module_ &m) {
@@ -107,5 +132,24 @@ void bindings_vision(py::module_ &m) {
       .def("compute_3d_detections",
            &compute3dDetections<DepthArrayF32, PointsOfInterest>,
            py::arg("depth_img"), py::arg("input"), py::arg("robot_x"),
-           py::arg("robot_y"), py::arg("robot_yaw"), py::arg("robot_speed"));
+           py::arg("robot_y"), py::arg("robot_yaw"), py::arg("robot_speed"))
+      .def("set_point_cloud_sensor", &DepthDetector::setPointCloudSensor,
+           py::arg("sensor"),
+           "Describes the point-cloud sensor: mount pose in the robot body "
+           "frame and encoding of its x/y/z fields, the same SensorConfig the "
+           "mapper takes. Identity mount with FLOAT32 fields until called.")
+      // Zero copy pointcloud view along with info; with points in the sensor
+      // frame described by set_point_cloud_sensor()
+      .def("compute_3d_detections",
+           &compute3dDetectionsCloud<std::vector<Bbox2D>>, py::arg("data"),
+           py::arg("point_step"), py::arg("row_step"), py::arg("height"),
+           py::arg("width"), py::arg("x_offset"), py::arg("y_offset"),
+           py::arg("z_offset"), py::arg("input"), py::arg("robot_x"),
+           py::arg("robot_y"), py::arg("robot_yaw"), py::arg("robot_speed"))
+      .def("compute_3d_detections", &compute3dDetectionsCloud<PointsOfInterest>,
+           py::arg("data"), py::arg("point_step"), py::arg("row_step"),
+           py::arg("height"), py::arg("width"), py::arg("x_offset"),
+           py::arg("y_offset"), py::arg("z_offset"), py::arg("input"),
+           py::arg("robot_x"), py::arg("robot_y"), py::arg("robot_yaw"),
+           py::arg("robot_speed"));
 }

--- a/src/kompass_cpp/bindings/bindings_vision.cpp
+++ b/src/kompass_cpp/bindings/bindings_vision.cpp
@@ -119,19 +119,19 @@ void bindings_vision(py::module_ &m) {
       // typed overload per dtype x input kind, all sharing one template
       .def("compute_3d_detections",
            &compute3dDetections<DepthArrayU16, std::vector<Bbox2D>>,
-           py::arg("depth_img"), py::arg("input"), py::arg("robot_x"),
+           py::arg("depth_image"), py::arg("input"), py::arg("robot_x"),
            py::arg("robot_y"), py::arg("robot_yaw"), py::arg("robot_speed"))
       .def("compute_3d_detections",
            &compute3dDetections<DepthArrayF32, std::vector<Bbox2D>>,
-           py::arg("depth_img"), py::arg("input"), py::arg("robot_x"),
+           py::arg("depth_image"), py::arg("input"), py::arg("robot_x"),
            py::arg("robot_y"), py::arg("robot_yaw"), py::arg("robot_speed"))
       .def("compute_3d_detections",
            &compute3dDetections<DepthArrayU16, PointsOfInterest>,
-           py::arg("depth_img"), py::arg("input"), py::arg("robot_x"),
+           py::arg("depth_image"), py::arg("input"), py::arg("robot_x"),
            py::arg("robot_y"), py::arg("robot_yaw"), py::arg("robot_speed"))
       .def("compute_3d_detections",
            &compute3dDetections<DepthArrayF32, PointsOfInterest>,
-           py::arg("depth_img"), py::arg("input"), py::arg("robot_x"),
+           py::arg("depth_image"), py::arg("input"), py::arg("robot_x"),
            py::arg("robot_y"), py::arg("robot_yaw"), py::arg("robot_speed"))
       .def("set_point_cloud_sensor", &DepthDetector::setPointCloudSensor,
            py::arg("sensor"),

--- a/src/kompass_cpp/bindings/bindings_vision.cpp
+++ b/src/kompass_cpp/bindings/bindings_vision.cpp
@@ -116,23 +116,31 @@ void bindings_vision(py::module_ &m) {
 
       // --- Converter Functions ---
       // Zero-copy depth view (uint16 mm / float32 m, C-contiguous); one
-      // typed overload per dtype x input kind, all sharing one template
+      // typed overload per dtype x input kind, all sharing one template.
+      // noconvert: the overloads differ only by dtype, and nanobind's
+      // permissive pass would otherwise cast a float32 image to the uint16
+      // overload (truncating metres to integers) whenever any other argument
+      // needs converting. A mismatched dtype or layout must fail loudly.
       .def("compute_3d_detections",
            &compute3dDetections<DepthArrayU16, std::vector<Bbox2D>>,
-           py::arg("depth_image"), py::arg("input"), py::arg("robot_x"),
-           py::arg("robot_y"), py::arg("robot_yaw"), py::arg("robot_speed"))
+           py::arg("depth_image").noconvert(), py::arg("input"),
+           py::arg("robot_x"), py::arg("robot_y"), py::arg("robot_yaw"),
+           py::arg("robot_speed"))
       .def("compute_3d_detections",
            &compute3dDetections<DepthArrayF32, std::vector<Bbox2D>>,
-           py::arg("depth_image"), py::arg("input"), py::arg("robot_x"),
-           py::arg("robot_y"), py::arg("robot_yaw"), py::arg("robot_speed"))
+           py::arg("depth_image").noconvert(), py::arg("input"),
+           py::arg("robot_x"), py::arg("robot_y"), py::arg("robot_yaw"),
+           py::arg("robot_speed"))
       .def("compute_3d_detections",
            &compute3dDetections<DepthArrayU16, PointsOfInterest>,
-           py::arg("depth_image"), py::arg("input"), py::arg("robot_x"),
-           py::arg("robot_y"), py::arg("robot_yaw"), py::arg("robot_speed"))
+           py::arg("depth_image").noconvert(), py::arg("input"),
+           py::arg("robot_x"), py::arg("robot_y"), py::arg("robot_yaw"),
+           py::arg("robot_speed"))
       .def("compute_3d_detections",
            &compute3dDetections<DepthArrayF32, PointsOfInterest>,
-           py::arg("depth_image"), py::arg("input"), py::arg("robot_x"),
-           py::arg("robot_y"), py::arg("robot_yaw"), py::arg("robot_speed"))
+           py::arg("depth_image").noconvert(), py::arg("input"),
+           py::arg("robot_x"), py::arg("robot_y"), py::arg("robot_yaw"),
+           py::arg("robot_speed"))
       .def("set_point_cloud_sensor", &DepthDetector::setPointCloudSensor,
            py::arg("sensor"),
            "Describes the point-cloud sensor: mount pose in the robot body "

--- a/src/kompass_cpp/kompass_cpp/include/controllers/dwa.h
+++ b/src/kompass_cpp/kompass_cpp/include/controllers/dwa.h
@@ -204,7 +204,7 @@ protected:
       return TrajSearchResult{trajectory, true, 0.0};
     }
 
-    adaptPredictionHorizon();
+    adaptPredictionHorizonToCurvature();
 
     // Generate set of valid trajectories in the DW
     std::unique_ptr<TrajectorySamples2D> samples_ =
@@ -241,16 +241,14 @@ private:
 
   Path::Path::View findTrackedPathSegment();
 
-  // Adapt the sampler's rollout horizon to the path ahead. At straight
-  // sections far from the goal use the full constructor-provided horizon; as
-  // the reference curvature rises, shrink it so straight-tangent samples
-  // don't diverge from the arc by more than `kSagittaTolerance` meters (a
-  // constant-curvature arc deviates from its tangent by ~(v·T)²·κ/8, so the
-  // cap is T ≤ sqrt(8·ε/κ) / v_max). Near the end of the path shrink it to
-  // the time the robot needs to reach the goal, so the samples can end on
-  // the goal instead of overshooting it, which with an end-point goal cost
-  // would make curling back score best.
-  void adaptPredictionHorizon();
+  // Adapt the sampler's rollout horizon to local path curvature. At straight
+  // sections use the full constructor-provided horizon; as the reference
+  // curvature rises, shrink it so straight-tangent samples don't diverge
+  // from the arc by more than `kSagittaTolerance` meters (a constant-
+  // curvature arc deviates from its tangent by ~(v·T)²·κ/8, so the cap is
+  // T ≤ sqrt(8·ε/κ) / v_max). Keeps straight-tangent samples from drifting
+  // too far off the arc and flat-lining the cost gradient at tight curves.
+  void adaptPredictionHorizonToCurvature();
 
   // One-shot warmup that dispatches every cost-evaluator kernel once with a
   // dummy reference path, forcing the SYCL runtime to JIT-compile them at

--- a/src/kompass_cpp/kompass_cpp/include/controllers/dwa.h
+++ b/src/kompass_cpp/kompass_cpp/include/controllers/dwa.h
@@ -29,7 +29,7 @@ public:
       const Eigen::Vector3f &sensor_position_body,
       const Eigen::Vector4f &sensor_rotation_body, const double octreeRes,
       CostEvaluator::TrajectoryCostsWeights costWeights,
-      const int maxNumThreads = 1);
+      const bool allowReverse = true, const int maxNumThreads = 1);
 
   DWA(TrajectorySampler::TrajectorySamplerParameters config,
       ControlLimitsParams controlLimits, ControlType controlType,
@@ -61,7 +61,7 @@ public:
                  const Eigen::Vector4f &sensor_rotation_body,
                  const double octreeRes,
                  CostEvaluator::TrajectoryCostsWeights costWeights,
-                 const int maxNumThreads = 1);
+                 const bool allowReverse = true, const int maxNumThreads = 1);
 
   void configure(TrajectorySampler::TrajectorySamplerParameters config,
                  ControlLimitsParams controlLimits, ControlType controlType,

--- a/src/kompass_cpp/kompass_cpp/include/controllers/dwa.h
+++ b/src/kompass_cpp/kompass_cpp/include/controllers/dwa.h
@@ -204,13 +204,7 @@ protected:
       return TrajSearchResult{trajectory, true, 0.0};
     }
 
-    // Adapt the prediction horizon to local path curvature. At straight
-    // sections use the full constructor-provided horizon; as the reference
-    // curvature rises, shrink the horizon so straight-tangent samples don't
-    // diverge from the arc by more than `kSagittaTolerance` meters. A
-    // constant-curvature arc deviates from its tangent by ~(v·T)²·κ/8, so
-    // the cap is T ≤ sqrt(8·ε/κ) / v_max.
-    adaptPredictionHorizonToCurvature();
+    adaptPredictionHorizon();
 
     // Generate set of valid trajectories in the DW
     std::unique_ptr<TrajectorySamples2D> samples_ =
@@ -247,10 +241,16 @@ private:
 
   Path::Path::View findTrackedPathSegment();
 
-  // Shrink the sampler's rollout horizon based on the max curvature ahead
-  // on the reference path. Keeps straight-tangent samples from drifting too
-  // far off the arc and flat-lining the cost gradient at tight curves.
-  void adaptPredictionHorizonToCurvature();
+  // Adapt the sampler's rollout horizon to the path ahead. At straight
+  // sections far from the goal use the full constructor-provided horizon; as
+  // the reference curvature rises, shrink it so straight-tangent samples
+  // don't diverge from the arc by more than `kSagittaTolerance` meters (a
+  // constant-curvature arc deviates from its tangent by ~(v·T)²·κ/8, so the
+  // cap is T ≤ sqrt(8·ε/κ) / v_max). Near the end of the path shrink it to
+  // the time the robot needs to reach the goal, so the samples can end on
+  // the goal instead of overshooting it, which with an end-point goal cost
+  // would make curling back score best.
+  void adaptPredictionHorizon();
 
   // One-shot warmup that dispatches every cost-evaluator kernel once with a
   // dummy reference path, forcing the SYCL runtime to JIT-compile them at

--- a/src/kompass_cpp/kompass_cpp/include/controllers/dwa.h
+++ b/src/kompass_cpp/kompass_cpp/include/controllers/dwa.h
@@ -192,8 +192,10 @@ protected:
     // find closest segment to use in cost computation
     determineTarget();
 
-    if (rotate_in_place and std::abs(currentTrackedTarget_->heading_error) >
-                                goal_orientation_tolerance * 10.0) {
+    if (rotate_in_place and
+        (std::abs(currentTrackedTarget_->heading_error) >
+         goal_orientation_tolerance * 10.0) and
+        (abs(goal_distance_) <= goal_dist_tolerance)) {
       // If the robot is rotating in place and the heading error is large, we
       // do not need to sample trajectories
       LOG_DEBUG("Rotating In Place ...");

--- a/src/kompass_cpp/kompass_cpp/include/controllers/rgb_follower.h
+++ b/src/kompass_cpp/kompass_cpp/include/controllers/rgb_follower.h
@@ -32,7 +32,6 @@ public:
       // Pure tracking control law parameters
       addParameter("rotation_gain", Parameter(1.0, 1e-2, 10.0));
       addParameter("speed_gain", Parameter(1.0, 1e-2, 10.0));
-      addParameter("min_vel", Parameter(0.1, 1e-9, 1e9));
       addParameter("enable_search", Parameter(false));
     }
     bool enable_search() const { return getParameter<bool>("enable_search"); }
@@ -61,7 +60,6 @@ public:
     }
     double K_omega() const { return getParameter<double>("rotation_gain"); }
     double K_v() const { return getParameter<double>("speed_gain"); }
-    double min_vel() const { return getParameter<double>("min_vel"); }
   };
 
   RGBFollower(const ControlType robotCtrlType,

--- a/src/kompass_cpp/kompass_cpp/include/controllers/rgbd_follower.h
+++ b/src/kompass_cpp/kompass_cpp/include/controllers/rgbd_follower.h
@@ -118,73 +118,40 @@ public:
    */
   Control::TrajSearchResult
   getTrackingCtrl(const std::vector<Bbox3D> &detected_boxes,
-                  const Velocity2D &current_vel) {
-    std::optional<TrackedPose2D> tracked_pose = std::nullopt;
-    if (!detected_boxes.empty()) {
-      if (tracker_->trackerInitialized()) {
-        // Update the tracker with the detected boxes
-        bool tracking_updated = tracker_->updateTracking(detected_boxes);
-        if (!tracking_updated) {
-          LOG_WARNING(
-              "Tracker failed to update target with the detected boxes");
-        } else {
-          tracked_pose = tracker_->getFilteredTrackedPose2D();
-          refreshTargetGeometry();
-        }
-      } else {
-        throw std::runtime_error(
-            "Tracker is not initialized with an initial tracking target. Call "
-            "'RGBDFollower::setInitialTracking' first");
-      }
-    }
-    return this->getTrackingCtrl(tracked_pose, current_vel);
-  };
+                  const Velocity2D &current_vel);
 
   /**
-   * Depth-image variant. The image crosses as a non-owning zero-copy view
-   * (UINT16 millimetres or FLOAT32 metres, row-major) and is only read for
-   * the duration of the call.
+   * @brief Depth-image variant: lifts the 2D detections to 3D through the
+   * depth detector, then tracks and controls like the 3D-box variant.
+   *
+   * @param aligned_depth_img Non-owning zero-copy view of the depth image
+   * (UINT16 millimetres or FLOAT32 metres, row-major), only read for the
+   * duration of the call
+   * @param detected_boxes_2d 2D detections in that image
+   * @param current_vel Current robot velocity
+   * @return Control::TrajSearchResult
    */
   Control::TrajSearchResult
   getTrackingCtrl(const DepthImageView &aligned_depth_img,
                   const std::vector<Bbox2D> &detected_boxes_2d,
-                  const Velocity2D &current_vel) {
-    if (!detector_) {
-      throw std::runtime_error(
-          "DepthDetector is not initialized with the camera intrinsics. Call "
-          "'RGBDFollower::setCameraIntrinsics' first");
-    }
-    if (!tracker_->trackerInitialized()) {
-      throw std::runtime_error(
-          "Tracker is not initialized with an initial tracking target. Call "
-          "'RGBDFollower::setInitialTracking' first");
-    }
-    std::optional<TrackedPose2D> tracked_pose = std::nullopt;
-    if (!detected_boxes_2d.empty()) {
-      if (track_velocity_) {
-        // Send current state to the detector
-        detector_->updateBoxes(aligned_depth_img, detected_boxes_2d,
-                               currentState);
-      } else {
-        detector_->updateBoxes(aligned_depth_img, detected_boxes_2d);
-      }
-      const auto &boxes_3d = detector_->get3dDetections();
-      if (!boxes_3d.empty()) {
-        // Update the tracker with the detected boxes
-        bool tracking_updated = tracker_->updateTracking(boxes_3d);
-        if (!tracking_updated) {
-          LOG_WARNING(
-              "Tracker failed to update target with the detected boxes");
-        } else {
-          tracked_pose = tracker_->getFilteredTrackedPose2D();
-          refreshTargetGeometry();
-        }
-      } else {
-        LOG_WARNING("Detector failed to find 3D boxes");
-      }
-    }
-    return this->getTrackingCtrl(tracked_pose, current_vel);
-  };
+                  const Velocity2D &current_vel);
+
+  /**
+   * @brief Point-cloud variant: lifts the 2D detections to 3D by projecting
+   * the cloud through the camera, then tracks and controls like the 3D-box
+   * variant.
+   *
+   * @param cloud Non-owning zero-copy view of the PointCloud2 buffer, points
+   * in the sensor's own frame as published, only read for the duration of
+   * the call. Mount pose and field encoding come from setPointCloudSensor().
+   * @param detected_boxes_2d 2D detections in the camera image
+   * @param current_vel Current robot velocity
+   * @return Control::TrajSearchResult
+   */
+  Control::TrajSearchResult
+  getTrackingCtrl(const PointCloudView &cloud,
+                  const std::vector<Bbox2D> &detected_boxes_2d,
+                  const Velocity2D &current_vel);
 
   /**
    * @brief Set the initial image position of the target to be tracked
@@ -200,22 +167,50 @@ public:
                           const float yaw = 0.0);
 
   /**
-   * @brief  Set the initial image position of the target to be tracked using 2D
-   * detections
+   * @brief Set the initial target from a pixel position using 2D detections
+   * and an aligned depth image.
    *
-   * @param pose_x_img
-   * @param pose_y_img
-   * @param detected_boxes_2d
-   * @return true
-   * @return false
+   * @param pose_x_img Pixel x of the target
+   * @param pose_y_img Pixel y of the target
+   * @param aligned_depth_image See getTrackingCtrl()
+   * @param detected_boxes_2d 2D detections in that image
+   * @param yaw Robot yaw used to initialize the tracked target
+   * @return True when a detection contains the pixel and was lifted
    */
   bool setInitialTracking(const int pose_x_img, const int pose_y_img,
                           const DepthImageView &aligned_depth_image,
                           const std::vector<Bbox2D> &detected_boxes_2d,
                           const float yaw = 0.0);
 
+  /**
+   * @brief Set the initial target from one 2D box and an aligned depth image.
+   *
+   * @param aligned_depth_image See getTrackingCtrl()
+   * @param target_box_2d 2D box of the target
+   * @param yaw Robot yaw used to initialize the tracked target
+   * @return True when the box was lifted to 3D
+   */
   bool setInitialTracking(const DepthImageView &aligned_depth_image,
                           const Bbox2D &target_box_2d, const float yaw = 0.0);
+
+  /// Point-cloud variant of the pixel-position initial tracking.
+  bool setInitialTracking(const int pose_x_img, const int pose_y_img,
+                          const PointCloudView &cloud,
+                          const std::vector<Bbox2D> &detected_boxes_2d,
+                          const float yaw = 0.0);
+
+  /// Point-cloud variant of the single-box initial tracking.
+  bool setInitialTracking(const PointCloudView &cloud,
+                          const Bbox2D &target_box_2d, const float yaw = 0.0);
+
+  /**
+   * @brief Describes the point-cloud sensor used by the point-cloud variants:
+   * its mount pose in the robot body frame and the encoding of its x/y/z
+   * fields. Forwarded to the depth detector.
+   *
+   * @param sensor Mount pose and field encoding of the point-cloud sensor
+   */
+  void setPointCloudSensor(const SensorConfig &sensor);
 
   Eigen::Vector2f getErrors() const {
     return Eigen::Vector2f(dist_error_, orientation_error_);
@@ -226,6 +221,7 @@ private:
   std::unique_ptr<FeatureBasedBboxTracker> tracker_;
   std::unique_ptr<DepthDetector> detector_;
   Eigen::Isometry3f vision_sensor_tf_;
+  SensorConfig cloud_sensor_;  // Point-cloud sensor if given
   int track_velocity_;
   double robot_radius_;
 
@@ -235,8 +231,48 @@ private:
   // has nothing to report.
   void refreshTargetGeometry();
 
+  // ---- Lifting 2D detections, shared by the depth-image and point-cloud
+  // variants. DepthSource is DepthImageView or PointCloudView. ----
+
+  // Runs the detector on the 2D boxes, with the robot state when the target
+  // is tracked in the world frame
+  template <typename DepthSource>
+  void liftDetections(const DepthSource &source,
+                      const std::vector<Bbox2D> &boxes);
+
+  // Body of the getTrackingCtrl variants taking 2D detections
+  template <typename DepthSource>
+  Control::TrajSearchResult trackDetections(const DepthSource &source,
+                                            const std::vector<Bbox2D> &boxes,
+                                            const Velocity2D &current_vel);
+
+  // Body of the setInitialTracking variants taking one 2D target box
+  template <typename DepthSource>
+  bool initTracking(const DepthSource &source, const Bbox2D &target_box_2d,
+                    const float yaw);
+
+  // Body of the setInitialTracking variants taking a pixel position. The
+  // detection containing the pixel is the target box
+  template <typename DepthSource>
+  bool initTrackingAtPixel(const int pose_x_img, const int pose_y_img,
+                           const DepthSource &source,
+                           const std::vector<Bbox2D> &detected_boxes_2d,
+                           const float yaw);
+
+  // Feeds the detector's last result to the tracker. Returns the filtered
+  // target pose, or nothing
+  std::optional<TrackedPose2D> trackLiftedBoxes();
+
+  // Initializes the tracker on the detector's last (single) result
+  bool initTrackingFromLiftedBox(const float yaw);
+
+  // The first detection whose box contains the pixel, or nullptr
+  static const Bbox2D *findBoxAtPixel(const int pose_x_img,
+                                      const int pose_y_img,
+                                      const std::vector<Bbox2D> &boxes);
+
   // Build a control-horizon-long stationary trajectory (zero velocities,
-  // path pinned at origin). Pure: no side effects on timers or queues.
+  // path pinned at origin).
   TrajSearchResult makeHoldResult() const;
 
   // Build a result by popping commands off `search_commands_queue_`
@@ -261,8 +297,7 @@ private:
   Trajectory2D getTrackingReferenceSegment(const TrackedPose2D &tracking_pose);
 
   // In local-coordinate mode, advance the target's robot-relative pose by
-  // one step of the robot's own motion (the "target gets pushed back" by
-  // the robot's forward step).
+  // one step of the robot's own motion.
   TrackedPose2D updateLocalTarget(const TrackedPose2D &current_target,
                                   const Velocity2D &robot_cmd, double dt);
 
@@ -274,10 +309,11 @@ private:
   Control::TrajSearchResult
   getTrackingCtrl(const std::optional<TrackedPose2D> &tracked_pose,
                   const Velocity2D &current_vel) {
-    // Pipeline-of-stages dispatch: each stage returns nullopt when it
+    // NOTE: Pipeline-of-stages dispatch. Each stage returns nullopt when it
     // doesn't apply, allowing the next stage to take a turn. The first
     // stage that returns a result wins.
-    LOG_DEBUG("Last velocity command: ", latest_velocity_command_.vx(), ", ", latest_velocity_command_.omega());
+    LOG_DEBUG("Last velocity command: ", latest_velocity_command_.vx(), ", ",
+              latest_velocity_command_.omega());
     if (tracked_pose) {
       // Target is back in view — clear any pending search/wait state.
       recorded_wait_time_ = 0.0;

--- a/src/kompass_cpp/kompass_cpp/include/datatypes/control.h
+++ b/src/kompass_cpp/kompass_cpp/include/datatypes/control.h
@@ -208,14 +208,16 @@ struct AngularVelocityControlParams {
   double maxOmega = 1.0;
   double maxAcceleration = 10.0;
   double maxDeceleration = 10.0;
+  double minOmega = 0.05; // [rad/sec]
 
   AngularVelocityControlParams(const AngularVelocityControlParams &) = default;
 
   // Parameterized constructor
   AngularVelocityControlParams(double maxAng = M_PI, double maxOmg = 1.0,
-                               double maxAcc = 10.0, double maxDec = 10.0)
+                               double maxAcc = 10.0, double maxDec = 10.0,
+                               double minOmg = 0.05)
       : maxAngle(maxAng), maxOmega(maxOmg), maxAcceleration(maxAcc),
-        maxDeceleration(maxDec) {}
+        maxDeceleration(maxDec), minOmega(minOmg) {}
 };
 
 // General Control parameters

--- a/src/kompass_cpp/kompass_cpp/include/datatypes/control.h
+++ b/src/kompass_cpp/kompass_cpp/include/datatypes/control.h
@@ -191,13 +191,15 @@ struct LinearVelocityControlParams {
   double maxVel = 1.0;
   double maxAcceleration = 10.0;
   double maxDeceleration = 10.0;
+  double minVel = 0.05;
 
   LinearVelocityControlParams(const LinearVelocityControlParams &) = default;
 
   // Parameterized constructor
   LinearVelocityControlParams(double maxVel = 1.0, double maxAcc = 10.0,
-                              double maxDec = 10.0)
-      : maxVel(maxVel), maxAcceleration(maxAcc), maxDeceleration(maxDec) {}
+                              double maxDec = 10.0, double minVel = 0.05)
+      : maxVel(maxVel), maxAcceleration(maxAcc), maxDeceleration(maxDec),
+        minVel(minVel) {}
 };
 
 // Structure for Angular Velocity Control parameters

--- a/src/kompass_cpp/kompass_cpp/include/datatypes/tracking.h
+++ b/src/kompass_cpp/kompass_cpp/include/datatypes/tracking.h
@@ -142,6 +142,12 @@ struct Bbox3D {
   std::vector<Eigen::Vector3f> pc_points = {};
   float timestamp = 0.0; // Timestamp of the detection in seconds
   std::string label = "";
+  // Number of in-range pixels of an aligned depth image or cloud points projected
+  // into the 2D box. Zero for a box not produced by the detector
+  int sample_count = 0;
+  // Index of the 2D box (or points-of-interest set) in the detector input
+  // this box was lifted from. -1 for a box not produced by the detector
+  int source_index = -1;
 
   Bbox3D() {};
 

--- a/src/kompass_cpp/kompass_cpp/include/datatypes/trajectory.h
+++ b/src/kompass_cpp/kompass_cpp/include/datatypes/trajectory.h
@@ -36,12 +36,15 @@ inline size_t getNumTrajectories(ControlType ctrType, int maxLinearSamples,
   const int angSlots = maxAngularSamples + 1 - (maxAngularSamples % 2);
   int vx_n, vy_n;
   computeLinearSampleSplit(ctrType, maxLinearSamples, vx_n, vy_n);
+  // Size for 3 extra linear speeds (0 and +/- the minimum speed), each with the
+  // full angular fan, plus the single stop sample added by the "+ 1" below.
+  const size_t vx_rows = static_cast<size_t>(vx_n) + 3;
   if (ctrType == ControlType::OMNI) {
-    return static_cast<size_t>(vx_n) * static_cast<size_t>(angSlots) +
-           static_cast<size_t>(vx_n) * static_cast<size_t>(vy_n);
+    return vx_rows * static_cast<size_t>(angSlots) +
+           vx_rows * static_cast<size_t>(vy_n) + 1;
   }
   // Non-holonomic: (vx, omega) grid, with an unused vy axis.
-  return static_cast<size_t>(vx_n) * static_cast<size_t>(angSlots);
+  return vx_rows * static_cast<size_t>(angSlots) + 1;
 }
 
 // calculate number of points per trajectory based on time step and horizon
@@ -90,7 +93,7 @@ struct TrajectoryVelocities2D {
   TrajectoryVelocities2D(const Eigen::VectorXf &vx_, const Eigen::VectorXf &vy_,
                          const Eigen::VectorXf &omega_)
       : vx(vx_), vy(vy_), omega(omega_),
-        numPointsPerTrajectory_(vx_.size() + 1){};
+        numPointsPerTrajectory_(vx_.size() + 1) {};
 
   // add velocity to specified index in TrajectoryVelocities2D
   void add(size_t idx, const Velocity2D &velocity) {
@@ -194,7 +197,7 @@ struct TrajectoryPath {
   // initialize from eigen vectors
   TrajectoryPath(const Eigen::VectorXf &x_, const Eigen::VectorXf &y_,
                  const Eigen::VectorXf &z_)
-      : x(x_), y(y_), z(z_), numPointsPerTrajectory_(x.size()){};
+      : x(x_), y(y_), z(z_), numPointsPerTrajectory_(x.size()) {};
 
   // add point to specified index in path
   void add(size_t idx, const Path::Point &point) {

--- a/src/kompass_cpp/kompass_cpp/include/datatypes/trajectory.h
+++ b/src/kompass_cpp/kompass_cpp/include/datatypes/trajectory.h
@@ -36,15 +36,17 @@ inline size_t getNumTrajectories(ControlType ctrType, int maxLinearSamples,
   const int angSlots = maxAngularSamples + 1 - (maxAngularSamples % 2);
   int vx_n, vy_n;
   computeLinearSampleSplit(ctrType, maxLinearSamples, vx_n, vy_n);
-  // Size for 3 extra linear speeds (0 and +/- the minimum speed), each with the
-  // full angular fan, plus the single stop sample added by the "+ 1" below.
+  // Every axis gets up to 3 extra samples (0 and +/- its minimum velocity):
+  // 3 more linear rows, each with the full angular fan of angSlots + 2, plus
+  // the single stop sample added by the "+ 1" below.
   const size_t vx_rows = static_cast<size_t>(vx_n) + 3;
+  const size_t omega_cols = static_cast<size_t>(angSlots) + 2;
   if (ctrType == ControlType::OMNI) {
-    return vx_rows * static_cast<size_t>(angSlots) +
-           vx_rows * static_cast<size_t>(vy_n) + 1;
+    const size_t vy_cols = static_cast<size_t>(vy_n) + 3;
+    return vx_rows * omega_cols + vx_rows * vy_cols + 1;
   }
   // Non-holonomic: (vx, omega) grid, with an unused vy axis.
-  return vx_rows * static_cast<size_t>(angSlots) + 1;
+  return vx_rows * omega_cols + 1;
 }
 
 // calculate number of points per trajectory based on time step and horizon

--- a/src/kompass_cpp/kompass_cpp/include/datatypes/trajectory.h
+++ b/src/kompass_cpp/kompass_cpp/include/datatypes/trajectory.h
@@ -37,16 +37,15 @@ inline size_t getNumTrajectories(ControlType ctrType, int maxLinearSamples,
   int vx_n, vy_n;
   computeLinearSampleSplit(ctrType, maxLinearSamples, vx_n, vy_n);
   // Every axis gets up to 3 extra samples (0 and +/- its minimum velocity):
-  // 3 more linear rows, each with the full angular fan of angSlots + 2, plus
-  // the single stop sample added by the "+ 1" below.
+  // 3 more linear rows, each with the full angular fan of angSlots + 2.
   const size_t vx_rows = static_cast<size_t>(vx_n) + 3;
   const size_t omega_cols = static_cast<size_t>(angSlots) + 2;
   if (ctrType == ControlType::OMNI) {
     const size_t vy_cols = static_cast<size_t>(vy_n) + 3;
-    return vx_rows * omega_cols + vx_rows * vy_cols + 1;
+    return vx_rows * omega_cols + vx_rows * vy_cols;
   }
   // Non-holonomic: (vx, omega) grid, with an unused vy axis.
-  return vx_rows * omega_cols + 1;
+  return vx_rows * omega_cols;
 }
 
 // calculate number of points per trajectory based on time step and horizon

--- a/src/kompass_cpp/kompass_cpp/include/mapping/local_mapper_gpu.h
+++ b/src/kompass_cpp/kompass_cpp/include/mapping/local_mapper_gpu.h
@@ -4,6 +4,7 @@
 #include "utils/logger.h"
 #include <Eigen/Dense>
 #include <array>
+#include <mutex>
 #include <sycl/sycl.hpp>
 #include <vector>
 
@@ -234,6 +235,9 @@ private:
   // Device-reported max work-group size. Used as the pointcloud conversion
   // kernel's block dim.
   size_t m_max_wg_size = 0;
+  // Mutex to make sure that mem alocs for angles in scan or growing clouds dont
+  // corrupt
+  std::mutex m_mutex;
 
   sycl::queue m_q;
 };

--- a/src/kompass_cpp/kompass_cpp/include/utils/cost_evaluator.h
+++ b/src/kompass_cpp/kompass_cpp/include/utils/cost_evaluator.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include <vector>
 #ifdef GPU
+#include <mutex>
 #include <sycl/sycl.hpp>
 #endif //! GPU
 
@@ -272,6 +273,8 @@ private:
   float *m_devicePtrTempCosts = nullptr;
   LowestCost *m_minCost;
   sycl::queue m_q;
+  // Mutex to serialize the obstacle device buffers allocation
+  std::mutex m_mutex;
   void initializeGPUMemory();
   /**
    * @brief Trajectory cost based on average cross-track error to the tracked

--- a/src/kompass_cpp/kompass_cpp/include/utils/critical_zone_check_gpu.h
+++ b/src/kompass_cpp/kompass_cpp/include/utils/critical_zone_check_gpu.h
@@ -4,6 +4,7 @@
 #include "utils/critical_zone_check.h"
 #include "utils/logger.h"
 #include <Eigen/Dense>
+#include <mutex>
 #include <sycl/sycl.hpp>
 #include <vector>
 
@@ -185,6 +186,9 @@ private:
   };
   std::vector<SensorDeviceState> m_sensorDev;
   size_t max_wg_size_ = 0;
+  // Mutex to make sure that two concurrent grow-and-reallocate paths dont free
+  // the same buffer or copy into a buffer the other thread just freed
+  std::mutex m_mutex;
 };
 
 } // namespace Kompass

--- a/src/kompass_cpp/kompass_cpp/include/utils/trajectory_sampler.h
+++ b/src/kompass_cpp/kompass_cpp/include/utils/trajectory_sampler.h
@@ -134,9 +134,27 @@ public:
   generateSingleSampleFromVel(const Velocity2D &vel,
                               const Path::State &pose = Path::State());
 
+  // Returns true if ANY of `states` collides with `sensor_points`.
+  // Defined here rather than in the .cpp: `updateSensorData` is itself a
+  // generic template, so every sensor type the samplers accept works without
+  // a matching explicit instantiation.
   template <typename T>
   bool checkStatesFeasibility(const std::vector<Path::State> &states,
-                              const T &sensor_points);
+                              const T &sensor_points) {
+    if (states.empty()) {
+      return false;
+    }
+    // states[0] is where the robot was when the data was captured; the rest
+    // are future poses tested against those same obstacles.
+    collChecker->updateSensorData(sensor_points, states[0]);
+    for (const auto &state : states) {
+      collChecker->updateState(state);
+      if (collChecker->checkCollisions()) {
+        return true;
+      }
+    }
+    return false;
+  }
 
   // Temporarily shrink the rollout horizon (e.g., when the reference path
   // has high curvature ahead and straight-tangent samples would diverge too

--- a/src/kompass_cpp/kompass_cpp/include/utils/trajectory_sampler.h
+++ b/src/kompass_cpp/kompass_cpp/include/utils/trajectory_sampler.h
@@ -173,6 +173,7 @@ private:
   int lin_samples_y_; // split of lin_samples_max_ used for the vy axis (1 for
                       // non-holonomic robots)
   int ang_samples_max_;
+  std::vector<double> lin_samples_scratch_;  // Linear speed samples of the current tick
   double lin_sample_x_resolution_;
   double lin_sample_y_resolution_;
   double ang_sample_resolution_;
@@ -191,6 +192,21 @@ private:
    * @param config
    */
   void updateParams(TrajectorySamplerParameters config);
+
+  /**
+   * @brief Linear speed samples of the current window: the regular grid
+   * over [min_vx_, max_vx_] plus 0 and +/- the minimum speed of the x-axis
+   * control limits whenever they lie inside the window.
+   */
+  const std::vector<double> &linearSamples();
+
+  /**
+   * @brief Adds the stop sample (zero velocity): a rollout that stays at the
+   * current pose, kept when zero is inside the reachable window and the pose
+   * is collision free. Rankable by the costs, unlike a pure rotation.
+   */
+  void addStopSample(const Path::State &current_pose,
+                     TrajectorySamples2D *admissible_velocity_trajectories);
 
   /**
    * @brief Updates the range of valid velocity actions that can be reached from

--- a/src/kompass_cpp/kompass_cpp/include/utils/trajectory_sampler.h
+++ b/src/kompass_cpp/kompass_cpp/include/utils/trajectory_sampler.h
@@ -42,6 +42,9 @@ public:
           Parameter(
               10, 1, 1000,
               "Maximum number of samples for the angular velocity controls"));
+      addParameter("allow_reverse",
+                   Parameter(true, "Whether reversing (negative forward "
+                                   "velocity) samples are generated"));
       addParameter("octree_map_resolution",
                    Parameter(0.1, 0.0, 1000.0,
                              "Resolution of the built-in Octree map used for "
@@ -77,7 +80,8 @@ public:
                     const std::vector<float> robotDimensions,
                     const Eigen::Vector3f &sensor_position_body,
                     const Eigen::Quaternionf &sensor_rotation_body,
-                    const double octreeRes, const int maxNumThreads = 1);
+                    const double octreeRes, const bool allowReverse = true,
+                    const int maxNumThreads = 1);
 
   TrajectorySampler(TrajectorySamplerParameters config,
                     ControlLimitsParams controlLimits, ControlType controlType,
@@ -184,6 +188,7 @@ private:
   double min_omega_;
   size_t numCtrlPoints_;
   bool drop_samples_{true};
+  bool allow_reverse_{true};  // Whether reversing samples are generated
 
   /**
    * @brief Helper method to update the class private parameters from config

--- a/src/kompass_cpp/kompass_cpp/include/utils/trajectory_sampler.h
+++ b/src/kompass_cpp/kompass_cpp/include/utils/trajectory_sampler.h
@@ -141,13 +141,17 @@ public:
   // Temporarily shrink the rollout horizon (e.g., when the reference path
   // has high curvature ahead and straight-tangent samples would diverge too
   // far from the arc). Updates numPointsPerTrajectory in lockstep so buffer
-  // sizing stays consistent. Clamped to >= 2 time steps and <= the sampler's
-  // originally-constructed horizon.
+  // sizing stays consistent. Clamped to >= 3 time steps (two rollout steps,
+  // the least that lets angular velocity show in the end point) and <= the
+  // sampler's originally-constructed horizon.
   void setPredictionHorizon(double horizon);
 
   // The prediction horizon the sampler was originally constructed with.
   // Callers use this as the upper bound when adapting the horizon per cycle.
   double getBasePredictionHorizon() const { return base_max_time_; }
+
+  // Duration of one rollout step, the resolution any horizon is rounded to
+  double getTimeStep() const { return time_step_; }
 
   size_t numTrajectories;
   size_t numPointsPerTrajectory;

--- a/src/kompass_cpp/kompass_cpp/include/utils/trajectory_sampler.h
+++ b/src/kompass_cpp/kompass_cpp/include/utils/trajectory_sampler.h
@@ -11,10 +11,6 @@
 #include <memory>
 #include <vector>
 
-#ifndef MIN_VEL
-#define MIN_VEL 0.01
-#endif
-
 namespace Kompass {
 
 namespace Control {
@@ -173,7 +169,10 @@ private:
   int lin_samples_y_; // split of lin_samples_max_ used for the vy axis (1 for
                       // non-holonomic robots)
   int ang_samples_max_;
-  std::vector<double> lin_samples_scratch_;  // Linear speed samples of the current tick
+  // Samples of each velocity axis for the current tick
+  std::vector<double> vx_samples_;
+  std::vector<double> vy_samples_;
+  std::vector<double> omega_samples_;
   double lin_sample_x_resolution_;
   double lin_sample_y_resolution_;
   double ang_sample_resolution_;
@@ -194,11 +193,15 @@ private:
   void updateParams(TrajectorySamplerParameters config);
 
   /**
-   * @brief Linear speed samples of the current window: the regular grid
-   * over [min_vx_, max_vx_] plus 0 and +/- the minimum speed of the x-axis
-   * control limits whenever they lie inside the window.
+   * @brief Samples of one velocity axis for the current tick, written into
+   * the given scratch vector: the regular grid over [low, high] with every
+   * value inside 0 < |v| < min_abs dropped, plus 0 and +/- min_abs whenever
+   * they lie inside the window.
    */
-  const std::vector<double> &linearSamples();
+  const std::vector<double> &axisSamples(std::vector<double> &samples,
+                                         double low, double high,
+                                         double resolution,
+                                         double min_abs) const;
 
   /**
    * @brief Adds the stop sample (zero velocity): a rollout that stays at the

--- a/src/kompass_cpp/kompass_cpp/include/utils/trajectory_sampler.h
+++ b/src/kompass_cpp/kompass_cpp/include/utils/trajectory_sampler.h
@@ -141,17 +141,13 @@ public:
   // Temporarily shrink the rollout horizon (e.g., when the reference path
   // has high curvature ahead and straight-tangent samples would diverge too
   // far from the arc). Updates numPointsPerTrajectory in lockstep so buffer
-  // sizing stays consistent. Clamped to >= 3 time steps (two rollout steps,
-  // the least that lets angular velocity show in the end point) and <= the
-  // sampler's originally-constructed horizon.
+  // sizing stays consistent. Clamped to >= 2 time steps and <= the sampler's
+  // originally-constructed horizon.
   void setPredictionHorizon(double horizon);
 
   // The prediction horizon the sampler was originally constructed with.
   // Callers use this as the upper bound when adapting the horizon per cycle.
   double getBasePredictionHorizon() const { return base_max_time_; }
-
-  // Duration of one rollout step, the resolution any horizon is rounded to
-  double getTimeStep() const { return time_step_; }
 
   size_t numTrajectories;
   size_t numPointsPerTrajectory;

--- a/src/kompass_cpp/kompass_cpp/include/utils/trajectory_sampler.h
+++ b/src/kompass_cpp/kompass_cpp/include/utils/trajectory_sampler.h
@@ -204,14 +204,6 @@ private:
                                          double min_abs) const;
 
   /**
-   * @brief Adds the stop sample (zero velocity): a rollout that stays at the
-   * current pose, kept when zero is inside the reachable window and the pose
-   * is collision free. Rankable by the costs, unlike a pure rotation.
-   */
-  void addStopSample(const Path::State &current_pose,
-                     TrajectorySamples2D *admissible_velocity_trajectories);
-
-  /**
    * @brief Updates the range of valid velocity actions that can be reached from
    * a current velocity based on the acceleration limits
    *

--- a/src/kompass_cpp/kompass_cpp/include/vision/depth_detector.h
+++ b/src/kompass_cpp/kompass_cpp/include/vision/depth_detector.h
@@ -51,60 +51,168 @@ public:
     BodyAligned ///< x forward, y left, z up (REP 103 body)
   };
 
-  DepthDetector(const Eigen::Vector2f &depth_range,
-                const Eigen::Vector3f &camera_in_body_translation,
-                const Eigen::Quaternionf &camera_in_body_rotation,
-                const Eigen::Vector2f &focal_length,
-                const Eigen::Vector2f &principal_point,
-                const float depth_conversion_factor = 1e-3,
-                const CameraFrameConvention convention =
-                    CameraFrameConvention::Optical);
+  DepthDetector(
+      const Eigen::Vector2f &depth_range,
+      const Eigen::Vector3f &camera_in_body_translation,
+      const Eigen::Quaternionf &camera_in_body_rotation,
+      const Eigen::Vector2f &focal_length,
+      const Eigen::Vector2f &principal_point,
+      const float depth_conversion_factor = 1e-3,
+      const CameraFrameConvention convention = CameraFrameConvention::Optical);
 
-  DepthDetector(const Eigen::Vector2f &depth_range,
-                const Eigen::Isometry3f &camera_in_body_tf,
-                const Eigen::Vector2f &focal_length,
-                const Eigen::Vector2f &principal_point,
-                const float depth_conversion_factor = 1e-3,
-                const CameraFrameConvention convention =
-                    CameraFrameConvention::Optical);
+  DepthDetector(
+      const Eigen::Vector2f &depth_range,
+      const Eigen::Isometry3f &camera_in_body_tf,
+      const Eigen::Vector2f &focal_length,
+      const Eigen::Vector2f &principal_point,
+      const float depth_conversion_factor = 1e-3,
+      const CameraFrameConvention convention = CameraFrameConvention::Optical);
 
   /// REP 103 rotation taking optical axes to body-aligned ones.
   static const Eigen::Quaternionf &opticalToBodyAligned();
 
   /**
-   * NOTE: Non owning zero-copy view of the depth image. UINT16 pixels are
-   * scaled by the configured depth_conversion_factor (mm -> m by default);
-   * FLOAT32 pixels are taken as metres. Non-finite pixels are rejected by the
-   * min/max range gate.
+   * @brief Lifts 2D detection boxes to 3D boxes using an aligned depth image.
+   *
+   * For every box, the in-range depth pixels of its region are reduced to a
+   * median depth and a MAD-clipped depth extent, the box centre pixel is
+   * back-projected through the intrinsics at that depth, and the result is
+   * moved into the world frame through the camera pose and the robot state.
+   * Boxes with fewer than two in-range pixels are dropped.
+   *
+   * @param aligned_depth_img Non-owning zero-copy view of the depth image,
+   * aligned with the image the boxes were detected in. UINT16 pixels are
+   * scaled by the configured depth_conversion_factor (millimetres to metres
+   * by default); FLOAT32 pixels are taken as metres. Non-finite pixels are
+   * rejected by the min/max range gate.
+   * @param detections 2D boxes in pixel coordinates of that image
+   * @param robot_state Robot pose in the world frame. When given, the boxes
+   * are returned in the world frame, otherwise in the robot body frame.
    */
   void
   updateBoxes(const DepthImageView &aligned_depth_img,
               const std::vector<Bbox2D> &detections,
               const std::optional<Path::State> &robot_state = std::nullopt);
 
+  /**
+   * @brief Lifts a set of points of interest to one 3D box using an aligned
+   * depth image.
+   *
+   * The points are first reduced to a single 2D box (see the Bbox2D
+   * constructor taking a PointsOfInterest), which then follows the same path
+   * as a detection box. The result holds at most one box.
+   *
+   * @param aligned_depth_img See updateBoxes()
+   * @param pois Points of interest in pixel coordinates of that image
+   * @param robot_state See updateBoxes()
+   */
   void updatePOIs(const DepthImageView &aligned_depth_img,
                   const PointsOfInterest &pois,
                   const std::optional<Path::State> &robot_state = std::nullopt);
 
-  /// Result of the last update; empty when no box converted.
+  /**
+   * @brief Lifts 2D detection boxes to 3D boxes using a point cloud.
+   *
+   * Every point is transformed into the camera and projected through the
+   * intrinsics; the points that land inside a box contribute their depth
+   * along the camera axis, and the box is then reduced exactly like the
+   * depth-image variant. Points behind the camera, outside the min/max range
+   * or non-finite are ignored.
+   *
+   * Points that project into a box but lie behind the object play the same role
+   * as background pixels in a depth image. The median/MAD reduction keeps the
+   * majority and clips the outliers.
+   *
+   * TODO: organized clouds (height > 1) currently take this projection path
+   * too. A pixel-indexed path could read point (row, col) directly.
+   *
+   * @param cloud Non-owning zero-copy view of the PointCloud2 buffer, with
+   * the points in the sensor's own frame as published. The sensor's mount
+   * pose and field encoding come from setPointCloudSensor().
+   * @param detections 2D boxes in pixel coordinates of the camera image
+   * @param robot_state See the depth-image updateBoxes()
+   */
+  void
+  updateBoxes(const PointCloudView &cloud,
+              const std::vector<Bbox2D> &detections,
+              const std::optional<Path::State> &robot_state = std::nullopt);
+
+  /**
+   * @brief Lifts a set of points of interest to one 3D box using a point
+   * cloud.
+   *
+   * The points are first reduced to a single 2D box (see the Bbox2D
+   * constructor taking a PointsOfInterest), which then follows the same path
+   * as a detection box. The result holds at most one box.
+   *
+   * @param cloud See the point-cloud updateBoxes()
+   * @param pois Points of interest in pixel coordinates of the camera image
+   * @param robot_state See the depth-image updateBoxes()
+   */
+  void updatePOIs(const PointCloudView &cloud, const PointsOfInterest &pois,
+                  const std::optional<Path::State> &robot_state = std::nullopt);
+
+  /**
+   * @brief Describes the point-cloud sensor: its mount pose in the robot body
+   * frame and the encoding of its x/y/z fields.
+   *
+   * The mount pose is taken in the axes the cloud's frame_id names. The default
+   * SensorConfig is an identity mount with FLOAT32 fields, which is what
+   * applies until this is called.
+   *
+   * @param sensor Mount pose and field encoding of the point-cloud sensor
+   */
+  void setPointCloudSensor(const SensorConfig &sensor);
+
+  /**
+   * @brief Result of the last update.
+   *
+   * @return The lifted 3D boxes, empty when no box converted
+   */
   const std::vector<Bbox3D> &get3dDetections() const { return boxes_; }
 
 private:
   float cx_, cy_, fx_, fy_; // Depth Image camera intrinsics
   float minDepth_, maxDepth_, depthConversionFactor_;
   Eigen::Isometry3f camera_in_body_tf_, body_in_world_tf_;
+  // Point-cloud sensor (mount pose + field encoding)
+  SensorConfig cloud_sensor_;
+  // camera_in_body_tf_^-1 * mount pose: takes a cloud point straight into the
+  // body-aligned camera axes the projection works in
+  Eigen::Isometry3f cloud_in_camera_tf_;
+
+  // Output buffer storing lifted 3D boxes of last update
   std::vector<Bbox3D> boxes_;
 
   // Per-box scratch, refilled for every converted box. Keep the
   // allocated capacity, so it grows to the largest box seen.
   std::vector<float> depth_values_; // in-range depth values (metres)
-  std::vector<float> mad_scratch_; // absolute deviations from the median
+  std::vector<float> mad_scratch_;  // absolute deviations from the median
+
+  // Cloud path scratch. One depth-sample bucket per box of the current
+  // update plus each box's inclusive pixel limits (x0, x1, y0, y1)
+  std::vector<std::vector<float>> cloud_samples_;
+  std::vector<Eigen::Vector4i> box_limits_;
 
   std::optional<Bbox3D> convert2Dboxto3Dbox(const DepthImageView &depth,
                                             const Bbox2D &box2d);
 
   std::optional<Bbox3D> convertPOIto3Dbox(const DepthImageView &depth,
                                           const PointsOfInterest &poi);
+
+  /// Fills depth_values_ with the in-range depths of the box region.
+  void gatherDepthSamples(const DepthImageView &depth, const Bbox2D &box2d);
+
+  /// Projects the whole cloud once and fills cloud_samples_[i] with the
+  /// in-range depths of the points that land inside boxes[i].
+  void projectCloud(const PointCloudView &cloud,
+                    const std::vector<Bbox2D> &boxes);
+
+  /// Median/MAD reduction of the depth samples of one box into a Bbox3D in
+  /// the world frame (body frame when no robot state was given). Shared by
+  /// the depth-image and the point-cloud paths.
+  std::optional<Bbox3D> boxFromDepthSamples(const Bbox2D &box2d,
+                                            std::vector<float> &samples);
 
   void calculateMAD(std::vector<float> &depthValues, float &median, float &mad);
 

--- a/src/kompass_cpp/kompass_cpp/src/controllers/dwa.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/controllers/dwa.cpp
@@ -101,6 +101,7 @@ void DWA::configure(ControlLimitsParams controlLimits, ControlType controlType,
                     const double octreeRes,
                     CostEvaluator::TrajectoryCostsWeights costWeights,
                     const int maxNumThreads) {
+  ctrlimitsParams = controlLimits;
   trajSampler = std::make_unique<TrajectorySampler>(
       controlLimits, controlType, timeStep, predictionHorizon, controlHorizon,
       maxLinearSamples, maxAngularSamples, robotShapeType, robotDimensions,
@@ -123,6 +124,7 @@ void DWA::configure(TrajectorySampler::TrajectorySamplerParameters config,
                     const Eigen::Vector4f &sensor_rotation_body,
                     CostEvaluator::TrajectoryCostsWeights costWeights,
                     const int maxNumThreads) {
+  ctrlimitsParams = controlLimits;
   trajSampler = std::make_unique<TrajectorySampler>(
       config, controlLimits, controlType, robotShapeType, robotDimensions,
       sensor_position_body, Eigen::Quaternionf(sensor_rotation_body),
@@ -154,7 +156,7 @@ void DWA::setCurrentState(const Path::State &position) {
   this->trajSampler->updateState(position);
 }
 
-void DWA::adaptPredictionHorizonToCurvature() {
+void DWA::adaptPredictionHorizon() {
   const double base_horizon = trajSampler->getBasePredictionHorizon();
   const double v_max = ctrlimitsParams.velXParams.maxVel;
   if (!currentPath || v_max < 1e-3 || max_point_interpolation_distance_ <= 0.0) {
@@ -199,6 +201,23 @@ void DWA::adaptPredictionHorizonToCurvature() {
         std::sqrt(8.0 * curvature_horizon_tolerance_ / kappa_max) / v_max;
     adaptive_horizon = std::min(base_horizon, horizon_cap);
     LOG_DEBUG("Using Adaptive Horizon: ", adaptive_horizon);
+  }
+
+  // NOTE: Cap the horizon at the time the robot needs to reach the end of the path
+  // at full speed. With a longer rollout every sample at a useful speed
+  // overshoots the goal, and since the goal cost scores the rollout's end
+  // point the samples that curl back toward the goal would score best. The
+  // goal tolerance keeps the last steps from collapsing, and one extra step
+  // pays for the rollout's first point being the current pose.
+  const double remaining_distance =
+      std::max(0.0, static_cast<double>(currentPath->totalPathLength() -
+                                        currentPath->getDistanceAtIndex(start_idx)));
+  const double goal_horizon =
+      (remaining_distance + goal_dist_tolerance) / v_max +
+      trajSampler->getTimeStep();
+  if (goal_horizon < adaptive_horizon) {
+    adaptive_horizon = goal_horizon;
+    LOG_DEBUG("Horizon capped by the distance to the goal: ", adaptive_horizon);
   }
 
   trajSampler->setPredictionHorizon(adaptive_horizon);

--- a/src/kompass_cpp/kompass_cpp/src/controllers/dwa.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/controllers/dwa.cpp
@@ -101,6 +101,8 @@ void DWA::configure(ControlLimitsParams controlLimits, ControlType controlType,
                     const double octreeRes,
                     CostEvaluator::TrajectoryCostsWeights costWeights,
                     const int maxNumThreads) {
+  // The controller base keeps its own copy of the limits for the command
+  // clamps, the rotate-in-place scaling and the horizon adaptation
   ctrlimitsParams = controlLimits;
   trajSampler = std::make_unique<TrajectorySampler>(
       controlLimits, controlType, timeStep, predictionHorizon, controlHorizon,
@@ -124,6 +126,8 @@ void DWA::configure(TrajectorySampler::TrajectorySamplerParameters config,
                     const Eigen::Vector4f &sensor_rotation_body,
                     CostEvaluator::TrajectoryCostsWeights costWeights,
                     const int maxNumThreads) {
+  // The controller base keeps its own copy of the limits for the command
+  // clamps, the rotate-in-place scaling and the horizon adaptation
   ctrlimitsParams = controlLimits;
   trajSampler = std::make_unique<TrajectorySampler>(
       config, controlLimits, controlType, robotShapeType, robotDimensions,
@@ -156,7 +160,7 @@ void DWA::setCurrentState(const Path::State &position) {
   this->trajSampler->updateState(position);
 }
 
-void DWA::adaptPredictionHorizon() {
+void DWA::adaptPredictionHorizonToCurvature() {
   const double base_horizon = trajSampler->getBasePredictionHorizon();
   const double v_max = ctrlimitsParams.velXParams.maxVel;
   if (!currentPath || v_max < 1e-3 || max_point_interpolation_distance_ <= 0.0) {
@@ -201,23 +205,6 @@ void DWA::adaptPredictionHorizon() {
         std::sqrt(8.0 * curvature_horizon_tolerance_ / kappa_max) / v_max;
     adaptive_horizon = std::min(base_horizon, horizon_cap);
     LOG_DEBUG("Using Adaptive Horizon: ", adaptive_horizon);
-  }
-
-  // NOTE: Cap the horizon at the time the robot needs to reach the end of the path
-  // at full speed. With a longer rollout every sample at a useful speed
-  // overshoots the goal, and since the goal cost scores the rollout's end
-  // point the samples that curl back toward the goal would score best. The
-  // goal tolerance keeps the last steps from collapsing, and one extra step
-  // pays for the rollout's first point being the current pose.
-  const double remaining_distance =
-      std::max(0.0, static_cast<double>(currentPath->totalPathLength() -
-                                        currentPath->getDistanceAtIndex(start_idx)));
-  const double goal_horizon =
-      (remaining_distance + goal_dist_tolerance) / v_max +
-      trajSampler->getTimeStep();
-  if (goal_horizon < adaptive_horizon) {
-    adaptive_horizon = goal_horizon;
-    LOG_DEBUG("Horizon capped by the distance to the goal: ", adaptive_horizon);
   }
 
   trajSampler->setPredictionHorizon(adaptive_horizon);

--- a/src/kompass_cpp/kompass_cpp/src/controllers/dwa.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/controllers/dwa.cpp
@@ -19,13 +19,13 @@ DWA::DWA(ControlLimitsParams controlLimits, ControlType controlType,
          const Eigen::Vector3f &sensor_position_body,
          const Eigen::Vector4f &sensor_rotation_body, const double octreeRes,
          CostEvaluator::TrajectoryCostsWeights costWeights,
-         const int maxNumThreads)
+         const bool allowReverse, const int maxNumThreads)
     : Follower() {
   // Setup the trajectory sampler and cost evaluator
   configure(controlLimits, controlType, timeStep, predictionHorizon,
             controlHorizon, maxLinearSamples, maxAngularSamples, robotShapeType,
             robotDimensions, sensor_position_body, sensor_rotation_body,
-            octreeRes, costWeights, maxNumThreads);
+            octreeRes, costWeights, allowReverse, maxNumThreads);
 
   // Update the max forward distance the robot can make
   if (controlType == ControlType::OMNI) {
@@ -100,7 +100,7 @@ void DWA::configure(ControlLimitsParams controlLimits, ControlType controlType,
                     const Eigen::Vector4f &sensor_rotation_body,
                     const double octreeRes,
                     CostEvaluator::TrajectoryCostsWeights costWeights,
-                    const int maxNumThreads) {
+                    const bool allowReverse, const int maxNumThreads) {
   // The controller base keeps its own copy of the limits for the command
   // clamps, the rotate-in-place scaling and the horizon adaptation
   ctrlimitsParams = controlLimits;
@@ -108,7 +108,7 @@ void DWA::configure(ControlLimitsParams controlLimits, ControlType controlType,
       controlLimits, controlType, timeStep, predictionHorizon, controlHorizon,
       maxLinearSamples, maxAngularSamples, robotShapeType, robotDimensions,
       sensor_position_body, Eigen::Quaternionf(sensor_rotation_body), octreeRes,
-      maxNumThreads);
+      allowReverse, maxNumThreads);
 
   trajCostEvaluator = std::make_unique<CostEvaluator>(
       costWeights, sensor_position_body,

--- a/src/kompass_cpp/kompass_cpp/src/controllers/rgb_follower.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/controllers/rgb_follower.cpp
@@ -56,7 +56,7 @@ void RGBFollower::generateSearchCommands(float total_rotation,
   double omega_val = total_rotation / rotation_time;
 
   omega_val = std::max(std::min(omega_val, ctrl_limits_.omegaParams.maxOmega),
-                       config_.min_vel());
+                       ctrl_limits_.omegaParams.minOmega);
   // Generate velocity commands
   for (float t = 0.0f; t <= max_rotation_time;
        t = t + config_.control_time_step()) {
@@ -209,14 +209,14 @@ void RGBFollower::trackTarget(const Bbox2D &target) {
   // - 1.0) in [-1, 1] V in [-K_v * speed_max, K_v * speed_max]
   v = config_.K_v() * dist_speed;
 
-  // Limit by the minimum allowed velocity to avoid sending meaningless low
-  // commands to the robot
-  omega = std::abs(omega) >= config_.min_vel() ? omega : 0.0;
+  // Zero commands below the robot's minimum velocities instead of sending
+  // meaningless low commands to the robot
+  omega = std::abs(omega) >= ctrl_limits_.omegaParams.minOmega ? omega : 0.0;
   float omega_limit = static_cast<float>(ctrl_limits_.omegaParams.maxOmega);
   omega = std::clamp(omega, -omega_limit, omega_limit);
 
   float v_limit = static_cast<float>(ctrl_limits_.velXParams.maxVel);
-  v = std::abs(v) >= config_.min_vel() ? v : 0.0;
+  v = std::abs(v) >= ctrl_limits_.velXParams.minVel ? v : 0.0;
   v = std::clamp(v, -v_limit, v_limit);
 
   LOG_DEBUG("dist_error ", dist_error_, ", error_x: ", error_x);

--- a/src/kompass_cpp/kompass_cpp/src/controllers/rgbd_follower.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/controllers/rgbd_follower.cpp
@@ -16,6 +16,8 @@
 namespace Kompass {
 namespace Control {
 
+// ---- Construction and sensor setup ----
+
 RGBDFollower::RGBDFollower(const ControlType &robotCtrlType,
                            const ControlLimitsParams &ctrlLimits,
                            const CollisionChecker::ShapeType &robotShapeType,
@@ -55,14 +57,212 @@ void RGBDFollower::setCameraIntrinsics(const float focal_length_x,
                                        const float principal_point_x,
                                        const float principal_point_y) {
   // The mount pose comes from a TF lookup against the frame the depth
-  // Image/CameraInfo names, which ROS always expresses in optical axes.
+  // Image/CameraInfo names
   detector_ = std::make_unique<DepthDetector>(
       config_.depth_range(), vision_sensor_tf_,
       Eigen::Vector2f{focal_length_x, focal_length_y},
       Eigen::Vector2f{principal_point_x, principal_point_y},
       config_.depth_conversion_factor(),
       DepthDetector::CameraFrameConvention::Optical);
+  detector_->setPointCloudSensor(cloud_sensor_);
 }
+
+void RGBDFollower::setPointCloudSensor(const SensorConfig &sensor) {
+  cloud_sensor_ = sensor;
+  if (detector_) {
+    detector_->setPointCloudSensor(sensor);
+  }
+}
+
+// ---- Lifting 2D detections ----
+
+template <typename DepthSource>
+void RGBDFollower::liftDetections(const DepthSource &source,
+                                  const std::vector<Bbox2D> &boxes) {
+  if (track_velocity_) {
+    // Send current state to the detector
+    detector_->updateBoxes(source, boxes, currentState);
+  } else {
+    detector_->updateBoxes(source, boxes);
+  }
+}
+
+template <typename DepthSource>
+Control::TrajSearchResult
+RGBDFollower::trackDetections(const DepthSource &source,
+                              const std::vector<Bbox2D> &boxes,
+                              const Velocity2D &current_vel) {
+  if (!detector_) {
+    throw std::runtime_error(
+        "DepthDetector is not initialized with the camera intrinsics. Call "
+        "'RGBDFollower::setCameraIntrinsics' first");
+  }
+  if (!tracker_->trackerInitialized()) {
+    throw std::runtime_error(
+        "Tracker is not initialized with an initial tracking target. Call "
+        "'RGBDFollower::setInitialTracking' first");
+  }
+  std::optional<TrackedPose2D> tracked_pose = std::nullopt;
+  if (!boxes.empty()) {
+    liftDetections(source, boxes);
+    tracked_pose = trackLiftedBoxes();
+  }
+  return this->getTrackingCtrl(tracked_pose, current_vel);
+}
+
+template <typename DepthSource>
+bool RGBDFollower::initTracking(const DepthSource &source,
+                                const Bbox2D &target_box_2d, const float yaw) {
+  if (!detector_) {
+    throw std::runtime_error(
+        "DepthDetector is not initialized with the camera intrinsics. Call "
+        "'RGBDFollower::setCameraIntrinsics' first");
+  }
+  liftDetections(source, {target_box_2d});
+  return initTrackingFromLiftedBox(yaw);
+}
+
+template <typename DepthSource>
+bool RGBDFollower::initTrackingAtPixel(
+    const int pose_x_img, const int pose_y_img, const DepthSource &source,
+    const std::vector<Bbox2D> &detected_boxes_2d, const float yaw) {
+  const Bbox2D *target_box =
+      findBoxAtPixel(pose_x_img, pose_y_img, detected_boxes_2d);
+  if (!target_box) {
+    LOG_DEBUG("Target point not found in any detected box");
+    return false;
+  }
+  return initTracking(source, *target_box, yaw);
+}
+
+Control::TrajSearchResult
+RGBDFollower::getTrackingCtrl(const std::vector<Bbox3D> &detected_boxes,
+                              const Velocity2D &current_vel) {
+  std::optional<TrackedPose2D> tracked_pose = std::nullopt;
+  if (!detected_boxes.empty()) {
+    if (tracker_->trackerInitialized()) {
+      // Update the tracker with the detected boxes
+      bool tracking_updated = tracker_->updateTracking(detected_boxes);
+      if (!tracking_updated) {
+        LOG_WARNING("Tracker failed to update target with the detected boxes");
+      } else {
+        tracked_pose = tracker_->getFilteredTrackedPose2D();
+        refreshTargetGeometry();
+      }
+    } else {
+      throw std::runtime_error(
+          "Tracker is not initialized with an initial tracking target. Call "
+          "'RGBDFollower::setInitialTracking' first");
+    }
+  }
+  return this->getTrackingCtrl(tracked_pose, current_vel);
+}
+
+Control::TrajSearchResult
+RGBDFollower::getTrackingCtrl(const DepthImageView &aligned_depth_img,
+                              const std::vector<Bbox2D> &detected_boxes_2d,
+                              const Velocity2D &current_vel) {
+  return trackDetections(aligned_depth_img, detected_boxes_2d, current_vel);
+}
+
+Control::TrajSearchResult
+RGBDFollower::getTrackingCtrl(const PointCloudView &cloud,
+                              const std::vector<Bbox2D> &detected_boxes_2d,
+                              const Velocity2D &current_vel) {
+  return trackDetections(cloud, detected_boxes_2d, current_vel);
+}
+
+bool RGBDFollower::setInitialTracking(
+    const int pose_x_img, const int pose_y_img,
+    const DepthImageView &aligned_depth_image,
+    const std::vector<Bbox2D> &detected_boxes_2d, const float yaw) {
+  return initTrackingAtPixel(pose_x_img, pose_y_img, aligned_depth_image,
+                             detected_boxes_2d, yaw);
+}
+
+bool RGBDFollower::setInitialTracking(const DepthImageView &aligned_depth_image,
+                                      const Bbox2D &target_box_2d,
+                                      const float yaw) {
+  return initTracking(aligned_depth_image, target_box_2d, yaw);
+}
+
+bool RGBDFollower::setInitialTracking(
+    const int pose_x_img, const int pose_y_img, const PointCloudView &cloud,
+    const std::vector<Bbox2D> &detected_boxes_2d, const float yaw) {
+  return initTrackingAtPixel(pose_x_img, pose_y_img, cloud, detected_boxes_2d,
+                             yaw);
+}
+
+bool RGBDFollower::setInitialTracking(const PointCloudView &cloud,
+                                      const Bbox2D &target_box_2d,
+                                      const float yaw) {
+  return initTracking(cloud, target_box_2d, yaw);
+}
+
+bool RGBDFollower::setInitialTracking(const int pose_x_img,
+                                      const int pose_y_img,
+                                      const std::vector<Bbox3D> &detected_boxes,
+                                      const float yaw) {
+  const bool ok =
+      tracker_->setInitialTracking(pose_x_img, pose_y_img, detected_boxes, yaw);
+  if (ok) {
+    refreshTargetGeometry();
+  }
+  return ok;
+}
+
+const Bbox2D *RGBDFollower::findBoxAtPixel(const int pose_x_img,
+                                           const int pose_y_img,
+                                           const std::vector<Bbox2D> &boxes) {
+  for (const auto &box : boxes) {
+    const auto limits_x = box.getXLimits();
+    const auto limits_y = box.getYLimits();
+    if (pose_x_img >= limits_x(0) && pose_x_img <= limits_x(1) &&
+        pose_y_img >= limits_y(0) && pose_y_img <= limits_y(1)) {
+      return &box;
+    }
+  }
+  return nullptr;
+}
+
+std::optional<TrackedPose2D> RGBDFollower::trackLiftedBoxes() {
+  const auto &boxes_3d = detector_->get3dDetections();
+  if (boxes_3d.empty()) {
+    LOG_WARNING("Detector failed to find 3D boxes");
+    return std::nullopt;
+  }
+  // Update the tracker with the detected boxes
+  if (!tracker_->updateTracking(boxes_3d)) {
+    LOG_WARNING("Tracker failed to update target with the detected boxes");
+    return std::nullopt;
+  }
+  refreshTargetGeometry();
+  return tracker_->getFilteredTrackedPose2D();
+}
+
+bool RGBDFollower::initTrackingFromLiftedBox(const float yaw) {
+  const auto &boxes_3d = detector_->get3dDetections();
+  if (boxes_3d.empty()) {
+    LOG_DEBUG("Failed to get 3D box from 2D target box");
+    return false;
+  }
+  const bool ok = tracker_->setInitialTracking(boxes_3d[0], yaw);
+  if (ok) {
+    refreshTargetGeometry();
+  }
+  return ok;
+}
+
+void RGBDFollower::refreshTargetGeometry() {
+  if (const auto *raw = tracker_->getRawTracking()) {
+    const auto &sz = raw->box.size;
+    currentTargetRadius_ = 0.5f * std::max(sz.x(), sz.y());
+  }
+  // else: leave previous value untouched so a transient miss doesn't
+  // erase a previously-known radius.
+}
+
+// ---- Tracking control law ----
 
 Velocity2D RGBDFollower::getPureTrackingCtrl(const TrackedPose2D &tracking_pose,
                                              const bool update_global_error) {
@@ -82,18 +282,15 @@ Velocity2D RGBDFollower::getPureTrackingCtrl(const TrackedPose2D &tracking_pose,
     psi = Angle::normalizeToMinusPiPlusPi(
         std::atan2(tracking_pose.y(), tracking_pose.x()));
   }
-  // Gap between the two bodies' surfaces: what the standoff is controlled
-  // against. Floored at zero because a target inside the combined radii is
-  // as close as "touching" gets, not a negative separation.
+  // Gap between the two bodies' surfaces that the standoff is controlled
+  // against. Floored at zero.
   constexpr float kMinDistance = 0.001f;
-  float distance = std::max(
-      static_cast<float>(range - robot_radius_ - currentTargetRadius_),
-      kMinDistance);
+  float distance =
+      std::max(static_cast<float>(range - robot_radius_ - currentTargetRadius_),
+               kMinDistance);
 
   float distance_error = config_.target_distance() - distance;
-  // target_orientation is the bearing-to-target to maintain in the robot
-  // frame; gamma (target heading relative to robot) belongs in the motion
-  // feedforward only, not in the angular error.
+  // target_orientation is the bearing-to-target to maintain in the robot frame
   float angle_error =
       Angle::normalizeToMinusPiPlusPi(config_.target_orientation() - psi);
 
@@ -127,9 +324,8 @@ Velocity2D RGBDFollower::getPureTrackingCtrl(const TrackedPose2D &tracking_pose,
         (track_velocity_ * tracking_pose.v() * sin_diff + v * std::sin(psi)) /
         ff_range;
 
-    // Backstop for whatever the floor above cannot cover: the feedforward
-    // alone must never be able to saturate the command, since the feedback
-    // term is what actually steers toward the target.
+    // Backstop for whatever the floor above cannot cover. The feedforward
+    // alone must never be able to saturate the command.
     omega_ff = std::clamp(omega_ff, -0.5 * ctrl_limits_.omegaParams.maxOmega,
                           0.5 * ctrl_limits_.omegaParams.maxOmega);
 
@@ -147,76 +343,7 @@ Velocity2D RGBDFollower::getPureTrackingCtrl(const TrackedPose2D &tracking_pose,
   return followingVel;
 }
 
-bool RGBDFollower::setInitialTracking(const int pose_x_img,
-                                      const int pose_y_img,
-                                      const std::vector<Bbox3D> &detected_boxes,
-                                      const float yaw) {
-  const bool ok =
-      tracker_->setInitialTracking(pose_x_img, pose_y_img, detected_boxes, yaw);
-  if (ok) {
-    refreshTargetGeometry();
-  }
-  return ok;
-}
-
-bool RGBDFollower::setInitialTracking(
-    const int pose_x_img, const int pose_y_img,
-    const DepthImageView &aligned_depth_image,
-    const std::vector<Bbox2D> &detected_boxes, const float yaw) {
-
-  std::unique_ptr<Bbox2D> target_box;
-  for (auto box : detected_boxes) {
-    auto limits_x = box.getXLimits();
-    if (pose_x_img >= limits_x(0) and pose_x_img <= limits_x(1)) {
-      auto limits_y = box.getYLimits();
-      if (pose_y_img >= limits_y(0) and pose_y_img <= limits_y(1)) {
-        target_box = std::make_unique<Bbox2D>(box);
-        break;
-      }
-    }
-  }
-  if (!target_box) {
-    LOG_DEBUG("Target point not found in any detected box");
-    return false;
-  }
-
-  return setInitialTracking(aligned_depth_image, *target_box, yaw);
-}
-
-bool RGBDFollower::setInitialTracking(const DepthImageView &aligned_depth_image,
-                                      const Bbox2D &target_box_2d,
-                                      const float yaw) {
-  if (!detector_) {
-    throw std::runtime_error(
-        "DepthDetector is not initialized with the camera intrinsics. Call "
-        "'RGBDFollower::setCameraIntrinsics' first");
-  }
-  if (track_velocity_) {
-    // Send current state to the detector
-    detector_->updateBoxes(aligned_depth_image, {target_box_2d}, currentState);
-  } else {
-    detector_->updateBoxes(aligned_depth_image, {target_box_2d});
-  }
-  const auto &boxes_3d = detector_->get3dDetections();
-  if (boxes_3d.empty()) {
-    LOG_DEBUG("Failed to get 3D box from 2D target box");
-    return false;
-  }
-  const bool ok = tracker_->setInitialTracking(boxes_3d[0], yaw);
-  if (ok) {
-    refreshTargetGeometry();
-  }
-  return ok;
-}
-
-void RGBDFollower::refreshTargetGeometry() {
-  if (const auto *raw = tracker_->getRawTracking()) {
-    const auto &sz = raw->box.size;
-    currentTargetRadius_ = 0.5f * std::max(sz.x(), sz.y());
-  }
-  // else: leave previous value untouched so a transient miss doesn't
-  // erase a previously-known radius.
-}
+// ---- Search and wait when the target is lost ----
 
 std::optional<TrajSearchResult> RGBDFollower::trySearch() {
   if (!config_.enable_search()) {
@@ -318,6 +445,8 @@ TrajSearchResult RGBDFollower::popSearchStepResult() {
   result.trajectory = Trajectory2D(velocities, path);
   return result;
 }
+
+// ---- Pipeline stages used by the inner getTrackingCtrl ----
 
 TrackedPose2D
 RGBDFollower::updateLocalTarget(const TrackedPose2D &current_target,

--- a/src/kompass_cpp/kompass_cpp/src/controllers/rgbd_follower.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/controllers/rgbd_follower.cpp
@@ -313,7 +313,7 @@ Velocity2D RGBDFollower::getPureTrackingCtrl(const TrackedPose2D &tracking_pose,
 
     v = std::clamp(v, -ctrl_limits_.velXParams.maxVel,
                    ctrl_limits_.velXParams.maxVel);
-    if (std::abs(v) < config_.min_vel()) {
+    if (std::abs(v) < ctrl_limits_.velXParams.minVel) {
       v = 0.0;
     }
     followingVel.setVx(v);
@@ -335,7 +335,7 @@ Velocity2D RGBDFollower::getPureTrackingCtrl(const TrackedPose2D &tracking_pose,
 
     omega = std::clamp(omega, -ctrl_limits_.omegaParams.maxOmega,
                        ctrl_limits_.omegaParams.maxOmega);
-    if (std::abs(omega) < config_.min_vel()) {
+    if (std::abs(omega) < ctrl_limits_.omegaParams.minOmega) {
       omega = 0.0;
     }
     followingVel.setOmega(omega);

--- a/src/kompass_cpp/kompass_cpp/src/mapping/local_mapper_gpu.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/mapping/local_mapper_gpu.cpp
@@ -385,6 +385,7 @@ Eigen::MatrixXi &LocalMapperGPU::scanToGrid(Span<PointCloudView> clouds) {
     throw std::logic_error(
         "scanToGrid(clouds): mapper was not constructed for pointcloud input");
   }
+  std::lock_guard<std::mutex> lock(m_mutex);
   validateClouds(clouds, m_sensorDev.size());
 
   try {
@@ -470,6 +471,7 @@ LocalMapperGPU::scanToGrid(Eigen::Ref<const Eigen::VectorXf> angles,
         "input; the laserscan overload would overwrite the pre-uploaded "
         "conversion bin angles");
   }
+  std::lock_guard<std::mutex> lock(m_mutex);
 
   try {
     m_q.fill(m_devicePtrGrid, static_cast<int>(OccupancyType::UNEXPLORED),

--- a/src/kompass_cpp/kompass_cpp/src/utils/cost_evaluator_gpu.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/utils/cost_evaluator_gpu.cpp
@@ -198,6 +198,7 @@ CostEvaluator::~CostEvaluator() {
 TrajSearchResult CostEvaluator::getMinTrajectoryCost(
     const std::unique_ptr<TrajectorySamples2D> &trajs,
     const Path::Path *reference_path, const Path::Path::View &tracked_segment) {
+  std::lock_guard<std::mutex> lock(m_mutex);
 
   try {
     double weight;

--- a/src/kompass_cpp/kompass_cpp/src/utils/critical_zone_check_gpu.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/utils/critical_zone_check_gpu.cpp
@@ -194,6 +194,7 @@ float CriticalZoneCheckerGPU::check(Span<PointCloudView> clouds,
     throw std::logic_error(
         "check(clouds): checker was not constructed for pointcloud input");
   }
+  std::lock_guard<std::mutex> lock(m_mutex);
   validateClouds(clouds, m_sensorDev.size());
 
   try {
@@ -260,6 +261,7 @@ float CriticalZoneCheckerGPU::check(Eigen::Ref<const Eigen::VectorXf> ranges,
     throw std::logic_error(
         "check(ranges): checker was constructed for pointcloud input");
   }
+  std::lock_guard<std::mutex> lock(m_mutex);
   try {
     // Input is float32. Straight H→D copy
     m_q.memcpy(m_devicePtrRanges, ranges.data(), sizeof(float) * m_scanSize);

--- a/src/kompass_cpp/kompass_cpp/src/utils/trajectory_sampler.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/utils/trajectory_sampler.cpp
@@ -443,42 +443,6 @@ void TrajectorySampler::updateState(const Path::State &current_state) {
   collChecker->updateState(current_state);
 }
 
-template <>
-bool TrajectorySampler::checkStatesFeasibility<LaserScan>(
-    const std::vector<Path::State> &states, const LaserScan &scan) {
-  if (states.empty()) {
-    return false;
-  }
-  // states[0] is where the robot was when the scan was taken; the rest are
-  // future poses tested against those same obstacles.
-  collChecker->updateSensorData(scan, states[0]);
-  for (auto state : states) {
-    collChecker->updateState(state);
-    if (collChecker->checkCollisions()) {
-      return true;
-    }
-  }
-  return false;
-}
-
-template <>
-bool TrajectorySampler::checkStatesFeasibility<std::vector<Path::Point>>(
-    const std::vector<Path::State> &states,
-    const std::vector<Path::Point> &cloud) {
-  if (states.empty()) {
-    return false;
-  }
-  // states[0] is the capture pose (see the LaserScan specialization)
-  collChecker->updateSensorData(cloud, states[0]);
-  for (auto state : states) {
-    collChecker->updateState(state);
-    if (collChecker->checkCollisions()) {
-      return true;
-    }
-  }
-  return false;
-}
-
 Trajectory2D
 TrajectorySampler::generateSingleSampleFromVel(const Velocity2D &vel,
                                                const Path::State &pose) {

--- a/src/kompass_cpp/kompass_cpp/src/utils/trajectory_sampler.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/utils/trajectory_sampler.cpp
@@ -120,29 +120,36 @@ void TrajectorySampler::updateParams(TrajectorySamplerParameters config) {
   ang_samples_max_ = maxAngularSamples + 1 - (maxAngularSamples % 2);
 }
 
-const std::vector<double> &TrajectorySampler::linearSamples() {
-  lin_samples_scratch_.clear();
-  for (double vx = min_vx_; vx <= max_vx_; vx += lin_sample_x_resolution_) {
-    lin_samples_scratch_.push_back(vx);
+const std::vector<double> &
+TrajectorySampler::axisSamples(std::vector<double> &samples, double low,
+                               double high, double resolution,
+                               double min_abs) const {
+  samples.clear();
+  for (double v = low; v <= high; v += resolution) {
+    // Drop values between 0 and minVel, the exact zero is added below
+    if (std::abs(v) < min_abs) {
+      continue;
+    }
+    samples.push_back(v);
   }
-  // Stop and creep speeds, when reachable and not already on the grid
-  const double min_speed = ctrlimits.velXParams.minVel;
-  for (const double extra : {0.0, min_speed, -min_speed}) {
-    if (extra < min_vx_ || extra > max_vx_) {
+  // Zero and the slowest executable motion, when reachable and not already
+  // on the grid
+  for (const double extra : {0.0, min_abs, -min_abs}) {
+    if (extra < low || extra > high) {
       continue;
     }
     bool present = false;
-    for (const double vx : lin_samples_scratch_) {
-      if (std::abs(vx - extra) < 1e-3) {
+    for (const double v : samples) {
+      if (std::abs(v - extra) < 1e-3) {
         present = true;
         break;
       }
     }
     if (!present) {
-      lin_samples_scratch_.push_back(extra);
+      samples.push_back(extra);
     }
   }
-  return lin_samples_scratch_;
+  return samples;
 }
 
 void TrajectorySampler::addStopSample(
@@ -225,19 +232,23 @@ TrajectorySampler::generateTrajectoriesNonHolonomic(
   std::unique_ptr<TrajectorySamples2D> admissible_velocity_trajectories =
       std::make_unique<TrajectorySamples2D>(numTrajectories,
                                             numPointsPerTrajectory);
-  // Sample the (vx × omega) grid for arc-like motion. Skip vx ≈ 0 so no
-  // pure-rotation samples are produced — unexecutable for Ackermann, and
-  // intentionally excluded for diff-drive (goal-cost cannot rank spins).
+  // Sample the (vx × omega) grid for arc-like motion. The vx = 0 row gets no
+  // angular fan so no pure-rotation samples are produced. Zero velocity itself
+  // is the stop sample added after the loops.
+  const std::vector<double> &vx_samples =
+      axisSamples(vx_samples_, min_vx_, max_vx_, lin_sample_x_resolution_,
+                  ctrlimits.velXParams.minVel);
+  const std::vector<double> &omega_samples =
+      axisSamples(omega_samples_, min_omega_, max_omega_,
+                  ang_sample_resolution_, ctrlimits.omegaParams.minOmega);
   if (m_pool) {
     // run in threadpool
     static thread_local std::vector<std::future<void>> futures;
     futures.clear();
     futures.reserve(numTrajectories);
-    for (const double vx : linearSamples()) {
-      if (std::abs(vx) >= MIN_VEL) {
-        for (double omega = min_omega_; omega <= max_omega_;
-             omega += ang_sample_resolution_) {
-
+    for (const double vx : vx_samples) {
+      if (vx != 0.0) {
+        for (const double omega : omega_samples) {
           Velocity2D vel = Velocity2D(vx, 0.0, omega); // Limit Y movement
           // Get admissible trajectories in separate threads
           futures.emplace_back(m_pool->enqueue(
@@ -251,11 +262,9 @@ TrajectorySampler::generateTrajectoriesNonHolonomic(
       f.wait();
     }
   } else {
-    for (const double vx : linearSamples()) {
-      if (std::abs(vx) >= MIN_VEL) {
-        for (double omega = min_omega_; omega <= max_omega_;
-             omega += ang_sample_resolution_) {
-
+    for (const double vx : vx_samples) {
+      if (vx != 0.0) {
+        for (const double omega : omega_samples) {
           Velocity2D vel = Velocity2D(vx, 0.0, omega); // Limit Y movement
           getAdmissibleTrajsFromVel(vel, current_pose,
                                     admissible_velocity_trajectories.get());
@@ -274,17 +283,24 @@ TrajectorySampler::generateTrajectoriesHolonomic(
       std::make_unique<TrajectorySamples2D>(numTrajectories,
                                             numPointsPerTrajectory);
 
+  const std::vector<double> &vx_samples =
+      axisSamples(vx_samples_, min_vx_, max_vx_, lin_sample_x_resolution_,
+                  ctrlimits.velXParams.minVel);
+  const std::vector<double> &vy_samples =
+      axisSamples(vy_samples_, min_vy_, max_vy_, lin_sample_y_resolution_,
+                  ctrlimits.velYParams.minVel);
+  const std::vector<double> &omega_samples =
+      axisSamples(omega_samples_, min_omega_, max_omega_,
+                  ang_sample_resolution_, ctrlimits.omegaParams.minOmega);
   if (m_pool) {
     // spawn in threadpool
     static thread_local std::vector<std::future<void>> futures;
     futures.clear();
     futures.reserve(numTrajectories);
-    for (const double vx : linearSamples()) {
-      if (std::abs(vx) >= MIN_VEL) {
+    for (const double vx : vx_samples) {
+      if (vx != 0.0) {
         // vx, omega
-        for (double omega = min_omega_; omega <= max_omega_;
-             omega += ang_sample_resolution_) {
-
+        for (const double omega : omega_samples) {
           Velocity2D vel = Velocity2D(vx, 0.0, omega); // Limit Y movement
           // Get admissible trajectories in separate threads
           futures.emplace_back(m_pool->enqueue(
@@ -293,9 +309,7 @@ TrajectorySampler::generateTrajectoriesHolonomic(
         }
 
         // vx, vy
-        for (double vy = min_vy_; vy <= max_vy_;
-             vy += lin_sample_y_resolution_) {
-
+        for (const double vy : vy_samples) {
           Velocity2D vel = Velocity2D(vx, vy, 0.0); // Limit Y movement
           // Get admissible trajectories in separate threads
           futures.emplace_back(m_pool->enqueue(
@@ -310,21 +324,19 @@ TrajectorySampler::generateTrajectoriesHolonomic(
     }
   } else {
 
-    for (const double vx : linearSamples()) {
+    for (const double vx : vx_samples) {
       // vx, vy
-      for (double vy = min_vy_; vy <= max_vy_; vy += lin_sample_y_resolution_) {
-        if (std::abs(vx) < MIN_VEL && std::abs(vy) < MIN_VEL) {
+      for (const double vy : vy_samples) {
+        if (vx == 0.0 && vy == 0.0) {
           // The stop sample is added once after the loops
           continue;
         }
         getAdmissibleTrajsFromVel(Velocity2D(vx, vy, 0.0), current_pose,
                                   admissible_velocity_trajectories.get());
       }
-      if (std::abs(vx) >= MIN_VEL) {
+      if (vx != 0.0) {
         // vx, omega
-        for (double omega = min_omega_; omega <= max_omega_;
-             omega += ang_sample_resolution_) {
-
+        for (const double omega : omega_samples) {
           getAdmissibleTrajsFromVel(Velocity2D(vx, 0.0, omega), current_pose,
                                     admissible_velocity_trajectories.get());
         }
@@ -480,7 +492,9 @@ TrajectorySampler::generateSingleSampleFromVel(const Velocity2D &vel,
   trajectory.path.add(0, simulated_pose.x, simulated_pose.y);
   if (ctrType == ControlType::DIFFERENTIAL_DRIVE) {
     for (size_t i = 0; i < (numPointsPerTrajectory - 1); ++i) {
-      if (std::abs(vel.vx()) > MIN_VEL && std::abs(vel.omega()) > MIN_VEL) {
+      // Rotate then move only when both parts are motions the robot executes
+      if (std::abs(vel.vx()) >= ctrlimits.velXParams.minVel &&
+          std::abs(vel.omega()) >= ctrlimits.omegaParams.minOmega) {
         // Rotate then move
         Velocity2D tempVel = vel;
         tempVel.setVx(0.0);

--- a/src/kompass_cpp/kompass_cpp/src/utils/trajectory_sampler.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/utils/trajectory_sampler.cpp
@@ -375,9 +375,9 @@ TrajectorySampler::generateTrajectories(const Velocity2D &current_vel,
 }
 
 void TrajectorySampler::setPredictionHorizon(double horizon) {
-  // Clamp to at least 2 time steps so rollout has room for a finite
-  // difference, and never exceed the horizon passed at construction.
-  const double min_horizon = 2.0 * time_step_;
+  // Clamp to at least 3 points (two rollout steps) and never exceed the
+  // horizon passed at construction.
+  const double min_horizon = 3.0 * time_step_;
   if (horizon < min_horizon)
     horizon = min_horizon;
   if (horizon > base_max_time_)

--- a/src/kompass_cpp/kompass_cpp/src/utils/trajectory_sampler.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/utils/trajectory_sampler.cpp
@@ -233,7 +233,7 @@ TrajectorySampler::generateTrajectoriesNonHolonomic(
     futures.clear();
     futures.reserve(numTrajectories);
     for (const double vx : vx_samples) {
-      if (vx != 0.0) {
+      if (std::abs(vx) >= ctrlimits.velXParams.minVel && vx != 0.0) {
         for (const double omega : omega_samples) {
           Velocity2D vel = Velocity2D(vx, 0.0, omega); // Limit Y movement
           // Get admissible trajectories in separate threads
@@ -249,7 +249,7 @@ TrajectorySampler::generateTrajectoriesNonHolonomic(
     }
   } else {
     for (const double vx : vx_samples) {
-      if (vx != 0.0) {
+      if (std::abs(vx) >= ctrlimits.velXParams.minVel && vx != 0.0) {
         for (const double omega : omega_samples) {
           Velocity2D vel = Velocity2D(vx, 0.0, omega); // Limit Y movement
           getAdmissibleTrajsFromVel(vel, current_pose,
@@ -283,7 +283,7 @@ TrajectorySampler::generateTrajectoriesHolonomic(
     futures.clear();
     futures.reserve(numTrajectories);
     for (const double vx : vx_samples) {
-      if (vx != 0.0) {
+      if (std::abs(vx) >= ctrlimits.velXParams.minVel && vx != 0.0) {
         // vx, omega
         for (const double omega : omega_samples) {
           Velocity2D vel = Velocity2D(vx, 0.0, omega); // Limit Y movement
@@ -292,15 +292,20 @@ TrajectorySampler::generateTrajectoriesHolonomic(
               &TrajectorySampler::getAdmissibleTrajsFromVel, this, vel,
               current_pose, admissible_velocity_trajectories.get()));
         }
-
-        // vx, vy
-        for (const double vy : vy_samples) {
-          Velocity2D vel = Velocity2D(vx, vy, 0.0); // Limit Y movement
-          // Get admissible trajectories in separate threads
-          futures.emplace_back(m_pool->enqueue(
-              &TrajectorySampler::getAdmissibleTrajsFromVel, this, vel,
-              current_pose, admissible_velocity_trajectories.get()));
+      }
+      // vx, vy
+      for (const double vy : vy_samples) {
+        if ((std::abs(vx) < ctrlimits.velXParams.minVel &&
+             std::abs(vy) < ctrlimits.velYParams.minVel) ||
+            (vx == 0.0 && vy == 0.0)) {
+          // Zero velocity is never sampled
+          continue;
         }
+        Velocity2D vel = Velocity2D(vx, vy, 0.0); // Limit Y movement
+        // Get admissible trajectories in separate threads
+        futures.emplace_back(m_pool->enqueue(
+            &TrajectorySampler::getAdmissibleTrajsFromVel, this, vel,
+            current_pose, admissible_velocity_trajectories.get()));
       }
     }
     // wait on the futures before returning
@@ -312,14 +317,16 @@ TrajectorySampler::generateTrajectoriesHolonomic(
     for (const double vx : vx_samples) {
       // vx, vy
       for (const double vy : vy_samples) {
-        if (vx == 0.0 && vy == 0.0) {
+        if ((std::abs(vx) < ctrlimits.velXParams.minVel &&
+             std::abs(vy) < ctrlimits.velYParams.minVel) ||
+            (vx == 0.0 && vy == 0.0)) {
           // Zero velocity is never sampled
           continue;
         }
         getAdmissibleTrajsFromVel(Velocity2D(vx, vy, 0.0), current_pose,
                                   admissible_velocity_trajectories.get());
       }
-      if (vx != 0.0) {
+      if (std::abs(vx) >= ctrlimits.velXParams.minVel && vx != 0.0) {
         // vx, omega
         for (const double omega : omega_samples) {
           getAdmissibleTrajsFromVel(Velocity2D(vx, 0.0, omega), current_pose,

--- a/src/kompass_cpp/kompass_cpp/src/utils/trajectory_sampler.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/utils/trajectory_sampler.cpp
@@ -49,7 +49,7 @@ TrajectorySampler::TrajectorySampler(
 
   if (ctrType != ControlType::OMNI) {
     // Discard Vy limits to eliminate movement on Y axis
-    ctrlimits.velYParams = LinearVelocityControlParams(0.0, 0.0, 0.0);
+    ctrlimits.velYParams = LinearVelocityControlParams(0.0, 0.0, 0.0, 0.0);
   }
 
   numTrajectories =
@@ -82,7 +82,7 @@ TrajectorySampler::TrajectorySampler(
 
   if (ctrType != ControlType::OMNI) {
     // Discard Vy limits to eliminate movement on Y axis
-    ctrlimits.velYParams = LinearVelocityControlParams(0.0, 0.0, 0.0);
+    ctrlimits.velYParams = LinearVelocityControlParams(0.0, 0.0, 0.0, 0.0);
   }
 
   numTrajectories =
@@ -120,14 +120,48 @@ void TrajectorySampler::updateParams(TrajectorySamplerParameters config) {
   ang_samples_max_ = maxAngularSamples + 1 - (maxAngularSamples % 2);
 }
 
+const std::vector<double> &TrajectorySampler::linearSamples() {
+  lin_samples_scratch_.clear();
+  for (double vx = min_vx_; vx <= max_vx_; vx += lin_sample_x_resolution_) {
+    lin_samples_scratch_.push_back(vx);
+  }
+  // Stop and creep speeds, when reachable and not already on the grid
+  const double min_speed = ctrlimits.velXParams.minVel;
+  for (const double extra : {0.0, min_speed, -min_speed}) {
+    if (extra < min_vx_ || extra > max_vx_) {
+      continue;
+    }
+    bool present = false;
+    for (const double vx : lin_samples_scratch_) {
+      if (std::abs(vx - extra) < 1e-3) {
+        present = true;
+        break;
+      }
+    }
+    if (!present) {
+      lin_samples_scratch_.push_back(extra);
+    }
+  }
+  return lin_samples_scratch_;
+}
+
+void TrajectorySampler::addStopSample(
+    const Path::State &current_pose,
+    TrajectorySamples2D *admissible_velocity_trajectories) {
+  // Only executable when zero lies inside the reachable window of every axis
+  // (vy is a zero window for non-holonomic robots)
+  if (min_vx_ > 0.0 || max_vx_ < 0.0 || min_vy_ > 0.0 || max_vy_ < 0.0 ||
+      min_omega_ > 0.0 || max_omega_ < 0.0) {
+    return;
+  }
+  getAdmissibleTrajsFromVel(Velocity2D(0.0, 0.0, 0.0), current_pose,
+                            admissible_velocity_trajectories);
+}
+
 void TrajectorySampler::getAdmissibleTrajsFromVel(
     const Velocity2D &vel, const Path::State &start_pose,
     TrajectorySamples2D *admissible_velocity_trajectories) {
 
-  if (std::abs(vel.vx()) < MIN_VEL and std::abs(vel.vy()) < MIN_VEL and
-      std::abs(vel.omega()) < MIN_VEL) {
-    return;
-  }
   Path::State simulated_pose = start_pose;
   TrajectoryVelocities2D simulated_velocities(numPointsPerTrajectory);
   TrajectoryPath path(numPointsPerTrajectory);
@@ -199,7 +233,7 @@ TrajectorySampler::generateTrajectoriesNonHolonomic(
     static thread_local std::vector<std::future<void>> futures;
     futures.clear();
     futures.reserve(numTrajectories);
-    for (double vx = min_vx_; vx <= max_vx_; vx += lin_sample_x_resolution_) {
+    for (const double vx : linearSamples()) {
       if (std::abs(vx) >= MIN_VEL) {
         for (double omega = min_omega_; omega <= max_omega_;
              omega += ang_sample_resolution_) {
@@ -217,7 +251,7 @@ TrajectorySampler::generateTrajectoriesNonHolonomic(
       f.wait();
     }
   } else {
-    for (double vx = min_vx_; vx <= max_vx_; vx += lin_sample_x_resolution_) {
+    for (const double vx : linearSamples()) {
       if (std::abs(vx) >= MIN_VEL) {
         for (double omega = min_omega_; omega <= max_omega_;
              omega += ang_sample_resolution_) {
@@ -229,6 +263,7 @@ TrajectorySampler::generateTrajectoriesNonHolonomic(
       }
     }
   }
+  addStopSample(current_pose, admissible_velocity_trajectories.get());
   return admissible_velocity_trajectories;
 }
 
@@ -244,7 +279,7 @@ TrajectorySampler::generateTrajectoriesHolonomic(
     static thread_local std::vector<std::future<void>> futures;
     futures.clear();
     futures.reserve(numTrajectories);
-    for (double vx = min_vx_; vx <= max_vx_; vx += lin_sample_x_resolution_) {
+    for (const double vx : linearSamples()) {
       if (std::abs(vx) >= MIN_VEL) {
         // vx, omega
         for (double omega = min_omega_; omega <= max_omega_;
@@ -275,10 +310,13 @@ TrajectorySampler::generateTrajectoriesHolonomic(
     }
   } else {
 
-    for (double vx = min_vx_; vx <= max_vx_; vx += lin_sample_x_resolution_) {
+    for (const double vx : linearSamples()) {
       // vx, vy
       for (double vy = min_vy_; vy <= max_vy_; vy += lin_sample_y_resolution_) {
-
+        if (std::abs(vx) < MIN_VEL && std::abs(vy) < MIN_VEL) {
+          // The stop sample is added once after the loops
+          continue;
+        }
         getAdmissibleTrajsFromVel(Velocity2D(vx, vy, 0.0), current_pose,
                                   admissible_velocity_trajectories.get());
       }
@@ -293,6 +331,7 @@ TrajectorySampler::generateTrajectoriesHolonomic(
       }
     }
   }
+  addStopSample(current_pose, admissible_velocity_trajectories.get());
   return admissible_velocity_trajectories;
 }
 

--- a/src/kompass_cpp/kompass_cpp/src/utils/trajectory_sampler.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/utils/trajectory_sampler.cpp
@@ -375,9 +375,9 @@ TrajectorySampler::generateTrajectories(const Velocity2D &current_vel,
 }
 
 void TrajectorySampler::setPredictionHorizon(double horizon) {
-  // Clamp to at least 3 points (two rollout steps) and never exceed the
-  // horizon passed at construction.
-  const double min_horizon = 3.0 * time_step_;
+  // Clamp to at least 2 time steps so rollout has room for a finite
+  // difference, and never exceed the horizon passed at construction.
+  const double min_horizon = 2.0 * time_step_;
   if (horizon < min_horizon)
     horizon = min_horizon;
   if (horizon > base_max_time_)

--- a/src/kompass_cpp/kompass_cpp/src/utils/trajectory_sampler.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/utils/trajectory_sampler.cpp
@@ -152,19 +152,6 @@ TrajectorySampler::axisSamples(std::vector<double> &samples, double low,
   return samples;
 }
 
-void TrajectorySampler::addStopSample(
-    const Path::State &current_pose,
-    TrajectorySamples2D *admissible_velocity_trajectories) {
-  // Only executable when zero lies inside the reachable window of every axis
-  // (vy is a zero window for non-holonomic robots)
-  if (min_vx_ > 0.0 || max_vx_ < 0.0 || min_vy_ > 0.0 || max_vy_ < 0.0 ||
-      min_omega_ > 0.0 || max_omega_ < 0.0) {
-    return;
-  }
-  getAdmissibleTrajsFromVel(Velocity2D(0.0, 0.0, 0.0), current_pose,
-                            admissible_velocity_trajectories);
-}
-
 void TrajectorySampler::getAdmissibleTrajsFromVel(
     const Velocity2D &vel, const Path::State &start_pose,
     TrajectorySamples2D *admissible_velocity_trajectories) {
@@ -233,8 +220,7 @@ TrajectorySampler::generateTrajectoriesNonHolonomic(
       std::make_unique<TrajectorySamples2D>(numTrajectories,
                                             numPointsPerTrajectory);
   // Sample the (vx × omega) grid for arc-like motion. The vx = 0 row gets no
-  // angular fan so no pure-rotation samples are produced. Zero velocity itself
-  // is the stop sample added after the loops.
+  // angular fan so no pure-rotation samples are produced.
   const std::vector<double> &vx_samples =
       axisSamples(vx_samples_, min_vx_, max_vx_, lin_sample_x_resolution_,
                   ctrlimits.velXParams.minVel);
@@ -272,7 +258,6 @@ TrajectorySampler::generateTrajectoriesNonHolonomic(
       }
     }
   }
-  addStopSample(current_pose, admissible_velocity_trajectories.get());
   return admissible_velocity_trajectories;
 }
 
@@ -328,7 +313,7 @@ TrajectorySampler::generateTrajectoriesHolonomic(
       // vx, vy
       for (const double vy : vy_samples) {
         if (vx == 0.0 && vy == 0.0) {
-          // The stop sample is added once after the loops
+          // Zero velocity is never sampled
           continue;
         }
         getAdmissibleTrajsFromVel(Velocity2D(vx, vy, 0.0), current_pose,
@@ -343,7 +328,6 @@ TrajectorySampler::generateTrajectoriesHolonomic(
       }
     }
   }
-  addStopSample(current_pose, admissible_velocity_trajectories.get());
   return admissible_velocity_trajectories;
 }
 

--- a/src/kompass_cpp/kompass_cpp/src/utils/trajectory_sampler.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/utils/trajectory_sampler.cpp
@@ -26,7 +26,8 @@ TrajectorySampler::TrajectorySampler(
     const std::vector<float> robotDimensions,
     const Eigen::Vector3f &sensor_position_body,
     const Eigen::Quaternionf &sensor_rotation_body, const double octreeRes,
-    const int maxNumThreads) {
+    const bool allowReverse, const int maxNumThreads) {
+  allow_reverse_ = allowReverse;
   // Setup the collision checker
   collChecker = std::make_unique<CollisionChecker>(
       robotShapeType, robotDimensions, sensor_position_body,
@@ -118,6 +119,7 @@ void TrajectorySampler::updateParams(TrajectorySamplerParameters config) {
                            lin_samples_y_);
   int maxAngularSamples = config.getParameter<int>("max_angular_samples");
   ang_samples_max_ = maxAngularSamples + 1 - (maxAngularSamples % 2);
+  allow_reverse_ = config.getParameter<bool>("allow_reverse");
 }
 
 const std::vector<double> &
@@ -398,7 +400,9 @@ void TrajectorySampler::UpdateReachableVelocityRange(
   max_vx_ = std::min(ctrlimits.velXParams.maxVel,
                      currentVel.vx() +
                          ctrlimits.velXParams.maxAcceleration * time_step_);
-  min_vx_ = std::max(-ctrlimits.velXParams.maxVel,
+  // With reversing disallowed the forward window is clipped at zero
+  const double x_floor = allow_reverse_ ? -ctrlimits.velXParams.maxVel : 0.0;
+  min_vx_ = std::max(x_floor,
                      currentVel.vx() -
                          ctrlimits.velXParams.maxDeceleration * time_step_);
 

--- a/src/kompass_cpp/kompass_cpp/src/vision/depth_detector.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/vision/depth_detector.cpp
@@ -3,6 +3,8 @@
 #include "utils/logger.h"
 #include "utils/transformation.h"
 #include <algorithm>
+#include <climits>
+#include <cmath>
 #include <optional>
 #include <vector>
 
@@ -48,7 +50,8 @@ DepthDetector::DepthDetector(
   // rotation lands twice and every detection is 90 degrees off.
   camera_in_body_tf_ =
       convention == CameraFrameConvention::Optical
-          ? camera_in_body_tf * Eigen::Isometry3f(opticalToBodyAligned().conjugate())
+          ? camera_in_body_tf *
+                Eigen::Isometry3f(opticalToBodyAligned().conjugate())
           : camera_in_body_tf;
 
   // Set camera  intrinsic parameters
@@ -58,6 +61,14 @@ DepthDetector::DepthDetector(
   cy_ = principal_point.y();
 
   body_in_world_tf_ = Eigen::Isometry3f::Identity();
+  // Until a sensor is described, a point cloud is taken as an identity mount
+  // with FLOAT32 fields (SensorConfig defaults)
+  setPointCloudSensor(SensorConfig{});
+}
+
+void DepthDetector::setPointCloudSensor(const SensorConfig &sensor) {
+  cloud_sensor_ = sensor;
+  cloud_in_camera_tf_ = camera_in_body_tf_.inverse() * sensor.tfBody();
 }
 
 void DepthDetector::updateBoxes(const DepthImageView &aligned_depth_img,
@@ -88,10 +99,42 @@ void DepthDetector::updatePOIs(const DepthImageView &aligned_depth_img,
   }
 }
 
+void DepthDetector::updateBoxes(const PointCloudView &cloud,
+                                const std::vector<Bbox2D> &detections,
+                                const std::optional<Path::State> &robot_state) {
+  if (robot_state.has_value()) {
+    body_in_world_tf_ = getTransformation(robot_state.value());
+  }
+  boxes_.clear();
+  if (detections.empty()) {
+    return;
+  }
+  projectCloud(cloud, detections);
+  for (std::size_t i = 0; i < detections.size(); ++i) {
+    auto converted_box = boxFromDepthSamples(detections[i], cloud_samples_[i]);
+    if (converted_box) {
+      boxes_.push_back(std::move(converted_box.value()));
+    }
+  }
+}
+
+void DepthDetector::updatePOIs(const PointCloudView &cloud,
+                               const PointsOfInterest &poi,
+                               const std::optional<Path::State> &robot_state) {
+  // A points-of-interest set reduces to one 2D box which then takes the same
+  // path as a detection
+  updateBoxes(cloud, {Bbox2D(poi)}, robot_state);
+}
+
 std::optional<Bbox3D>
 DepthDetector::convert2Dboxto3Dbox(const DepthImageView &depth,
                                    const Bbox2D &box2d) {
-  Bbox3D box3d(box2d);
+  gatherDepthSamples(depth, box2d);
+  return boxFromDepthSamples(box2d, depth_values_);
+}
+
+void DepthDetector::gatherDepthSamples(const DepthImageView &depth,
+                                       const Bbox2D &box2d) {
   Eigen::Vector2i x_limits = box2d.getXLimits();
   Eigen::Vector2i y_limits = box2d.getYLimits();
   // FLOAT32 pixels are metres already; UINT16 scale by the configured factor
@@ -113,17 +156,113 @@ DepthDetector::convert2Dboxto3Dbox(const DepthImageView &depth,
       }
     }
   }
-  if (depth_values_.size() <= 1) {
+}
+
+void DepthDetector::projectCloud(const PointCloudView &cloud,
+                                 const std::vector<Bbox2D> &boxes) {
+  const PointFieldType field_type = cloud_sensor_.cloud_field_type;
+  // TODO: an organized cloud (height > 1, height x width equal to the
+  // detection image) in the camera frame maps pixel (row, col) to point
+  // (row, col) directly. Such a cloud could index the box region the way
+  // gatherDepthSamples does instead of projecting every point.
+  cloud_samples_.resize(boxes.size());
+  box_limits_.resize(boxes.size());
+  // NOTE: Union rectangle of all boxes in inclusive pixel limits. A point that
+  // projects outside it cannot fall inside any box, which keeps the per-box
+  // loop off most of the cloud
+  int u_min = INT_MAX, u_max = INT_MIN, v_min = INT_MAX, v_max = INT_MIN;
+  for (std::size_t i = 0; i < boxes.size(); ++i) {
+    cloud_samples_[i].clear();
+    const Eigen::Vector2i x_limits = boxes[i].getXLimits();
+    const Eigen::Vector2i y_limits = boxes[i].getYLimits();
+    box_limits_[i] =
+        Eigen::Vector4i(x_limits(0), x_limits(1), y_limits(0), y_limits(1));
+    u_min = std::min(u_min, x_limits(0));
+    u_max = std::max(u_max, x_limits(1));
+    v_min = std::min(v_min, y_limits(0));
+    v_max = std::max(v_max, y_limits(1));
+  }
+
+  if (cloud.empty() || !cloud.offsetsValid()) {
+    LOG_WARNING("Point cloud is empty or has no x/y/z fields, no depth "
+                "samples for the 2D boxes");
+    return;
+  }
+  // The layout is checked once up front instead of per point. The last point
+  // of the last row must fit in the buffer with fields included
+  const int elem_size = elementSizeOf(field_type);
+  const std::size_t required_bytes =
+      static_cast<std::size_t>(cloud.height - 1) * cloud.row_step +
+      static_cast<std::size_t>(cloud.width - 1) * cloud.point_step +
+      std::max({cloud.x_offset, cloud.y_offset, cloud.z_offset}) + elem_size;
+  if (required_bytes > cloud.data.size()) {
+    LOG_WARNING("Point cloud layout exceeds its buffer (", required_bytes,
+                " bytes needed, ", cloud.data.size(),
+                " given), no depth "
+                "samples for the 2D boxes");
+    return;
+  }
+
+  const Eigen::Matrix3f rotation = cloud_in_camera_tf_.linear();
+  const Eigen::Vector3f translation = cloud_in_camera_tf_.translation();
+  const uint8_t *bytes = cloud.data.data();
+
+  // Walk the rows by their payload only (width points), so the row padding of
+  // organized clouds is never decoded as points
+  const int row_bytes = cloud.width * cloud.point_step;
+  for (int row = 0; row < cloud.height; ++row) {
+    for (int col = 0; col < row_bytes; col += cloud.point_step) {
+      const std::size_t point_start = row * cloud.row_step + col;
+      const Eigen::Vector3f point{
+          load_and_cast_val(bytes, point_start + cloud.x_offset, field_type),
+          load_and_cast_val(bytes, point_start + cloud.y_offset, field_type),
+          load_and_cast_val(bytes, point_start + cloud.z_offset, field_type)};
+      // Into the body-aligned camera axes: x forward, y left, z up
+      const Eigen::Vector3f in_camera = rotation * point + translation;
+      const float depth = in_camera.x();
+
+      // Filter non finite points
+      if (!(depth >= minDepth_ && depth <= maxDepth_) || depth <= 0.0f) {
+        continue;
+      }
+
+      // NOTE: Pinhole projection: optical x (right) is -y and optical y (down)
+      // is -z of the body-aligned axes. Pixel i spans [i, i + 1) so the pixel a
+      // continuous coordinate lands in is its floor
+      const float inv_depth = 1.0f / depth;
+      const int u = static_cast<int>(
+          std::floor(fx_ * (-in_camera.y()) * inv_depth + cx_));
+      const int v = static_cast<int>(
+          std::floor(fy_ * (-in_camera.z()) * inv_depth + cy_));
+      if (u < u_min || u > u_max || v < v_min || v > v_max) {
+        continue;
+      }
+      for (std::size_t i = 0; i < boxes.size(); ++i) {
+        const Eigen::Vector4i &limits = box_limits_[i];
+        if (u >= limits(0) && u <= limits(1) && v >= limits(2) &&
+            v <= limits(3)) {
+          cloud_samples_[i].push_back(depth);
+        }
+      }
+    }
+  }
+}
+
+std::optional<Bbox3D>
+DepthDetector::boxFromDepthSamples(const Bbox2D &box2d,
+                                   std::vector<float> &samples) {
+  Bbox3D box3d(box2d);
+  if (samples.size() <= 1) {
     LOG_WARNING("Could not get any depth values for 2D bounding box at ",
                 box2d.top_corner.x(), ", ", box2d.top_corner.y());
     return std::nullopt;
   }
   float medianDepth, madDepth;
-  calculateMAD(depth_values_, medianDepth, madDepth);
+  calculateMAD(samples, medianDepth, madDepth);
 
   // Get min and max depth
   float minimum_d = maxDepth_, maximum_d = minDepth_;
-  for (auto depth_val : depth_values_) {
+  for (auto depth_val : samples) {
     if ((depth_val < minimum_d) &&
         (depth_val >= medianDepth - 1.5 * madDepth)) {
       minimum_d = depth_val;

--- a/src/kompass_cpp/kompass_cpp/src/vision/depth_detector.cpp
+++ b/src/kompass_cpp/kompass_cpp/src/vision/depth_detector.cpp
@@ -78,9 +78,10 @@ void DepthDetector::updateBoxes(const DepthImageView &aligned_depth_img,
     body_in_world_tf_ = getTransformation(robot_state.value());
   }
   boxes_.clear();
-  for (const auto &box2d : detections) {
-    auto converted_box = convert2Dboxto3Dbox(aligned_depth_img, box2d);
+  for (std::size_t i = 0; i < detections.size(); ++i) {
+    auto converted_box = convert2Dboxto3Dbox(aligned_depth_img, detections[i]);
     if (converted_box) {
+      converted_box->source_index = static_cast<int>(i);
       boxes_.push_back(std::move(converted_box.value()));
     }
   }
@@ -95,6 +96,7 @@ void DepthDetector::updatePOIs(const DepthImageView &aligned_depth_img,
   boxes_.clear();
   auto converted_box = convertPOIto3Dbox(aligned_depth_img, poi);
   if (converted_box) {
+    converted_box->source_index = 0;
     boxes_.push_back(std::move(converted_box.value()));
   }
 }
@@ -113,6 +115,7 @@ void DepthDetector::updateBoxes(const PointCloudView &cloud,
   for (std::size_t i = 0; i < detections.size(); ++i) {
     auto converted_box = boxFromDepthSamples(detections[i], cloud_samples_[i]);
     if (converted_box) {
+      converted_box->source_index = static_cast<int>(i);
       boxes_.push_back(std::move(converted_box.value()));
     }
   }
@@ -252,6 +255,7 @@ std::optional<Bbox3D>
 DepthDetector::boxFromDepthSamples(const Bbox2D &box2d,
                                    std::vector<float> &samples) {
   Bbox3D box3d(box2d);
+  box3d.sample_count = static_cast<int>(samples.size());
   if (samples.size() <= 1) {
     LOG_WARNING("Could not get any depth values for 2D bounding box at ",
                 box2d.top_corner.x(), ", ", box2d.top_corner.y());

--- a/src/kompass_cpp/tests/CMakeLists.txt
+++ b/src/kompass_cpp/tests/CMakeLists.txt
@@ -71,6 +71,11 @@ add_executable(vision_tracking_test vision_tracking_test.cpp)
 target_link_libraries(vision_tracking_test PRIVATE ${MODULE_NAME} Boost::headers nlohmann_json::nlohmann_json)
 add_test(vision_tracking_tests vision_tracking_test)
 
+# Depth detector unit tests (point-cloud path, parity against the depth image)
+add_executable(depth_detector_test depth_detector_test.cpp)
+target_link_libraries(depth_detector_test PRIVATE ${MODULE_NAME} Boost::headers)
+add_test(depth_detector_tests depth_detector_test)
+
 # add sycl based GPU tests
 if(AdaptiveCpp_FOUND)
   # Mapper GPU test

--- a/src/kompass_cpp/tests/CMakeLists.txt
+++ b/src/kompass_cpp/tests/CMakeLists.txt
@@ -26,9 +26,9 @@ add_executable(dwa_test dwa_test.cpp)
 target_link_libraries(dwa_test PRIVATE ${MODULE_NAME} Boost::headers nlohmann_json::nlohmann_json)
 add_test(dwa_tests dwa_test)
 
-# Trajectory Sampler Test (Generate and Plot Samples)
+# Trajectory Sampler Tests (sample set checks, and plots of the samples)
 add_executable(trajectory_sampler_test trajectory_sampler_test.cpp)
-target_link_libraries(trajectory_sampler_test PRIVATE ${MODULE_NAME} nlohmann_json::nlohmann_json)
+target_link_libraries(trajectory_sampler_test PRIVATE ${MODULE_NAME} Boost::headers nlohmann_json::nlohmann_json)
 add_test(trajectory_sampler_tests trajectory_sampler_test)
 
 # Cost evaluator tests

--- a/src/kompass_cpp/tests/critical_zone_test_gpu.cpp
+++ b/src/kompass_cpp/tests/critical_zone_test_gpu.cpp
@@ -18,7 +18,9 @@
 #include "utils/collision_check.h"
 #include "utils/critical_zone_check_gpu.h"
 #include <boost/test/included/unit_test.hpp>
+#include <atomic>
 #include <cmath>
+#include <thread>
 #include <vector>
 
 // ---------------------------------------------------------------------------
@@ -525,4 +527,65 @@ BOOST_AUTO_TEST_CASE(test_multi_sensor_optical_axis_not_filtered) {
              "Sensor-origin self-return should be filtered -> expected 1.0, "
              "got "
                  << clear);
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency: the drive manager calls check() from several executor threads
+// at once with the GIL released, and spinning LiDARs return a different point
+// count every revolution. Each check that sees a larger frame than before
+// reallocates the sensor's device buffer; without serialization two threads free
+// the same buffer or copy into one the other just freed.
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_pointcloud_concurrent_checks_with_varying_frames) {
+  Timer time;
+  // Frames of different sizes so the grow-and-reallocate path keeps firing;
+  // every point is far away, so every check must still report 1.0.
+  std::vector<std::vector<uint8_t>> frames;
+  for (int n : {40000, 52000, 41000, 55000, 43000, 50000, 47000, 54000}) {
+    std::vector<uint8_t> cloud;
+    cloud.reserve(static_cast<size_t>(n) * PC_POINT_STEP);
+    for (int i = 0; i < n; ++i) {
+      addPointToCloud(cloud, 5.0f + (i % 7) * 0.1f, 4.0f - (i % 5) * 0.1f,
+                      0.5f);
+    }
+    frames.push_back(std::move(cloud));
+  }
+  auto view = [](const std::vector<uint8_t> &cloud) {
+    const int num_points = static_cast<int>(cloud.size() / PC_POINT_STEP);
+    return PointCloudView{ByteSpan(cloud.data(), cloud.size()),
+                          PC_POINT_STEP,
+                          num_points * PC_POINT_STEP,
+                          1,
+                          num_points,
+                          PC_X_OFF,
+                          PC_Y_OFF,
+                          PC_Z_OFF};
+  };
+
+  auto &checker = shared_multi_checker();
+  constexpr int kThreads = 4;
+  constexpr int kIterations = 150;
+  std::atomic<int> unsafe_results{0};
+  std::vector<std::thread> workers;
+  for (int t = 0; t < kThreads; ++t) {
+    workers.emplace_back([&, t] {
+      for (int k = 0; k < kIterations; ++k) {
+        const auto &a = frames[(t + k) % frames.size()];
+        const auto &b = frames[(t * 3 + k * 5) % frames.size()];
+        const float factor =
+            checker.check(std::vector<PointCloudView>{view(a), view(b)},
+                          /*forward*/ true);
+        if (factor != 1.0f) {
+          ++unsafe_results;
+        }
+      }
+    });
+  }
+  for (auto &w : workers) {
+    w.join();
+  }
+  BOOST_TEST(unsafe_results == 0,
+             "far-away clouds must always be safe; got " << unsafe_results
+                                                         << " other results");
 }

--- a/src/kompass_cpp/tests/depth_detector_test.cpp
+++ b/src/kompass_cpp/tests/depth_detector_test.cpp
@@ -1,0 +1,301 @@
+#include "datatypes/sensors.h"
+#include "datatypes/tracking.h"
+#include "utils/transformation.h"
+#include "vision/depth_detector.h"
+#define BOOST_TEST_MODULE KOMPASS TESTS
+#include <boost/test/included/unit_test.hpp>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <vector>
+
+using namespace Kompass;
+
+namespace {
+
+// The VGA pinhole the Python fixtures use
+constexpr float kFx = 525.0f, kFy = 525.0f, kCx = 320.0f, kCy = 240.0f;
+constexpr int kCols = 640, kRows = 480;
+const Eigen::Vector2f kDepthRange{0.1f, 5.0f};
+constexpr float kDepthConversion = 1e-3f;
+
+// PointCloud2-style float32 xyz records with 4 bytes of padding, the layout
+// real LiDAR drivers publish (point_step 16, offsets 0/4/8)
+constexpr int kPointStep = 16;
+
+struct PackedCloud {
+  std::vector<uint8_t> data;
+  int height = 1;
+  int width = 0;
+  int row_step = 0;
+
+  PointCloudView view() const {
+    return PointCloudView{ByteSpan(data.data(), data.size()),
+                          kPointStep,
+                          row_step,
+                          height,
+                          width,
+                          0,
+                          4,
+                          8};
+  }
+};
+
+// Packs the points into a raw buffer. With height > 1 the cloud is organized
+// and every row gets `row_padding` trailing bytes, as PointCloud2 allows.
+PackedCloud pack(const std::vector<Eigen::Vector3f> &points, int height = 1,
+                 int row_padding = 0) {
+  PackedCloud cloud;
+  cloud.height = height;
+  cloud.width = static_cast<int>(points.size()) / height;
+  cloud.row_step = cloud.width * kPointStep + row_padding;
+  cloud.data.assign(static_cast<std::size_t>(height) * cloud.row_step, 0);
+  for (std::size_t i = 0; i < points.size(); ++i) {
+    const int row = static_cast<int>(i) / cloud.width;
+    const int col = static_cast<int>(i) % cloud.width;
+    std::memcpy(&cloud.data[row * cloud.row_step + col * kPointStep],
+                points[i].data(), 3 * sizeof(float));
+  }
+  return cloud;
+}
+
+// Pose of a camera's OPTICAL frame in the body frame: at `translation`,
+// looking along body +x turned by `yaw`
+Eigen::Isometry3f opticalCameraPose(const Eigen::Vector3f &translation,
+                                    const float yaw) {
+  const Eigen::Quaternionf rotation =
+      Eigen::AngleAxisf(yaw, Eigen::Vector3f::UnitZ()) *
+      DepthDetector::opticalToBodyAligned();
+  return getTransformation(rotation, translation);
+}
+
+DepthDetector makeDetector(const Eigen::Isometry3f &camera_optical_in_body) {
+  return DepthDetector(kDepthRange, camera_optical_in_body,
+                       Eigen::Vector2f{kFx, kFy}, Eigen::Vector2f{kCx, kCy},
+                       kDepthConversion,
+                       DepthDetector::CameraFrameConvention::Optical);
+}
+
+// A SensorConfig (mount pose in the body frame, FLOAT32 fields) from an
+// isometry, the way kompass builds one from a TF lookup
+SensorConfig sensorAt(const Eigen::Isometry3f &sensor_in_body) {
+  SensorConfig sensor;
+  sensor.position = sensor_in_body.translation();
+  const Eigen::Quaternionf q(sensor_in_body.linear());
+  sensor.rotation = Eigen::Vector4f{q.x(), q.y(), q.z(), q.w()};
+  return sensor;
+}
+
+// A synthetic uint16 depth image (millimetres) and the same scene as an
+// optical-frame point cloud: every pixel back-projected at its centre
+struct Scene {
+  std::vector<uint16_t> depth_mm;
+  std::vector<Eigen::Vector3f> points;
+
+  DepthImageView depthView() const {
+    return DepthImageView(
+        ByteSpan(reinterpret_cast<const uint8_t *>(depth_mm.data()),
+                 depth_mm.size() * sizeof(uint16_t)),
+        kRows, kCols, PointFieldType::UINT16);
+  }
+};
+
+// A 4.5 m background with one plateau per box that also ramps a little along
+// the columns, so the median and the MAD extent are both non-trivial
+Scene makeScene(const std::vector<std::pair<Bbox2D, uint16_t>> &plateaus) {
+  Scene scene;
+  scene.depth_mm.assign(static_cast<std::size_t>(kRows) * kCols, 4500);
+  for (const auto &[box, depth] : plateaus) {
+    const Eigen::Vector2i x_limits = box.getXLimits();
+    const Eigen::Vector2i y_limits = box.getYLimits();
+    for (int row = y_limits(0); row <= y_limits(1); ++row) {
+      for (int col = x_limits(0); col <= x_limits(1); ++col) {
+        scene.depth_mm[row * kCols + col] =
+            static_cast<uint16_t>(depth + 2 * (col - x_limits(0)));
+      }
+    }
+  }
+  scene.points.reserve(scene.depth_mm.size());
+  for (int row = 0; row < kRows; ++row) {
+    for (int col = 0; col < kCols; ++col) {
+      const float d = scene.depth_mm[row * kCols + col] * kDepthConversion;
+      scene.points.emplace_back((col + 0.5f - kCx) * d / kFx,
+                                (row + 0.5f - kCy) * d / kFy, d);
+    }
+  }
+  return scene;
+}
+
+void checkSameBoxes(const std::vector<Bbox3D> &from_depth,
+                    const std::vector<Bbox3D> &from_cloud) {
+  BOOST_REQUIRE_EQUAL(from_depth.size(), from_cloud.size());
+  for (std::size_t i = 0; i < from_depth.size(); ++i) {
+    BOOST_CHECK_SMALL((from_depth[i].center - from_cloud[i].center).norm(),
+                      1e-3f);
+    BOOST_CHECK_SMALL((from_depth[i].size - from_cloud[i].size).norm(), 1e-3f);
+    BOOST_CHECK(from_depth[i].center_img_frame == from_cloud[i].center_img_frame);
+    BOOST_CHECK(from_depth[i].size_img_frame == from_cloud[i].size_img_frame);
+    BOOST_CHECK(from_cloud[i].pc_points.empty());
+  }
+}
+
+} // namespace
+
+// The projection path must reproduce the depth-image path: a cloud made by
+// back-projecting the image, handed over in the camera's optical frame, gives
+// the same 3D boxes (two boxes at once, with a robot pose so the result is in
+// the world frame)
+BOOST_AUTO_TEST_CASE(cloud_path_matches_depth_image_path) {
+  const Bbox2D box_a(Eigen::Vector2i{270, 190}, Eigen::Vector2i{100, 100});
+  const Bbox2D box_b(Eigen::Vector2i{50, 300}, Eigen::Vector2i{60, 40});
+  const Scene scene = makeScene({{box_a, 2000}, {box_b, 3000}});
+  const Path::State robot_state(1.0, -2.0, 0.3, 0.0);
+  const Eigen::Isometry3f camera =
+      opticalCameraPose(Eigen::Vector3f{0.2f, 0.05f, 0.6f}, 0.17f);
+  const std::vector<Bbox2D> boxes{box_a, box_b};
+
+  DepthDetector from_depth = makeDetector(camera);
+  from_depth.updateBoxes(scene.depthView(), boxes, robot_state);
+  BOOST_REQUIRE_EQUAL(from_depth.get3dDetections().size(), 2);
+
+  DepthDetector from_cloud = makeDetector(camera);
+  // The cloud is expressed in the optical frame, so its sensor sits at the
+  // camera's optical pose
+  from_cloud.setPointCloudSensor(sensorAt(camera));
+  const PackedCloud cloud = pack(scene.points);
+  from_cloud.updateBoxes(cloud.view(), boxes,
+                         robot_state);
+
+  checkSameBoxes(from_depth.get3dDetections(), from_cloud.get3dDetections());
+}
+
+// Same scene as an organized cloud with padded rows: the row padding must be
+// skipped, not decoded as points
+BOOST_AUTO_TEST_CASE(cloud_path_handles_organized_row_padding) {
+  const Bbox2D box(Eigen::Vector2i{270, 190}, Eigen::Vector2i{100, 100});
+  const Scene scene = makeScene({{box, 2000}});
+  const Eigen::Isometry3f camera =
+      opticalCameraPose(Eigen::Vector3f{0.2f, 0.0f, 0.6f}, 0.0f);
+
+  DepthDetector from_depth = makeDetector(camera);
+  from_depth.updateBoxes(scene.depthView(), {box});
+
+  DepthDetector from_cloud = makeDetector(camera);
+  from_cloud.setPointCloudSensor(sensorAt(camera));
+  const PackedCloud cloud = pack(scene.points, kRows, 8);
+  from_cloud.updateBoxes(cloud.view(), {box});
+
+  checkSameBoxes(from_depth.get3dDetections(), from_cloud.get3dDetections());
+}
+
+// A LiDAR mounted away from the camera, in its own body-aligned frame: a
+// cluster at a known body-frame location comes back at that location, while
+// points behind the camera, out of range (a wall behind the cluster that
+// projects into the same box), outside the box, or non-finite are ignored
+BOOST_AUTO_TEST_CASE(cloud_path_lifts_lidar_cluster_through_mount_pose) {
+  const Eigen::Isometry3f camera =
+      opticalCameraPose(Eigen::Vector3f{0.3f, 0.0f, 0.5f}, 0.0f);
+  DepthDetector detector = makeDetector(camera);
+
+  const Eigen::Isometry3f lidar_in_body = getTransformation(
+      Eigen::Quaternionf(Eigen::AngleAxisf(0.2f, Eigen::Vector3f::UnitZ())),
+      Eigen::Vector3f{-0.1f, 0.0f, 0.8f});
+  detector.setPointCloudSensor(sensorAt(lidar_in_body));
+  const Eigen::Isometry3f body_in_lidar = lidar_in_body.inverse();
+
+  // Everything is placed in body coordinates and then moved into the LiDAR
+  // frame, which is what the sensor publishes
+  std::vector<Eigen::Vector3f> points;
+  const Eigen::Vector3f cluster{3.0f, 0.5f, 0.4f};
+  for (int i = -5; i <= 5; ++i) {
+    for (int j = -5; j <= 5; ++j) {
+      for (int k = -1; k <= 1; ++k) {
+        points.push_back(
+            body_in_lidar *
+            (cluster + Eigen::Vector3f{0.05f * k, 0.04f * i, 0.04f * j}));
+      }
+    }
+  }
+  const std::size_t cluster_points = points.size();
+  // A wall 5.7 m from the camera, more points than the cluster: if the range
+  // gate failed it would take over the median
+  for (int i = -10; i <= 10; ++i) {
+    for (int j = -10; j <= 10; ++j) {
+      points.push_back(body_in_lidar *
+                       Eigen::Vector3f{6.0f, 0.5f + 0.02f * i, 0.4f + 0.02f * j});
+    }
+  }
+  BOOST_REQUIRE_GT(points.size() - cluster_points, cluster_points);
+  points.push_back(body_in_lidar * Eigen::Vector3f{-2.0f, 0.5f, 0.4f});
+  points.push_back(body_in_lidar * Eigen::Vector3f{3.0f, -1.5f, 0.4f});
+  const float nan = std::numeric_limits<float>::quiet_NaN();
+  points.emplace_back(nan, nan, nan);
+
+  // The cluster's projection spans u in [184, 262] and v in [221, 298]
+  const Bbox2D box(Eigen::Vector2i{180, 218}, Eigen::Vector2i{86, 84});
+  const PackedCloud cloud = pack(points);
+  detector.updateBoxes(cloud.view(), {box});
+
+  const auto &boxes = detector.get3dDetections();
+  BOOST_REQUIRE_EQUAL(boxes.size(), 1);
+  // Body frame since no robot state was given. The centre is the box centre
+  // pixel at the median depth, which sits within a few millimetres of the
+  // cluster centre for this box
+  BOOST_CHECK_SMALL((boxes[0].center - cluster).norm(), 0.02f);
+  // Depth extent comes from the +-5 cm spread, MAD-clipped
+  BOOST_CHECK_GT(boxes[0].size.x(), 0.0f);
+  BOOST_CHECK_LT(boxes[0].size.x(), 0.2f);
+}
+
+// Nothing to lift: no point lands in the box, an empty view, or a view with
+// no x/y/z offsets all give an empty result without touching the buffer
+BOOST_AUTO_TEST_CASE(cloud_path_empty_results) {
+  const Eigen::Isometry3f camera =
+      opticalCameraPose(Eigen::Vector3f{0.0f, 0.0f, 0.0f}, 0.0f);
+  DepthDetector detector = makeDetector(camera);
+  const Bbox2D box(Eigen::Vector2i{300, 220}, Eigen::Vector2i{40, 40});
+
+  // In view, in range, but projecting far from the box
+  const PackedCloud outside = pack({Eigen::Vector3f{2.0f, 1.5f, 0.0f},
+                                    Eigen::Vector3f{2.0f, -1.5f, 0.0f}});
+  detector.updateBoxes(outside.view(), {box});
+  BOOST_CHECK(detector.get3dDetections().empty());
+
+  detector.updateBoxes(PointCloudView{}, {box});
+  BOOST_CHECK(detector.get3dDetections().empty());
+
+  PointCloudView no_offsets = outside.view();
+  no_offsets.z_offset = -1;
+  detector.updateBoxes(no_offsets, {box});
+  BOOST_CHECK(detector.get3dDetections().empty());
+
+  detector.updateBoxes(outside.view(), {});
+  BOOST_CHECK(detector.get3dDetections().empty());
+}
+
+// Points of interest reduce to one box and take the same path
+BOOST_AUTO_TEST_CASE(cloud_path_matches_depth_image_path_for_pois) {
+  const Bbox2D region(Eigen::Vector2i{270, 190}, Eigen::Vector2i{100, 100});
+  const Scene scene = makeScene({{region, 2000}});
+  const Eigen::Isometry3f camera =
+      opticalCameraPose(Eigen::Vector3f{0.2f, 0.0f, 0.6f}, -0.1f);
+  const PointsOfInterest poi(
+      {Eigen::Vector2i{300, 220}, Eigen::Vector2i{340, 260},
+       Eigen::Vector2i{320, 240}, Eigen::Vector2i{310, 250},
+       Eigen::Vector2i{330, 230}},
+      Eigen::Vector2i{kCols, kRows});
+  const Path::State robot_state(0.5, 0.25, -0.4, 0.0);
+
+  DepthDetector from_depth = makeDetector(camera);
+  from_depth.updatePOIs(scene.depthView(), poi, robot_state);
+  BOOST_REQUIRE_EQUAL(from_depth.get3dDetections().size(), 1);
+
+  DepthDetector from_cloud = makeDetector(camera);
+  from_cloud.setPointCloudSensor(sensorAt(camera));
+  const PackedCloud cloud = pack(scene.points);
+  from_cloud.updatePOIs(cloud.view(), poi,
+                        robot_state);
+
+  checkSameBoxes(from_depth.get3dDetections(), from_cloud.get3dDetections());
+}

--- a/src/kompass_cpp/tests/depth_detector_test.cpp
+++ b/src/kompass_cpp/tests/depth_detector_test.cpp
@@ -299,3 +299,58 @@ BOOST_AUTO_TEST_CASE(cloud_path_matches_depth_image_path_for_pois) {
 
   checkSameBoxes(from_depth.get3dDetections(), from_cloud.get3dDetections());
 }
+
+// Every lifted box says which input it came from and how many depth readings
+// it rests on, on both paths.
+BOOST_AUTO_TEST_CASE(lifted_boxes_carry_their_provenance) {
+  const Bbox3D untouched;
+  BOOST_CHECK_EQUAL(untouched.sample_count, 0);
+  BOOST_CHECK_EQUAL(untouched.source_index, -1);
+
+  // box_a rests on a plateau in range; box_b sits beyond the depth range and
+  // is dropped
+  const Bbox2D box_a(Eigen::Vector2i{270, 190}, Eigen::Vector2i{100, 100});
+  const Bbox2D box_b(Eigen::Vector2i{50, 300}, Eigen::Vector2i{60, 40});
+  const Scene scene = makeScene({{box_a, 2000}, {box_b, 6000}});
+  const std::vector<Bbox2D> boxes{box_b, box_a};
+  const Eigen::Isometry3f camera =
+      opticalCameraPose(Eigen::Vector3f{0.0f, 0.0f, 0.0f}, 0.0f);
+
+  // The readings the image path can use: in-range pixels within the box's
+  // inclusive limits
+  int usable = 0;
+  const Eigen::Vector2i x_limits = box_a.getXLimits();
+  const Eigen::Vector2i y_limits = box_a.getYLimits();
+  for (int row = y_limits(0); row <= y_limits(1); ++row) {
+    for (int col = x_limits(0); col <= x_limits(1); ++col) {
+      const float metres = scene.depth_mm[row * kCols + col] * kDepthConversion;
+      usable += (metres >= kDepthRange(0) && metres <= kDepthRange(1)) ? 1 : 0;
+    }
+  }
+
+  DepthDetector from_depth = makeDetector(camera);
+  from_depth.updateBoxes(scene.depthView(), boxes);
+  BOOST_REQUIRE_EQUAL(from_depth.get3dDetections().size(), 1);
+  const Bbox3D &from_image = from_depth.get3dDetections()[0];
+  BOOST_CHECK_EQUAL(from_image.source_index, 1);
+  BOOST_CHECK_EQUAL(from_image.sample_count, usable);
+
+  // One point per pixel, so the cloud path rests on the same readings
+  DepthDetector from_cloud = makeDetector(camera);
+  from_cloud.setPointCloudSensor(sensorAt(camera));
+  const PackedCloud cloud = pack(scene.points);
+  from_cloud.updateBoxes(cloud.view(), boxes);
+  BOOST_REQUIRE_EQUAL(from_cloud.get3dDetections().size(), 1);
+  BOOST_CHECK_EQUAL(from_cloud.get3dDetections()[0].source_index, 1);
+  BOOST_CHECK_EQUAL(from_cloud.get3dDetections()[0].sample_count, usable);
+
+  // A points-of-interest set is one input
+  const PointsOfInterest poi(
+      {Eigen::Vector2i{300, 220}, Eigen::Vector2i{340, 260},
+       Eigen::Vector2i{320, 240}},
+      Eigen::Vector2i{kCols, kRows});
+  from_depth.updatePOIs(scene.depthView(), poi);
+  BOOST_REQUIRE_EQUAL(from_depth.get3dDetections().size(), 1);
+  BOOST_CHECK_EQUAL(from_depth.get3dDetections()[0].source_index, 0);
+  BOOST_CHECK_GT(from_depth.get3dDetections()[0].sample_count, 1);
+}

--- a/src/kompass_cpp/tests/dwa_test.cpp
+++ b/src/kompass_cpp/tests/dwa_test.cpp
@@ -157,7 +157,7 @@ BOOST_AUTO_TEST_CASE(test_DWA) {
 // A goal closer than the smallest grid speed covers within the horizon: 0.5 s
 // steps, a 5 s rollout and a speed grid whose smallest speed (0.2 m/s)
 // travels 0.9 m, twice the distance to the goal. Every straight grid sample
-// overshoots, so only the stop sample and the creep speed can end near the
+// overshoots, so only the creep speed can end near the
 // goal. The controller must reach it with forward motion only: no reverse,
 // turning, or overshoot.
 BOOST_AUTO_TEST_CASE(test_DWA_creeps_onto_a_close_goal) {

--- a/src/kompass_cpp/tests/dwa_test.cpp
+++ b/src/kompass_cpp/tests/dwa_test.cpp
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(test_DWA) {
   Control::DWA planner(controlLimits, controlType, timeStep, predictionHorizon,
                        controlHorizon, maxLinearSamples, maxAngularSamples,
                        robotShapeType, robotDimensions, sensor_position_body,
-                       sensor_rotation_body, octreeRes, costWeights,
+                       sensor_rotation_body, octreeRes, costWeights, true,
                        maxNumThreads);
 
   LOG_INFO("Simulating one step of DWA planner");
@@ -196,7 +196,7 @@ BOOST_AUTO_TEST_CASE(test_DWA_creeps_onto_a_close_goal) {
                        maxLinearSamples, maxAngularSamples,
                        Kompass::CollisionChecker::ShapeType::CYLINDER,
                        robotDimensions, sensor_position_body,
-                       sensor_rotation_body, 0.1, costWeights, 1);
+                       sensor_rotation_body, 0.1, costWeights, true, 1);
   planner.setCurrentPath(path);
 
   // Nothing within 20 m in any direction
@@ -308,7 +308,7 @@ BOOST_AUTO_TEST_CASE(test_DWA_All_Scenarios) {
                              maxLinearSamples, maxAngularSamples, robotShapeType,
                              robotDimensions, sensor_position_body,
                              sensor_rotation_body, octreeRes, costWeights,
-                             maxNumThreads);
+                             true, maxNumThreads);
 
         // Match PurePursuit's goal tolerance — DWA's default 0.1 m is tight
         // given sampling resolution and sidestep-then-continue behavior.

--- a/src/kompass_cpp/tests/dwa_test.cpp
+++ b/src/kompass_cpp/tests/dwa_test.cpp
@@ -11,6 +11,7 @@
 #include <boost/dll/runtime_symbol_info.hpp> // for program_location
 #include <boost/filesystem.hpp>
 #include <boost/test/included/unit_test.hpp>
+#include <algorithm>
 #include <cmath>
 #include <functional>
 #include <limits>
@@ -158,8 +159,10 @@ BOOST_AUTO_TEST_CASE(test_DWA) {
 // steps, a 5 s rollout and a speed grid whose smallest speed (0.2 m/s)
 // travels 0.9 m, twice the distance to the goal. Every straight grid sample
 // overshoots, so only the stop sample and the creep speed can end near the
-// goal. The controller must reach it with forward motion only: no reverse,
-// turning, or overshoot.
+// goal, and with the horizon capped at the goal the grid speeds can end on
+// it too. The controller must reach it with forward motion only: no
+// reverse, turning, or overshoot, and within a few steps rather than by
+// creeping the whole way.
 BOOST_AUTO_TEST_CASE(test_DWA_creeps_onto_a_close_goal) {
   std::vector<Path::Point> points{Path::Point(0.0, 0.0, 0.0),
                                   Path::Point(1.5, 0.0, 0.0),
@@ -235,6 +238,99 @@ BOOST_AUTO_TEST_CASE(test_DWA_creeps_onto_a_close_goal) {
   }
   BOOST_TEST(planner.isGoalReached(),
              "Goal not reached in " << counter << " steps");
+  // Four steps with the goal-aware horizon; fifteen when creeping at the
+  // minimum speed the whole way
+  BOOST_TEST(counter <= 6);
+}
+
+// The rollout horizon follows the distance left to the goal: the base
+// horizon far away, the time to reach the goal at full speed (rounded to
+// steps, never below two steps) close to it.
+BOOST_AUTO_TEST_CASE(test_DWA_horizon_caps_at_the_goal) {
+  // Reads the sampler's rollout length and the tracked remaining distance,
+  // which the planner keeps protected
+  struct Probe : Control::DWA {
+    using Control::DWA::DWA;
+    size_t rolloutPoints() const { return trajSampler->numPointsPerTrajectory; }
+    double remainingDistance() const {
+      return currentPath->totalPathLength() -
+             currentPath->getDistanceAtIndex(closestPosition->index);
+    }
+  };
+
+  std::vector<Path::Point> points{Path::Point(0.0, 0.0, 0.0),
+                                  Path::Point(5.0, 0.0, 0.0),
+                                  Path::Point(10.0, 0.0, 0.0)};
+  Path::Path path(points);
+
+  const double timeStep = 0.5;
+  const double predictionHorizon = 5.0;
+  Control::CostEvaluator::TrajectoryCostsWeights costWeights;
+  costWeights.setParameter("reference_path_distance_weight", 1.0);
+  costWeights.setParameter("goal_distance_weight", 1.0);
+  costWeights.setParameter("obstacles_distance_weight", 0.0);
+  costWeights.setParameter("smoothness_weight", 0.0);
+  costWeights.setParameter("jerk_weight", 0.0);
+  Control::LinearVelocityControlParams x_params(0.8, 5.0, 10.0, 0.05);
+  Control::LinearVelocityControlParams y_params(0.0, 0.0, 0.0, 0.0);
+  Control::AngularVelocityControlParams angular_params(M_PI, 1.5, 3.0, 3.0);
+  Control::ControlLimitsParams controlLimits(x_params, y_params,
+                                             angular_params);
+  Probe planner(controlLimits, Control::ControlType::DIFFERENTIAL_DRIVE,
+                timeStep, predictionHorizon, 2.5, 9, 10,
+                Kompass::CollisionChecker::ShapeType::CYLINDER,
+                std::vector<float>{0.2, 0.4}, Eigen::Vector3f{0.0, 0.0, 0.0},
+                Eigen::Vector4f{0, 0, 0, 1}, 0.1, costWeights, 1);
+  planner.setCurrentPath(path);
+
+  Eigen::VectorXf ranges = Eigen::VectorXf::Constant(36, 20.0f);
+  Eigen::VectorXf angles(36);
+  for (int i = 0; i < 36; ++i) {
+    angles(i) = static_cast<float>(i) * 2.0f * M_PI / 36;
+  }
+  Control::LaserScan robotScan(ranges, angles);
+
+  // The goal tolerance of the follower defaults to 0.1 m
+  const double goal_tolerance = 0.1;
+  const double v_max = 0.8;
+  auto expected_points = [&](double remaining) {
+    const double horizon = (remaining + goal_tolerance) / v_max + timeStep;
+    return Control::getNumPointsPerTrajectory(
+        timeStep, std::clamp(horizon, 3.0 * timeStep, predictionHorizon));
+  };
+
+  // Moves the robot along the path in small steps with a planning tick at
+  // each, as the follower's segment tracking follows the state tick by tick
+  // and cannot jump across segments
+  double x = 0.0;
+  auto driveTo = [&](double target_x) {
+    while (x < target_x - 1e-9) {
+      x = std::min(x + 0.25, target_x);
+      planner.setCurrentState(Path::State(x, 0.0, 0.0, 0.0));
+      planner.computeVelocityCommandsSet(Control::Velocity2D(), robotScan);
+    }
+  };
+
+  // 9.5 m from the goal: the base horizon
+  driveTo(0.5);
+  BOOST_TEST(planner.rolloutPoints() ==
+             Control::getNumPointsPerTrajectory(timeStep, predictionHorizon));
+
+  // About 2 m from the goal: the remaining path plus the tolerance at
+  // 0.8 m/s, plus one step, rounded down to whole steps
+  driveTo(8.0);
+  BOOST_TEST(planner.remainingDistance() > 1.5);
+  BOOST_TEST(planner.remainingDistance() < 2.5);
+  BOOST_TEST(planner.rolloutPoints() ==
+             expected_points(planner.remainingDistance()));
+  BOOST_TEST(planner.rolloutPoints() <
+             Control::getNumPointsPerTrajectory(timeStep, predictionHorizon));
+
+  // 0.45 m from the goal: the two-step floor
+  driveTo(9.55);
+  BOOST_TEST(planner.rolloutPoints() ==
+             expected_points(planner.remainingDistance()));
+  BOOST_TEST(planner.rolloutPoints() == 3u);
 }
 
 // DWA scenario matrix: same {robot × path × avoidance} cross-product the

--- a/src/kompass_cpp/tests/dwa_test.cpp
+++ b/src/kompass_cpp/tests/dwa_test.cpp
@@ -154,6 +154,89 @@ BOOST_AUTO_TEST_CASE(test_DWA) {
              "Goal not reached in " << counter << " steps");
 }
 
+// A goal closer than the smallest grid speed covers within the horizon: 0.5 s
+// steps, a 5 s rollout and a speed grid whose smallest speed (0.2 m/s)
+// travels 0.9 m, twice the distance to the goal. Every straight grid sample
+// overshoots, so only the stop sample and the creep speed can end near the
+// goal. The controller must reach it with forward motion only: no reverse,
+// turning, or overshoot.
+BOOST_AUTO_TEST_CASE(test_DWA_creeps_onto_a_close_goal) {
+  std::vector<Path::Point> points{Path::Point(0.0, 0.0, 0.0),
+                                  Path::Point(1.5, 0.0, 0.0),
+                                  Path::Point(3.0, 0.0, 0.0)};
+  Path::Path path(points);
+
+  const double timeStep = 0.5;
+  const double predictionHorizon = 5.0;
+  const double controlHorizon = 2.5;
+  // 9 speeds over [-0.8, 0.8]: +/-0.2, +/-0.4, +/-0.6, +/-0.8 and a zero
+  // the sampler skips, exactly the grid seen in the bag
+  const int maxLinearSamples = 9;
+  const int maxAngularSamples = 10;
+
+  Control::CostEvaluator::TrajectoryCostsWeights costWeights;
+  costWeights.setParameter("reference_path_distance_weight", 1.0);
+  costWeights.setParameter("goal_distance_weight", 1.0);
+  costWeights.setParameter("obstacles_distance_weight", 0.0);
+  costWeights.setParameter("smoothness_weight", 0.0);
+  costWeights.setParameter("jerk_weight", 0.0);
+
+  // The creep speed is the minimum speed of the x-axis limits
+  Control::LinearVelocityControlParams x_params(0.8, 5.0, 10.0, 0.05);
+  Control::LinearVelocityControlParams y_params(0.0, 0.0, 0.0, 0.0);
+  Control::AngularVelocityControlParams angular_params(M_PI, 1.5, 3.0, 3.0);
+  Control::ControlLimitsParams controlLimits(x_params, y_params,
+                                             angular_params);
+  std::vector<float> robotDimensions{0.2, 0.4};
+  const Eigen::Vector3f sensor_position_body{0.0, 0.0, 0.0};
+  const Eigen::Vector4f sensor_rotation_body{0, 0, 0, 1};
+
+  Control::DWA planner(controlLimits, Control::ControlType::DIFFERENTIAL_DRIVE,
+                       timeStep, predictionHorizon, controlHorizon,
+                       maxLinearSamples, maxAngularSamples,
+                       Kompass::CollisionChecker::ShapeType::CYLINDER,
+                       robotDimensions, sensor_position_body,
+                       sensor_rotation_body, 0.1, costWeights, 1);
+  planner.setCurrentPath(path);
+
+  // Nothing within 20 m in any direction
+  Eigen::VectorXf ranges = Eigen::VectorXf::Constant(36, 20.0f);
+  Eigen::VectorXf angles(36);
+  for (int i = 0; i < 36; ++i) {
+    angles(i) = static_cast<float>(i) * 2.0f * M_PI / 36;
+  }
+  Control::LaserScan robotScan(ranges, angles);
+
+  // 0.45 m short of the goal, facing it, at rest
+  Path::State robotState(2.55, 0.0, 0.0, 0.0);
+  Control::Velocity2D robotControl;
+  const double start_distance = 0.45;
+
+  int counter = 0;
+  while (!planner.isGoalReached() and counter < 60) {
+    counter++;
+    planner.setCurrentState(robotState);
+    Control::TrajSearchResult result =
+        planner.computeVelocityCommandsSet(robotControl, robotScan);
+    BOOST_REQUIRE_MESSAGE(result.isTrajFound,
+                          "No command found at step " << counter);
+
+    const double vx = planner.getLinearVelocityCmdX();
+    const double omega = planner.getAngularVelocityCmd();
+    BOOST_TEST_CONTEXT("step " << counter << ", x " << robotState.x) {
+      BOOST_TEST(vx >= 0.0);
+      BOOST_TEST(std::abs(omega) < 0.3);
+    }
+    // The chosen command becomes the measured velocity of the next step
+    robotControl = Control::Velocity2D(vx, 0.0, omega);
+    applyControl(robotState, robotControl, timeStep);
+    const double distance = std::hypot(3.0 - robotState.x, robotState.y);
+    BOOST_TEST(distance <= start_distance + 0.05);
+  }
+  BOOST_TEST(planner.isGoalReached(),
+             "Goal not reached in " << counter << " steps");
+}
+
 // DWA scenario matrix: same {robot × path × avoidance} cross-product the
 // PurePursuit test uses, with the same obstacle locations. Verifies DWA can
 // drive each robot type along each reference path, with and without a

--- a/src/kompass_cpp/tests/dwa_test.cpp
+++ b/src/kompass_cpp/tests/dwa_test.cpp
@@ -11,7 +11,6 @@
 #include <boost/dll/runtime_symbol_info.hpp> // for program_location
 #include <boost/filesystem.hpp>
 #include <boost/test/included/unit_test.hpp>
-#include <algorithm>
 #include <cmath>
 #include <functional>
 #include <limits>
@@ -159,10 +158,8 @@ BOOST_AUTO_TEST_CASE(test_DWA) {
 // steps, a 5 s rollout and a speed grid whose smallest speed (0.2 m/s)
 // travels 0.9 m, twice the distance to the goal. Every straight grid sample
 // overshoots, so only the stop sample and the creep speed can end near the
-// goal, and with the horizon capped at the goal the grid speeds can end on
-// it too. The controller must reach it with forward motion only: no
-// reverse, turning, or overshoot, and within a few steps rather than by
-// creeping the whole way.
+// goal. The controller must reach it with forward motion only: no reverse,
+// turning, or overshoot.
 BOOST_AUTO_TEST_CASE(test_DWA_creeps_onto_a_close_goal) {
   std::vector<Path::Point> points{Path::Point(0.0, 0.0, 0.0),
                                   Path::Point(1.5, 0.0, 0.0),
@@ -238,99 +235,6 @@ BOOST_AUTO_TEST_CASE(test_DWA_creeps_onto_a_close_goal) {
   }
   BOOST_TEST(planner.isGoalReached(),
              "Goal not reached in " << counter << " steps");
-  // Four steps with the goal-aware horizon; fifteen when creeping at the
-  // minimum speed the whole way
-  BOOST_TEST(counter <= 6);
-}
-
-// The rollout horizon follows the distance left to the goal: the base
-// horizon far away, the time to reach the goal at full speed (rounded to
-// steps, never below two steps) close to it.
-BOOST_AUTO_TEST_CASE(test_DWA_horizon_caps_at_the_goal) {
-  // Reads the sampler's rollout length and the tracked remaining distance,
-  // which the planner keeps protected
-  struct Probe : Control::DWA {
-    using Control::DWA::DWA;
-    size_t rolloutPoints() const { return trajSampler->numPointsPerTrajectory; }
-    double remainingDistance() const {
-      return currentPath->totalPathLength() -
-             currentPath->getDistanceAtIndex(closestPosition->index);
-    }
-  };
-
-  std::vector<Path::Point> points{Path::Point(0.0, 0.0, 0.0),
-                                  Path::Point(5.0, 0.0, 0.0),
-                                  Path::Point(10.0, 0.0, 0.0)};
-  Path::Path path(points);
-
-  const double timeStep = 0.5;
-  const double predictionHorizon = 5.0;
-  Control::CostEvaluator::TrajectoryCostsWeights costWeights;
-  costWeights.setParameter("reference_path_distance_weight", 1.0);
-  costWeights.setParameter("goal_distance_weight", 1.0);
-  costWeights.setParameter("obstacles_distance_weight", 0.0);
-  costWeights.setParameter("smoothness_weight", 0.0);
-  costWeights.setParameter("jerk_weight", 0.0);
-  Control::LinearVelocityControlParams x_params(0.8, 5.0, 10.0, 0.05);
-  Control::LinearVelocityControlParams y_params(0.0, 0.0, 0.0, 0.0);
-  Control::AngularVelocityControlParams angular_params(M_PI, 1.5, 3.0, 3.0);
-  Control::ControlLimitsParams controlLimits(x_params, y_params,
-                                             angular_params);
-  Probe planner(controlLimits, Control::ControlType::DIFFERENTIAL_DRIVE,
-                timeStep, predictionHorizon, 2.5, 9, 10,
-                Kompass::CollisionChecker::ShapeType::CYLINDER,
-                std::vector<float>{0.2, 0.4}, Eigen::Vector3f{0.0, 0.0, 0.0},
-                Eigen::Vector4f{0, 0, 0, 1}, 0.1, costWeights, 1);
-  planner.setCurrentPath(path);
-
-  Eigen::VectorXf ranges = Eigen::VectorXf::Constant(36, 20.0f);
-  Eigen::VectorXf angles(36);
-  for (int i = 0; i < 36; ++i) {
-    angles(i) = static_cast<float>(i) * 2.0f * M_PI / 36;
-  }
-  Control::LaserScan robotScan(ranges, angles);
-
-  // The goal tolerance of the follower defaults to 0.1 m
-  const double goal_tolerance = 0.1;
-  const double v_max = 0.8;
-  auto expected_points = [&](double remaining) {
-    const double horizon = (remaining + goal_tolerance) / v_max + timeStep;
-    return Control::getNumPointsPerTrajectory(
-        timeStep, std::clamp(horizon, 3.0 * timeStep, predictionHorizon));
-  };
-
-  // Moves the robot along the path in small steps with a planning tick at
-  // each, as the follower's segment tracking follows the state tick by tick
-  // and cannot jump across segments
-  double x = 0.0;
-  auto driveTo = [&](double target_x) {
-    while (x < target_x - 1e-9) {
-      x = std::min(x + 0.25, target_x);
-      planner.setCurrentState(Path::State(x, 0.0, 0.0, 0.0));
-      planner.computeVelocityCommandsSet(Control::Velocity2D(), robotScan);
-    }
-  };
-
-  // 9.5 m from the goal: the base horizon
-  driveTo(0.5);
-  BOOST_TEST(planner.rolloutPoints() ==
-             Control::getNumPointsPerTrajectory(timeStep, predictionHorizon));
-
-  // About 2 m from the goal: the remaining path plus the tolerance at
-  // 0.8 m/s, plus one step, rounded down to whole steps
-  driveTo(8.0);
-  BOOST_TEST(planner.remainingDistance() > 1.5);
-  BOOST_TEST(planner.remainingDistance() < 2.5);
-  BOOST_TEST(planner.rolloutPoints() ==
-             expected_points(planner.remainingDistance()));
-  BOOST_TEST(planner.rolloutPoints() <
-             Control::getNumPointsPerTrajectory(timeStep, predictionHorizon));
-
-  // 0.45 m from the goal: the two-step floor
-  driveTo(9.55);
-  BOOST_TEST(planner.rolloutPoints() ==
-             expected_points(planner.remainingDistance()));
-  BOOST_TEST(planner.rolloutPoints() == 3u);
 }
 
 // DWA scenario matrix: same {robot × path × avoidance} cross-product the

--- a/src/kompass_cpp/tests/mapper_test_gpu.cpp
+++ b/src/kompass_cpp/tests/mapper_test_gpu.cpp
@@ -18,9 +18,11 @@
 #define BOOST_TEST_MODULE KOMPASS MAPPER TESTS
 #include <Eigen/Dense>
 #include <boost/test/included/unit_test.hpp>
+#include <atomic>
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
+#include <thread>
 #include <vector>
 
 using namespace Kompass;
@@ -692,4 +694,96 @@ BOOST_AUTO_TEST_CASE(test_multi_sensor_error_paths_gpu) {
   auto &scan_cfg = get_config();
   BOOST_CHECK_THROW(scan_cfg.gpu_local_mapper.scanToGrid({makeCloudView(ring)}),
                     std::logic_error);
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency Tests. The mapper mutates per-sensor device buffers, the device grid
+// and the host grid it returns by reference, all through one in-order queue.
+// A reentrant callback group can run the scan callback concurrently, and a scan
+// of a different length reallocates the cached angle vector; a second caller in
+// pointcloud mode would hit the grow-and-reallocate path of the device buffers.
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(test_mapper_pointcloud_concurrent_varying_frames_gpu) {
+  const std::vector<SensorConfig> sensors = {
+      SensorConfig::fromYaw({0.3f, 0.0f, 0.2f}, 0.0f),
+      SensorConfig::fromYaw({-0.3f, 0.0f, 0.2f}, static_cast<float>(M_PI))};
+  Mapping::LocalMapperGPU mapper(20, 20, 0.1f, sensors, /*isPointCloud*/ true,
+                                 /*scanSize*/ 360, /*maxHeight*/ 0.5f,
+                                 /*minHeight*/ 0.0f, /*rangeMax*/ 5.0f, kMppl);
+  // Frames of different sizes so the device buffers keep growing; all points
+  // sit in the height band around the sensors, at varying ranges
+  std::vector<std::vector<uint8_t>> frames;
+  for (int n : {20000, 26000, 21000, 30000, 23000, 28000}) {
+    std::vector<uint8_t> cloud;
+    for (int i = 0; i < n; ++i) {
+      const float theta = 2.0f * static_cast<float>(M_PI) * i / n;
+      const float r = 0.4f + 0.02f * (i % 7);
+      addPointToCloud(cloud, r * std::cos(theta), r * std::sin(theta), -0.1f);
+    }
+    frames.push_back(std::move(cloud));
+  }
+  constexpr int kThreads = 4;
+  constexpr int kIterations = 60;
+  std::atomic<int> failures{0};
+  std::vector<std::thread> workers;
+  for (int t = 0; t < kThreads; ++t) {
+    workers.emplace_back([&, t] {
+      for (int k = 0; k < kIterations; ++k) {
+        const auto &a = frames[(t + k) % frames.size()];
+        const auto &b = frames[(t * 5 + k * 3) % frames.size()];
+        try {
+          mapper.scanToGrid({makeCloudView(a), makeCloudView(b)});
+        } catch (const std::exception &) {
+          ++failures;
+        }
+      }
+    });
+  }
+  for (auto &w : workers) {
+    w.join();
+  }
+  BOOST_TEST(failures == 0, "scanToGrid threw " << failures << " times");
+  // A quiet call afterwards still maps the ring of points around the robot
+  const auto &grid = mapper.scanToGrid({makeCloudView(frames[0]), makeCloudView(frames[1])});
+  BOOST_TEST(countOccupiedInRows(grid, 0, 19) > 0, "no OCCUPIED cell after the storm");
+}
+
+BOOST_AUTO_TEST_CASE(test_mapper_laserscan_concurrent_varying_lengths_gpu) {
+  constexpr int kScanSize = 63;
+  Mapping::LocalMapperGPU mapper(10, 10, 0.1f, {SensorConfig{}},
+                                 /*isPointCloud*/ false, kScanSize,
+                                 /*maxHeight*/ 0.0f, /*minHeight*/ 0.0f,
+                                 /*rangeMax*/ 20.0f, kMppl);
+  // Scans of different lengths (all at least scan_size, so none is skipped)
+  // make the cached angle vector reallocate on every length change
+  std::vector<std::pair<Eigen::VectorXf, Eigen::VectorXf>> scans;
+  for (int n : {63, 70, 65, 80, 63, 75}) {
+    Eigen::VectorXf angles = Eigen::VectorXf::LinSpaced(
+        n, -static_cast<float>(M_PI), static_cast<float>(M_PI));
+    Eigen::VectorXf ranges = Eigen::VectorXf::Constant(n, 0.3f);
+    scans.emplace_back(angles, ranges);
+  }
+  constexpr int kThreads = 4;
+  constexpr int kIterations = 150;
+  std::atomic<int> failures{0};
+  std::vector<std::thread> workers;
+  for (int t = 0; t < kThreads; ++t) {
+    workers.emplace_back([&, t] {
+      for (int k = 0; k < kIterations; ++k) {
+        const auto &scan = scans[(t + k) % scans.size()];
+        try {
+          mapper.scanToGrid(scan.first, scan.second);
+        } catch (const std::exception &) {
+          ++failures;
+        }
+      }
+    });
+  }
+  for (auto &w : workers) {
+    w.join();
+  }
+  BOOST_TEST(failures == 0, "scanToGrid threw " << failures << " times");
+  const auto &grid = mapper.scanToGrid(scans[0].first, scans[0].second);
+  BOOST_TEST(countOccupiedInRows(grid, 0, 9) > 0, "no OCCUPIED cell after the storm");
 }

--- a/src/kompass_cpp/tests/trajectory_sampler_test.cpp
+++ b/src/kompass_cpp/tests/trajectory_sampler_test.cpp
@@ -172,7 +172,7 @@ size_t countVx(const Control::TrajectorySamples2D &samples, double vx) {
   return count;
 }
 
-// Number of samples that command no motion at all (the stop sample)
+// Number of samples that command no motion at all (never expected)
 size_t countStops(const Control::TrajectorySamples2D &samples) {
   size_t count = 0;
   for (size_t i = 0; i < samples.size(); ++i) {
@@ -211,9 +211,9 @@ double smallestSpeed(const Control::TrajectorySamples2D &samples) {
 
 // At rest the reachable window is [-1, 1]: the grid of 5 speeds already
 // holds 0 and +/-1, the creep speeds +/-0.05 are added with the full angular
-// fan of a grid speed, and exactly one stop sample exists. Holds for every
+// fan of a grid speed, and zero velocity is never sampled. Holds for every
 // robot type, pooled and serial.
-BOOST_AUTO_TEST_CASE(grid_holds_stop_and_creep_speeds_for_every_robot_type) {
+BOOST_AUTO_TEST_CASE(grid_holds_creep_speeds_for_every_robot_type) {
   const std::vector<Control::ControlType> types{
       Control::ControlType::ACKERMANN, Control::ControlType::DIFFERENTIAL_DRIVE,
       Control::ControlType::OMNI};
@@ -227,7 +227,7 @@ BOOST_AUTO_TEST_CASE(grid_holds_stop_and_creep_speeds_for_every_robot_type) {
       BOOST_TEST_CONTEXT("type " << Control::controlTypeToString(type)
                                  << ", threads " << threads) {
         BOOST_TEST(samples->size() <= sampler->numTrajectories);
-        BOOST_TEST(countStops(*samples) == 1);
+        BOOST_TEST(countStops(*samples) == 0);
         BOOST_TEST(countPureSpins(*samples) == 0);
         BOOST_TEST(countVx(*samples, 0.05) >= 1);
         BOOST_TEST(countVx(*samples, -0.05) == countVx(*samples, 0.05));
@@ -251,16 +251,17 @@ BOOST_AUTO_TEST_CASE(creep_speeds_are_added_only_inside_the_window) {
       Control::Velocity2D(0.12, 0.0, 0.0), Path::State(0.0, 0.0, 0.0, 0.0),
       clearScan());
 
-  BOOST_TEST(countStops(*samples) == 1);
+  BOOST_TEST(countStops(*samples) == 0);
   BOOST_TEST(countVx(*samples, 0.05) >= 1);
   BOOST_TEST(countVx(*samples, -0.05) == 0);
   BOOST_TEST(countVx(*samples, 0.07) == countVx(*samples, 0.05));
-  BOOST_TEST(smallestSpeed(*samples) == 0.0);
+  // The creep speed is the slowest moving sample
+  BOOST_TEST(std::abs(smallestSpeed(*samples) - 0.05) < 1e-6);
 }
 
-// A robot that cannot brake to zero within one step gets neither the stop
-// sample nor the creep speeds: every sample stays inside the window
-BOOST_AUTO_TEST_CASE(no_stop_or_creep_when_zero_is_not_reachable) {
+// A robot that cannot brake to zero within one step gets no creep speeds:
+// every sample stays inside the window
+BOOST_AUTO_TEST_CASE(no_creep_when_zero_is_not_reachable) {
   const Control::LinearVelocityControlParams x_params(1.0, 5.0, 0.2, 0.05);
   auto sampler = makeSampler(Control::ControlType::DIFFERENTIAL_DRIVE, x_params,
                              4, 4, 1);
@@ -285,8 +286,8 @@ size_t countOmega(const Control::TrajectorySamples2D &samples, double omega) {
 }
 
 // Grid values inside the robot's dead band are not sampled: with a minimum
-// speed of 0.3 m/s the grid speeds +/-0.25 are gone, +/-0.3 take their
-// place and the stop sample stays
+// speed of 0.3 m/s the grid speeds +/-0.25 are gone and +/-0.3 take their
+// place
 BOOST_AUTO_TEST_CASE(grid_speeds_inside_the_dead_band_are_not_sampled) {
   const Control::LinearVelocityControlParams x_params(1.0, 5.0, 10.0, 0.3);
   // 9 speeds over [-1, 1]: 0, +/-0.25, +/-0.5, +/-0.75, +/-1
@@ -299,7 +300,7 @@ BOOST_AUTO_TEST_CASE(grid_speeds_inside_the_dead_band_are_not_sampled) {
   BOOST_TEST(countVx(*samples, -0.25) == 0);
   BOOST_TEST(countVx(*samples, 0.3) == countVx(*samples, 0.5));
   BOOST_TEST(countVx(*samples, -0.3) == countVx(*samples, 0.5));
-  BOOST_TEST(countStops(*samples) == 1);
+  BOOST_TEST(countStops(*samples) == 0);
   for (size_t i = 0; i < samples->size(); ++i) {
     const double vx = samples->velocities.vx(i, 0);
     BOOST_TEST((vx == 0.0 || std::abs(vx) >= 0.3 - 1e-6));
@@ -350,7 +351,7 @@ BOOST_AUTO_TEST_CASE(creep_speed_on_the_grid_is_not_duplicated) {
   BOOST_TEST(countVx(*samples, 0.05) == 0);
 }
 
-// A zero minimum speed means no creep samples; the stop sample stays
+// A zero minimum speed means no creep samples
 BOOST_AUTO_TEST_CASE(zero_minimum_speed_disables_the_creep_samples) {
   const Control::LinearVelocityControlParams x_params(1.0, 5.0, 10.0, 0.0);
   auto sampler = makeSampler(Control::ControlType::DIFFERENTIAL_DRIVE, x_params,
@@ -358,7 +359,7 @@ BOOST_AUTO_TEST_CASE(zero_minimum_speed_disables_the_creep_samples) {
   auto samples = sampler->generateTrajectories(
       Control::Velocity2D(), Path::State(0.0, 0.0, 0.0, 0.0), clearScan());
 
-  BOOST_TEST(countStops(*samples) == 1);
+  BOOST_TEST(countStops(*samples) == 0);
   BOOST_TEST(countPureSpins(*samples) == 0);
   // Every moving sample is a grid speed (multiples of 0.5 m/s)
   for (size_t i = 0; i < samples->size(); ++i) {
@@ -370,37 +371,34 @@ BOOST_AUTO_TEST_CASE(zero_minimum_speed_disables_the_creep_samples) {
   }
 }
 
-// The stop sample keeps the robot where it is, so it is dropped when the
-// current pose already collides, in both sample dropping modes
-BOOST_AUTO_TEST_CASE(stop_sample_is_dropped_when_the_pose_collides) {
+// Zero velocity is never a sample, at rest or in motion, in either sample
+// dropping mode: a standing rollout would win in the middle of a route
+BOOST_AUTO_TEST_CASE(zero_velocity_is_never_sampled) {
   const Control::LinearVelocityControlParams x_params(1.0, 5.0, 10.0, 0.05);
-  // One return 5 cm ahead, inside the 20 cm body radius
-  Control::LaserScan touching(Eigen::VectorXf::Constant(1, 0.05f),
-                              Eigen::VectorXf::Constant(1, 0.0f));
   for (const bool drop : {true, false}) {
-    auto sampler = makeSampler(Control::ControlType::DIFFERENTIAL_DRIVE,
-                               x_params, 4, 4, 1);
+    auto sampler = makeSampler(Control::ControlType::OMNI, x_params, 4, 4, 1);
     sampler->setSampleDroppingMode(drop);
-    auto blocked = sampler->generateTrajectories(
-        Control::Velocity2D(), Path::State(0.0, 0.0, 0.0, 0.0), touching);
-    auto free = sampler->generateTrajectories(
+    auto at_rest = sampler->generateTrajectories(
         Control::Velocity2D(), Path::State(0.0, 0.0, 0.0, 0.0), clearScan());
+    auto moving = sampler->generateTrajectories(
+        Control::Velocity2D(0.5, 0.0, 0.0), Path::State(0.0, 0.0, 0.0, 0.0),
+        clearScan());
     BOOST_TEST_CONTEXT("drop_samples " << drop) {
-      BOOST_TEST(countStops(*blocked) == 0);
-      BOOST_TEST(countStops(*free) == 1);
+      BOOST_TEST(countStops(*at_rest) == 0);
+      BOOST_TEST(countStops(*moving) == 0);
     }
   }
 }
 
 // The sample buffers are sized for the grid plus the three extra speeds and
-// the stop sample, for every robot type
+// the two extra rates, for every robot type
 BOOST_AUTO_TEST_CASE(capacity_counts_the_extra_samples) {
-  // Differential drive, 4 and 4: (5 + 3) speeds x (5 + 2) rates + 1
+  // Differential drive, 4 and 4: (5 + 3) speeds x (5 + 2) rates
   BOOST_TEST(Control::getNumTrajectories(
-                 Control::ControlType::DIFFERENTIAL_DRIVE, 4, 4) == 57u);
-  // Omni, 20 and 20: (15 + 3) x (21 + 2) + (15 + 3) x (5 + 3) + 1
+                 Control::ControlType::DIFFERENTIAL_DRIVE, 4, 4) == 56u);
+  // Omni, 20 and 20: (15 + 3) x (21 + 2) + (15 + 3) x (5 + 3)
   BOOST_TEST(Control::getNumTrajectories(Control::ControlType::OMNI, 20, 20) ==
-             559u);
+             558u);
 
   const Control::LinearVelocityControlParams x_params(1.0, 5.0, 10.0, 0.05);
   const std::vector<Control::ControlType> types{
@@ -412,7 +410,7 @@ BOOST_AUTO_TEST_CASE(capacity_counts_the_extra_samples) {
         Control::Velocity2D(), Path::State(0.0, 0.0, 0.0, 0.0), clearScan());
     BOOST_TEST_CONTEXT("type " << Control::controlTypeToString(type)) {
       BOOST_TEST(samples->size() <= sampler->numTrajectories);
-      BOOST_TEST(countStops(*samples) == 1);
+      BOOST_TEST(countStops(*samples) == 0);
       BOOST_TEST(countVx(*samples, 0.05) >= 1);
       BOOST_TEST(countVx(*samples, -0.05) >= 1);
     }

--- a/src/kompass_cpp/tests/trajectory_sampler_test.cpp
+++ b/src/kompass_cpp/tests/trajectory_sampler_test.cpp
@@ -2,19 +2,30 @@
 #include "controllers/follower.h"
 #include "datatypes/control.h"
 #include "datatypes/path.h"
+#include "datatypes/trajectory.h"
 #include "json_export.h"
 #include "test.h"
 #include "utils/logger.h"
 #include "utils/trajectory_sampler.h"
+#define BOOST_TEST_MODULE KOMPASS TRAJECTORY SAMPLER TESTS
 #include <Eigen/Dense>
+#include <algorithm>
 #include <boost/dll/runtime_symbol_info.hpp> // for program_location
 #include <boost/filesystem.hpp>
+#include <boost/test/included/unit_test.hpp>
+#include <cmath>
+#include <limits>
+#include <memory>
 #include <string>
 #include <vector>
 
 using namespace Kompass;
 
-void testTrajSampler() {
+// Generates the sample set of every robot type from one state, saves the
+// samples and the reference path to JSON and plots them with
+// trajectory_sampler_plt.py. The pictures are for inspection; the case fails
+// when the plotting script fails.
+BOOST_AUTO_TEST_CASE(plots_samples_for_each_robot_type) {
 
   Logger::getInstance().setLogLevel(LogLevel::DEBUG);
 
@@ -115,10 +126,233 @@ void testTrajSampler() {
 
     // Execute the Python script
     int res = system(command.c_str());
-    if (res != 0)
-      throw std::system_error(res, std::generic_category(),
-                              "Python script failed with error code");
+    BOOST_TEST(res == 0, "Plotting script failed with code " << res);
   }
 }
 
-int main() { testTrajSampler(); }
+namespace {
+
+// A scan that sees nothing within 20 m in any direction
+Control::LaserScan clearScan() {
+  const int n = 36;
+  Eigen::VectorXf ranges = Eigen::VectorXf::Constant(n, 20.0f);
+  Eigen::VectorXf angles(n);
+  for (int i = 0; i < n; ++i) {
+    angles(i) = static_cast<float>(i) * 2.0f * M_PI / n;
+  }
+  return Control::LaserScan(ranges, angles);
+}
+
+// The sampler under test: 0.5 s steps like the Lite3 configuration, a
+// cylinder of 0.2 m radius, the proximity sensor at the body origin. The
+// creep speed comes from the minimum speed of the x-axis limits.
+std::unique_ptr<Control::TrajectorySampler>
+makeSampler(Control::ControlType type,
+            const Control::LinearVelocityControlParams &x_params,
+            int maxLinearSamples, int maxAngularSamples, int maxNumThreads) {
+  Control::LinearVelocityControlParams y_params(1.0, 5.0, 10.0, 0.0);
+  Control::AngularVelocityControlParams angular_params(M_PI, 3.14, 2.0, 3.0);
+  Control::ControlLimitsParams limits(x_params, y_params, angular_params);
+  return std::make_unique<Control::TrajectorySampler>(
+      limits, type, 0.5, 5.0, 2.5, maxLinearSamples, maxAngularSamples,
+      CollisionChecker::ShapeType::CYLINDER, std::vector<float>{0.2f, 0.4f},
+      Eigen::Vector3f{0.0f, 0.0f, 0.0f}, Eigen::Quaternionf{1.0f, 0.0f, 0.0f, 0.0f},
+      0.1, maxNumThreads);
+}
+
+// Number of samples whose first commanded vx equals the given value
+size_t countVx(const Control::TrajectorySamples2D &samples, double vx) {
+  size_t count = 0;
+  for (size_t i = 0; i < samples.size(); ++i) {
+    if (std::abs(samples.velocities.vx(i, 0) - vx) < 1e-6) {
+      ++count;
+    }
+  }
+  return count;
+}
+
+// Number of samples that command no motion at all (the stop sample)
+size_t countStops(const Control::TrajectorySamples2D &samples) {
+  size_t count = 0;
+  for (size_t i = 0; i < samples.size(); ++i) {
+    if (std::abs(samples.velocities.vx(i, 0)) < 1e-9 &&
+        std::abs(samples.velocities.vy(i, 0)) < 1e-9 &&
+        std::abs(samples.velocities.omega(i, 0)) < 1e-9) {
+      ++count;
+    }
+  }
+  return count;
+}
+
+// Number of samples that rotate in place (not allowed by the sampler)
+size_t countPureSpins(const Control::TrajectorySamples2D &samples) {
+  size_t count = 0;
+  for (size_t i = 0; i < samples.size(); ++i) {
+    if (std::abs(samples.velocities.vx(i, 0)) < 1e-9 &&
+        std::abs(samples.velocities.vy(i, 0)) < 1e-9 &&
+        std::abs(samples.velocities.omega(i, 0)) > 1e-9) {
+      ++count;
+    }
+  }
+  return count;
+}
+
+double smallestSpeed(const Control::TrajectorySamples2D &samples) {
+  double smallest = std::numeric_limits<double>::infinity();
+  for (size_t i = 0; i < samples.size(); ++i) {
+    smallest = std::min(smallest, std::abs(static_cast<double>(
+                                      samples.velocities.vx(i, 0))));
+  }
+  return smallest;
+}
+
+} // namespace
+
+// At rest the reachable window is [-1, 1]: the grid of 5 speeds already
+// holds 0 and +/-1, the creep speeds +/-0.05 are added with the full angular
+// fan of a grid speed, and exactly one stop sample exists. Holds for every
+// robot type, pooled and serial.
+BOOST_AUTO_TEST_CASE(grid_holds_stop_and_creep_speeds_for_every_robot_type) {
+  const std::vector<Control::ControlType> types{
+      Control::ControlType::ACKERMANN, Control::ControlType::DIFFERENTIAL_DRIVE,
+      Control::ControlType::OMNI};
+  const Control::LinearVelocityControlParams x_params(1.0, 5.0, 10.0, 0.05);
+  for (const auto type : types) {
+    for (const int threads : {1, 4}) {
+      auto sampler = makeSampler(type, x_params, 4, 4, threads);
+      auto samples = sampler->generateTrajectories(
+          Control::Velocity2D(), Path::State(0.0, 0.0, 0.0, 0.0), clearScan());
+
+      BOOST_TEST_CONTEXT("type " << Control::controlTypeToString(type)
+                                 << ", threads " << threads) {
+        BOOST_TEST(samples->size() <= sampler->numTrajectories);
+        BOOST_TEST(countStops(*samples) == 1);
+        BOOST_TEST(countPureSpins(*samples) == 0);
+        BOOST_TEST(countVx(*samples, 0.05) >= 1);
+        BOOST_TEST(countVx(*samples, -0.05) == countVx(*samples, 0.05));
+        // The creep speed carries the same fan as a speed of the grid
+        BOOST_TEST(countVx(*samples, 0.05) == countVx(*samples, 1.0));
+        BOOST_TEST(countVx(*samples, 1.0) >= 1);
+        BOOST_TEST(countVx(*samples, -1.0) >= 1);
+      }
+    }
+  }
+}
+
+// Moving at 0.12 m/s with a window of +/-0.15 m/s around it, the grid of 7
+// speeds holds neither 0 nor +/-0.05: 0 and +0.05 are inside the window and
+// get added, -0.05 is outside and is not.
+BOOST_AUTO_TEST_CASE(creep_speeds_are_added_only_inside_the_window) {
+  const Control::LinearVelocityControlParams x_params(0.8, 0.3, 0.3, 0.05);
+  auto sampler = makeSampler(Control::ControlType::DIFFERENTIAL_DRIVE, x_params,
+                             6, 4, 1);
+  auto samples = sampler->generateTrajectories(
+      Control::Velocity2D(0.12, 0.0, 0.0), Path::State(0.0, 0.0, 0.0, 0.0),
+      clearScan());
+
+  BOOST_TEST(countStops(*samples) == 1);
+  BOOST_TEST(countVx(*samples, 0.05) >= 1);
+  BOOST_TEST(countVx(*samples, -0.05) == 0);
+  BOOST_TEST(countVx(*samples, 0.07) == countVx(*samples, 0.05));
+  BOOST_TEST(smallestSpeed(*samples) == 0.0);
+}
+
+// A robot that cannot brake to zero within one step gets neither the stop
+// sample nor the creep speeds: every sample stays inside the window
+BOOST_AUTO_TEST_CASE(no_stop_or_creep_when_zero_is_not_reachable) {
+  const Control::LinearVelocityControlParams x_params(1.0, 5.0, 0.2, 0.05);
+  auto sampler = makeSampler(Control::ControlType::DIFFERENTIAL_DRIVE, x_params,
+                             4, 4, 1);
+  auto samples = sampler->generateTrajectories(
+      Control::Velocity2D(1.0, 0.0, 0.0), Path::State(0.0, 0.0, 0.0, 0.0),
+      clearScan());
+
+  BOOST_TEST(samples->size() > 0);
+  BOOST_TEST(countStops(*samples) == 0);
+  BOOST_TEST(smallestSpeed(*samples) >= 0.9 - 1e-6);
+}
+
+// A creep speed that happens to be on the grid is not sampled twice
+BOOST_AUTO_TEST_CASE(creep_speed_on_the_grid_is_not_duplicated) {
+  const Control::LinearVelocityControlParams on_grid(1.0, 5.0, 10.0, 0.5);
+  const Control::LinearVelocityControlParams x_params(1.0, 5.0, 10.0, 0.05);
+  auto with_creep = makeSampler(Control::ControlType::DIFFERENTIAL_DRIVE,
+                                on_grid, 4, 4, 1);
+  auto other = makeSampler(Control::ControlType::DIFFERENTIAL_DRIVE, x_params,
+                           4, 4, 1);
+  auto samples = with_creep->generateTrajectories(
+      Control::Velocity2D(), Path::State(0.0, 0.0, 0.0, 0.0), clearScan());
+  auto reference = other->generateTrajectories(
+      Control::Velocity2D(), Path::State(0.0, 0.0, 0.0, 0.0), clearScan());
+
+  BOOST_TEST(countVx(*samples, 0.5) == countVx(*reference, 0.5));
+  BOOST_TEST(countVx(*samples, -0.5) == countVx(*reference, -0.5));
+  BOOST_TEST(countVx(*samples, 0.05) == 0);
+}
+
+// A zero minimum speed means no creep samples; the stop sample stays
+BOOST_AUTO_TEST_CASE(zero_minimum_speed_disables_the_creep_samples) {
+  const Control::LinearVelocityControlParams x_params(1.0, 5.0, 10.0, 0.0);
+  auto sampler = makeSampler(Control::ControlType::DIFFERENTIAL_DRIVE, x_params,
+                             4, 4, 1);
+  auto samples = sampler->generateTrajectories(
+      Control::Velocity2D(), Path::State(0.0, 0.0, 0.0, 0.0), clearScan());
+
+  BOOST_TEST(countStops(*samples) == 1);
+  BOOST_TEST(countPureSpins(*samples) == 0);
+  // Every moving sample is a grid speed (multiples of 0.5 m/s)
+  for (size_t i = 0; i < samples->size(); ++i) {
+    const double vx = samples->velocities.vx(i, 0);
+    BOOST_TEST_CONTEXT("sample " << i << ", vx " << vx) {
+      BOOST_TEST((vx == 0.0 || std::abs(std::abs(vx) - 0.5) < 1e-6 ||
+                  std::abs(std::abs(vx) - 1.0) < 1e-6));
+    }
+  }
+}
+
+// The stop sample keeps the robot where it is, so it is dropped when the
+// current pose already collides, in both sample dropping modes
+BOOST_AUTO_TEST_CASE(stop_sample_is_dropped_when_the_pose_collides) {
+  const Control::LinearVelocityControlParams x_params(1.0, 5.0, 10.0, 0.05);
+  // One return 5 cm ahead, inside the 20 cm body radius
+  Control::LaserScan touching(Eigen::VectorXf::Constant(1, 0.05f),
+                              Eigen::VectorXf::Constant(1, 0.0f));
+  for (const bool drop : {true, false}) {
+    auto sampler = makeSampler(Control::ControlType::DIFFERENTIAL_DRIVE,
+                               x_params, 4, 4, 1);
+    sampler->setSampleDroppingMode(drop);
+    auto blocked = sampler->generateTrajectories(
+        Control::Velocity2D(), Path::State(0.0, 0.0, 0.0, 0.0), touching);
+    auto free = sampler->generateTrajectories(
+        Control::Velocity2D(), Path::State(0.0, 0.0, 0.0, 0.0), clearScan());
+    BOOST_TEST_CONTEXT("drop_samples " << drop) {
+      BOOST_TEST(countStops(*blocked) == 0);
+      BOOST_TEST(countStops(*free) == 1);
+    }
+  }
+}
+
+// The sample buffers are sized for the grid plus the three extra speeds and
+// the stop sample, for every robot type
+BOOST_AUTO_TEST_CASE(capacity_counts_the_extra_samples) {
+  BOOST_TEST(Control::getNumTrajectories(
+                 Control::ControlType::DIFFERENTIAL_DRIVE, 4, 4) == 41u);
+  BOOST_TEST(Control::getNumTrajectories(Control::ControlType::OMNI, 20, 20) ==
+             469u);
+
+  const Control::LinearVelocityControlParams x_params(1.0, 5.0, 10.0, 0.05);
+  const std::vector<Control::ControlType> types{
+      Control::ControlType::ACKERMANN, Control::ControlType::DIFFERENTIAL_DRIVE,
+      Control::ControlType::OMNI};
+  for (const auto type : types) {
+    auto sampler = makeSampler(type, x_params, 20, 20, 4);
+    auto samples = sampler->generateTrajectories(
+        Control::Velocity2D(), Path::State(0.0, 0.0, 0.0, 0.0), clearScan());
+    BOOST_TEST_CONTEXT("type " << Control::controlTypeToString(type)) {
+      BOOST_TEST(samples->size() <= sampler->numTrajectories);
+      BOOST_TEST(countStops(*samples) == 1);
+      BOOST_TEST(countVx(*samples, 0.05) >= 1);
+      BOOST_TEST(countVx(*samples, -0.05) >= 1);
+    }
+  }
+}

--- a/src/kompass_cpp/tests/trajectory_sampler_test.cpp
+++ b/src/kompass_cpp/tests/trajectory_sampler_test.cpp
@@ -94,7 +94,7 @@ BOOST_AUTO_TEST_CASE(plots_samples_for_each_robot_type) {
         controlLimits, robot_types[j], timeStep, predictionHorizon,
         controlHorizon, maxLinearSamples, maxAngularSamples, robotShapeType,
         robotDimensions, sensor_position_body, sensor_rotation_body, octreeRes,
-        numThreads);
+        true, numThreads);
 
     // Robot initial velocity control
     Control::Velocity2D robotControl;
@@ -151,14 +151,15 @@ makeSampler(Control::ControlType type,
             const Control::LinearVelocityControlParams &x_params,
             int maxLinearSamples, int maxAngularSamples, int maxNumThreads,
             const Control::AngularVelocityControlParams &angular_params =
-                Control::AngularVelocityControlParams(M_PI, 3.14, 2.0, 3.0)) {
+                Control::AngularVelocityControlParams(M_PI, 3.14, 2.0, 3.0),
+            bool allowReverse = true) {
   Control::LinearVelocityControlParams y_params(1.0, 5.0, 10.0, 0.0);
   Control::ControlLimitsParams limits(x_params, y_params, angular_params);
   return std::make_unique<Control::TrajectorySampler>(
       limits, type, 0.5, 5.0, 2.5, maxLinearSamples, maxAngularSamples,
       CollisionChecker::ShapeType::CYLINDER, std::vector<float>{0.2f, 0.4f},
       Eigen::Vector3f{0.0f, 0.0f, 0.0f}, Eigen::Quaternionf{1.0f, 0.0f, 0.0f, 0.0f},
-      0.1, maxNumThreads);
+      0.1, allowReverse, maxNumThreads);
 }
 
 // Number of samples whose first commanded vx equals the given value
@@ -331,6 +332,35 @@ BOOST_AUTO_TEST_CASE(angular_rates_inside_the_dead_band_are_not_sampled) {
     const double omega = samples->velocities.omega(i, 0);
     BOOST_TEST((omega == 0.0 || std::abs(omega) >= 0.4 - 1e-6));
   }
+}
+
+// With reversing disallowed the window is clipped at zero: no negative speed
+// is sampled, at rest or while being pushed backwards, while the forward
+// creep speed stays. The window still opens fully when reversing is allowed.
+BOOST_AUTO_TEST_CASE(no_reverse_samples_when_reversing_is_disallowed) {
+  const Control::LinearVelocityControlParams x_params(1.0, 5.0, 10.0, 0.05);
+  auto sampler = makeSampler(
+      Control::ControlType::DIFFERENTIAL_DRIVE, x_params, 4, 4, 1,
+      Control::AngularVelocityControlParams(M_PI, 3.14, 2.0, 3.0), false);
+  for (const double current_vx : {0.0, -0.3}) {
+    auto samples = sampler->generateTrajectories(
+        Control::Velocity2D(current_vx, 0.0, 0.0),
+        Path::State(0.0, 0.0, 0.0, 0.0), clearScan());
+    BOOST_TEST_CONTEXT("current vx " << current_vx) {
+      BOOST_TEST(samples->size() > 0);
+      for (size_t i = 0; i < samples->size(); ++i) {
+        BOOST_TEST(samples->velocities.vx(i, 0) >= 0.0);
+      }
+      BOOST_TEST(countVx(*samples, 0.05) >= 1);
+      BOOST_TEST(countVx(*samples, -0.05) == 0);
+    }
+  }
+  auto free = makeSampler(Control::ControlType::DIFFERENTIAL_DRIVE, x_params,
+                          4, 4, 1);
+  auto samples = free->generateTrajectories(
+      Control::Velocity2D(), Path::State(0.0, 0.0, 0.0, 0.0), clearScan());
+  BOOST_TEST(countVx(*samples, -0.05) >= 1);
+  BOOST_TEST(countVx(*samples, -1.0) >= 1);
 }
 
 // A creep speed that happens to be on the grid is not sampled twice

--- a/src/kompass_cpp/tests/trajectory_sampler_test.cpp
+++ b/src/kompass_cpp/tests/trajectory_sampler_test.cpp
@@ -149,9 +149,10 @@ Control::LaserScan clearScan() {
 std::unique_ptr<Control::TrajectorySampler>
 makeSampler(Control::ControlType type,
             const Control::LinearVelocityControlParams &x_params,
-            int maxLinearSamples, int maxAngularSamples, int maxNumThreads) {
+            int maxLinearSamples, int maxAngularSamples, int maxNumThreads,
+            const Control::AngularVelocityControlParams &angular_params =
+                Control::AngularVelocityControlParams(M_PI, 3.14, 2.0, 3.0)) {
   Control::LinearVelocityControlParams y_params(1.0, 5.0, 10.0, 0.0);
-  Control::AngularVelocityControlParams angular_params(M_PI, 3.14, 2.0, 3.0);
   Control::ControlLimitsParams limits(x_params, y_params, angular_params);
   return std::make_unique<Control::TrajectorySampler>(
       limits, type, 0.5, 5.0, 2.5, maxLinearSamples, maxAngularSamples,
@@ -272,6 +273,65 @@ BOOST_AUTO_TEST_CASE(no_stop_or_creep_when_zero_is_not_reachable) {
   BOOST_TEST(smallestSpeed(*samples) >= 0.9 - 1e-6);
 }
 
+// Number of samples whose first commanded omega equals the given value
+size_t countOmega(const Control::TrajectorySamples2D &samples, double omega) {
+  size_t count = 0;
+  for (size_t i = 0; i < samples.size(); ++i) {
+    if (std::abs(samples.velocities.omega(i, 0) - omega) < 1e-6) {
+      ++count;
+    }
+  }
+  return count;
+}
+
+// Grid values inside the robot's dead band are not sampled: with a minimum
+// speed of 0.3 m/s the grid speeds +/-0.25 are gone, +/-0.3 take their
+// place and the stop sample stays
+BOOST_AUTO_TEST_CASE(grid_speeds_inside_the_dead_band_are_not_sampled) {
+  const Control::LinearVelocityControlParams x_params(1.0, 5.0, 10.0, 0.3);
+  // 9 speeds over [-1, 1]: 0, +/-0.25, +/-0.5, +/-0.75, +/-1
+  auto sampler = makeSampler(Control::ControlType::DIFFERENTIAL_DRIVE, x_params,
+                             8, 4, 1);
+  auto samples = sampler->generateTrajectories(
+      Control::Velocity2D(), Path::State(0.0, 0.0, 0.0, 0.0), clearScan());
+
+  BOOST_TEST(countVx(*samples, 0.25) == 0);
+  BOOST_TEST(countVx(*samples, -0.25) == 0);
+  BOOST_TEST(countVx(*samples, 0.3) == countVx(*samples, 0.5));
+  BOOST_TEST(countVx(*samples, -0.3) == countVx(*samples, 0.5));
+  BOOST_TEST(countStops(*samples) == 1);
+  for (size_t i = 0; i < samples->size(); ++i) {
+    const double vx = samples->velocities.vx(i, 0);
+    BOOST_TEST((vx == 0.0 || std::abs(vx) >= 0.3 - 1e-6));
+  }
+}
+
+// The same for the angular axis: with a minimum rate of 0.4 rad/s the grid
+// rates +/-0.3 are gone, +/-0.4 take their place, and straight driving
+// (omega = 0) stays
+BOOST_AUTO_TEST_CASE(angular_rates_inside_the_dead_band_are_not_sampled) {
+  const Control::LinearVelocityControlParams x_params(1.0, 5.0, 10.0, 0.05);
+  // Window [-1.5, 1.5] in 11 slots: 0, +/-0.3, +/-0.6, ..., +/-1.5
+  const Control::AngularVelocityControlParams angular_params(M_PI, 1.5, 3.0,
+                                                             3.0, 0.4);
+  auto sampler = makeSampler(Control::ControlType::DIFFERENTIAL_DRIVE, x_params,
+                             4, 10, 1, angular_params);
+  auto samples = sampler->generateTrajectories(
+      Control::Velocity2D(), Path::State(0.0, 0.0, 0.0, 0.0), clearScan());
+
+  BOOST_TEST(countOmega(*samples, 0.3) == 0);
+  BOOST_TEST(countOmega(*samples, -0.3) == 0);
+  BOOST_TEST(countOmega(*samples, 0.4) >= 1);
+  BOOST_TEST(countOmega(*samples, 0.4) == countOmega(*samples, 0.6));
+  BOOST_TEST(countOmega(*samples, -0.4) == countOmega(*samples, 0.6));
+  BOOST_TEST(countOmega(*samples, 0.0) >= 1);
+  BOOST_TEST(countPureSpins(*samples) == 0);
+  for (size_t i = 0; i < samples->size(); ++i) {
+    const double omega = samples->velocities.omega(i, 0);
+    BOOST_TEST((omega == 0.0 || std::abs(omega) >= 0.4 - 1e-6));
+  }
+}
+
 // A creep speed that happens to be on the grid is not sampled twice
 BOOST_AUTO_TEST_CASE(creep_speed_on_the_grid_is_not_duplicated) {
   const Control::LinearVelocityControlParams on_grid(1.0, 5.0, 10.0, 0.5);
@@ -335,10 +395,12 @@ BOOST_AUTO_TEST_CASE(stop_sample_is_dropped_when_the_pose_collides) {
 // The sample buffers are sized for the grid plus the three extra speeds and
 // the stop sample, for every robot type
 BOOST_AUTO_TEST_CASE(capacity_counts_the_extra_samples) {
+  // Differential drive, 4 and 4: (5 + 3) speeds x (5 + 2) rates + 1
   BOOST_TEST(Control::getNumTrajectories(
-                 Control::ControlType::DIFFERENTIAL_DRIVE, 4, 4) == 41u);
+                 Control::ControlType::DIFFERENTIAL_DRIVE, 4, 4) == 57u);
+  // Omni, 20 and 20: (15 + 3) x (21 + 2) + (15 + 3) x (5 + 3) + 1
   BOOST_TEST(Control::getNumTrajectories(Control::ControlType::OMNI, 20, 20) ==
-             469u);
+             559u);
 
   const Control::LinearVelocityControlParams x_params(1.0, 5.0, 10.0, 0.05);
   const std::vector<Control::ControlType> types{

--- a/src/kompass_cpp/tests/vision_follower_fixture_test.cpp
+++ b/src/kompass_cpp/tests/vision_follower_fixture_test.cpp
@@ -1,13 +1,14 @@
 // Parametrized fixture-based test for RGBDFollower.
 //
-// Loads each fixture under tests/resources/vision_follower/<case>/ which contains:
+// Loads each fixture under tests/resources/vision_follower/<case>/ which
+// contains:
 //   - depth.png: 16-bit single-channel depth image (millimeters)
 //   - case.json: camera intrinsics, robot state, 2D detections, click pixel,
 //                and loose expected bounds for the resulting control command.
 //
 // Mirrors tests/test_vision_follower.py so both layers exercise the same
-// data. To add cases, edit tests/resources/vision_follower/generate_fixtures.py and
-// re-run it (or drop a new fixture directory in by hand).
+// data. To add cases, edit tests/resources/vision_follower/generate_fixtures.py
+// and re-run it (or drop a new fixture directory in by hand).
 
 #include "controllers/rgbd_follower.h"
 #include "datatypes/control.h"
@@ -54,8 +55,11 @@ fs::path locate_fixture_root() {
     }
   }
   // Fall back to the source-tree path (cmake current source dir).
-  fs::path src_default = fs::path(__FILE__).parent_path().parent_path()
-                             .parent_path().parent_path() /
+  fs::path src_default = fs::path(__FILE__)
+                             .parent_path()
+                             .parent_path()
+                             .parent_path()
+                             .parent_path() /
                          "tests" / "resources" / "vision_follower";
   return src_default;
 }
@@ -68,9 +72,12 @@ std::vector<FixtureCase> discover_fixtures() {
     return out;
   }
   for (auto const &entry : fs::directory_iterator(root)) {
-    if (!fs::is_directory(entry.path())) continue;
-    if (!fs::exists(entry.path() / "case.json")) continue;
-    if (!fs::exists(entry.path() / "depth.png")) continue;
+    if (!fs::is_directory(entry.path()))
+      continue;
+    if (!fs::exists(entry.path() / "case.json"))
+      continue;
+    if (!fs::exists(entry.path() / "depth.png"))
+      continue;
     out.push_back({entry.path().filename().string(), entry.path()});
   }
   std::sort(out.begin(), out.end(),
@@ -84,9 +91,9 @@ cv::Mat load_depth_png(const fs::path &png_path) {
   cv::Mat raw = cv::imread(png_path.string(), cv::IMREAD_UNCHANGED);
   BOOST_REQUIRE_MESSAGE(!raw.empty(),
                         "Could not load depth.png at " << png_path.string());
-  BOOST_REQUIRE_MESSAGE(raw.type() == CV_16UC1,
-                        "depth.png must be 16-bit single-channel: "
-                            << png_path.string());
+  BOOST_REQUIRE_MESSAGE(
+      raw.type() == CV_16UC1,
+      "depth.png must be 16-bit single-channel: " << png_path.string());
   BOOST_REQUIRE(raw.isContinuous());
   return raw;
 }
@@ -139,10 +146,13 @@ std::unique_ptr<Control::RGBDFollower> build_controller(const json &case_json) {
                       case_json["camera"]["max_depth"].get<double>());
 
   std::vector<float> robot_dimensions{0.1f, 0.4f};
-  // Synthetic fixtures are rendered as if the camera coincides with the
-  // robot body frame, so use an identity body->camera transform here.
+  // Synthetic fixtures are rendered as if the camera sits at the robot body
+  // origin looking straight ahead. The follower reads the pose in the optical
+  // convention, so that pose is the REP 103 optical -> body quarter turn as [x,
+  // y, z, w]. An identity here would be read as an optical frame pointing along
+  // body +z and put every target 90 degrees off.
   Eigen::Vector3f cam_pos{0.0f, 0.0f, 0.0f};
-  Eigen::Vector4f cam_rot{0.0f, 0.0f, 0.0f, 1.0f};
+  Eigen::Vector4f cam_rot{-0.5f, 0.5f, -0.5f, 0.5f};
 
   auto controller = std::make_unique<RGBDFollower>(
       ControlType::DIFFERENTIAL_DRIVE, ctrl_limits,
@@ -150,10 +160,9 @@ std::unique_ptr<Control::RGBDFollower> build_controller(const json &case_json) {
       config);
 
   const auto &cam = case_json["camera"];
-  controller->setCameraIntrinsics(cam["fx"].get<float>(),
-                                  cam["fy"].get<float>(),
-                                  cam["cx"].get<float>(),
-                                  cam["cy"].get<float>());
+  controller->setCameraIntrinsics(
+      cam["fx"].get<float>(), cam["fy"].get<float>(), cam["cx"].get<float>(),
+      cam["cy"].get<float>());
   return controller;
 }
 
@@ -182,13 +191,15 @@ void run_one_fixture(const FixtureCase &fx) {
   BOOST_TEST(init_ok == expected_init,
              fx.name << ": setInitialTracking returned " << init_ok
                      << ", expected " << expected_init);
-  if (!init_ok) return;
+  if (!init_ok)
+    return;
 
   Control::Velocity2D current_vel;
   auto result = controller->getTrackingCtrl(depth, detections, current_vel);
   BOOST_TEST(result.isTrajFound,
              fx.name << ": planner failed to find a control");
-  if (!result.isTrajFound) return;
+  if (!result.isTrajFound)
+    return;
 
   const float vx = result.trajectory.velocities.vx[0];
   const float omega = result.trajectory.velocities.omega[0];
@@ -199,17 +210,15 @@ void run_one_fixture(const FixtureCase &fx) {
   const float w_min = exp["omega_min"].get<float>();
   const float w_max = exp["omega_max"].get<float>();
 
-  BOOST_TEST(vx >= vx_min,
-             fx.name << ": vx=" << vx << " < vx_min=" << vx_min);
-  BOOST_TEST(vx <= vx_max,
-             fx.name << ": vx=" << vx << " > vx_max=" << vx_max);
+  BOOST_TEST(vx >= vx_min, fx.name << ": vx=" << vx << " < vx_min=" << vx_min);
+  BOOST_TEST(vx <= vx_max, fx.name << ": vx=" << vx << " > vx_max=" << vx_max);
   BOOST_TEST(omega >= w_min,
              fx.name << ": omega=" << omega << " < omega_min=" << w_min);
   BOOST_TEST(omega <= w_max,
              fx.name << ": omega=" << omega << " > omega_max=" << w_max);
 }
 
-}  // namespace
+} // namespace
 
 BOOST_AUTO_TEST_CASE(RGBDFollower_fixture_cases) {
   auto fixtures = discover_fixtures();

--- a/src/kompass_cpp/tests/vision_follower_fixture_test.cpp
+++ b/src/kompass_cpp/tests/vision_follower_fixture_test.cpp
@@ -22,8 +22,11 @@
 #include <nlohmann/json.hpp>
 #include <opencv2/opencv.hpp>
 
+#include <cstring>
 #include <fstream>
+#include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 using namespace Kompass;
@@ -122,6 +125,59 @@ std::vector<Bbox2D> parse_detections(const json &case_json) {
   return dets;
 }
 
+// Synthetic fixtures are rendered as if the camera sits at the robot body
+// origin looking straight ahead. The follower reads the pose in the optical
+// convention, so that pose is the REP 103 optical -> body quarter turn as [x,
+// y, z, w]. An identity here would be read as an optical frame pointing along
+// body +z and put every target 90 degrees off.
+const Eigen::Vector3f kCameraPosition{0.0f, 0.0f, 0.0f};
+const Eigen::Vector4f kCameraRotation{-0.5f, 0.5f, -0.5f, 0.5f};
+
+// The depth PNG as a point cloud in the camera's optical frame: every
+// in-range pixel back-projected at its centre, packed as float32 xyz records
+// with 4 bytes of padding (point_step 16, offsets 0/4/8) like a LiDAR driver
+// publishes. The point-cloud path must then reproduce the depth-image path.
+struct PackedCloud {
+  std::vector<uint8_t> data;
+  int count = 0;
+
+  PointCloudView view() const {
+    return PointCloudView{
+        ByteSpan(data.data(), data.size()), 16, 16 * count, 1, count, 0, 4, 8};
+  }
+};
+
+PackedCloud cloud_from_depth(const cv::Mat &depth_mm, const json &cam) {
+  const float fx = cam["fx"].get<float>(), fy = cam["fy"].get<float>();
+  const float cx = cam["cx"].get<float>(), cy = cam["cy"].get<float>();
+  const float to_metres = cam["depth_conversion_factor"].get<float>();
+  PackedCloud cloud;
+  cloud.data.reserve(static_cast<std::size_t>(depth_mm.total()) * 16);
+  for (int row = 0; row < depth_mm.rows; ++row) {
+    for (int col = 0; col < depth_mm.cols; ++col) {
+      const float d = depth_mm.at<uint16_t>(row, col) * to_metres;
+      if (d <= 0.0f) {
+        continue;
+      }
+      const float xyz[3] = {(col + 0.5f - cx) * d / fx,
+                            (row + 0.5f - cy) * d / fy, d};
+      uint8_t record[16] = {};
+      std::memcpy(record, xyz, sizeof(xyz));
+      cloud.data.insert(cloud.data.end(), record, record + 16);
+      ++cloud.count;
+    }
+  }
+  return cloud;
+}
+
+// The cloud is in the optical frame, so its sensor is the camera itself
+SensorConfig camera_as_cloud_sensor() {
+  SensorConfig sensor;
+  sensor.position = kCameraPosition;
+  sensor.rotation = kCameraRotation;
+  return sensor;
+}
+
 std::unique_ptr<Control::RGBDFollower> build_controller(const json &case_json) {
   using namespace Control;
   LinearVelocityControlParams x_params(2.0f, 5.0f, 10.0f);
@@ -146,18 +202,10 @@ std::unique_ptr<Control::RGBDFollower> build_controller(const json &case_json) {
                       case_json["camera"]["max_depth"].get<double>());
 
   std::vector<float> robot_dimensions{0.1f, 0.4f};
-  // Synthetic fixtures are rendered as if the camera sits at the robot body
-  // origin looking straight ahead. The follower reads the pose in the optical
-  // convention, so that pose is the REP 103 optical -> body quarter turn as [x,
-  // y, z, w]. An identity here would be read as an optical frame pointing along
-  // body +z and put every target 90 degrees off.
-  Eigen::Vector3f cam_pos{0.0f, 0.0f, 0.0f};
-  Eigen::Vector4f cam_rot{-0.5f, 0.5f, -0.5f, 0.5f};
-
   auto controller = std::make_unique<RGBDFollower>(
       ControlType::DIFFERENTIAL_DRIVE, ctrl_limits,
-      CollisionChecker::ShapeType::CYLINDER, robot_dimensions, cam_pos, cam_rot,
-      config);
+      CollisionChecker::ShapeType::CYLINDER, robot_dimensions, kCameraPosition,
+      kCameraRotation, config);
 
   const auto &cam = case_json["camera"];
   controller->setCameraIntrinsics(
@@ -166,40 +214,37 @@ std::unique_ptr<Control::RGBDFollower> build_controller(const json &case_json) {
   return controller;
 }
 
-void run_one_fixture(const FixtureCase &fx) {
-  BOOST_TEST_MESSAGE("Running fixture: " << fx.name);
-  std::ifstream in((fx.dir / "case.json").string());
-  json case_json;
-  in >> case_json;
-
-  const cv::Mat depth_mat = load_depth_png(fx.dir / "depth.png");
-  const auto depth = depth_view(depth_mat);
-  auto detections = parse_detections(case_json);
-  auto controller = build_controller(case_json);
-
+// First command of one fixture through one depth source, checked against
+// the fixture's expected bounds. Returns (vx, omega) when a command was found.
+template <typename DepthSource>
+std::optional<std::pair<float, float>>
+run_one_source(const FixtureCase &fx, const std::string &source_name,
+               const json &case_json, const DepthSource &source,
+               Control::RGBDFollower &controller) {
+  const auto detections = parse_detections(case_json);
   Path::State state(case_json["robot"]["x"].get<float>(),
                     case_json["robot"]["y"].get<float>(),
                     case_json["robot"]["yaw"].get<float>(),
                     case_json["robot"]["speed"].get<float>());
-  controller->setCurrentState(state);
+  controller.setCurrentState(state);
+  const std::string tag = fx.name + " (" + source_name + ")";
 
   const int click_x = case_json["click"]["x"].get<int>();
   const int click_y = case_json["click"]["y"].get<int>();
-  const bool init_ok = controller->setInitialTracking(click_x, click_y, depth,
-                                                      detections, state.yaw);
+  const bool init_ok = controller.setInitialTracking(click_x, click_y, source,
+                                                     detections, state.yaw);
   const bool expected_init = case_json["expected"]["init_success"].get<bool>();
-  BOOST_TEST(init_ok == expected_init,
-             fx.name << ": setInitialTracking returned " << init_ok
-                     << ", expected " << expected_init);
+  BOOST_TEST(init_ok == expected_init, tag << ": setInitialTracking returned "
+                                           << init_ok << ", expected "
+                                           << expected_init);
   if (!init_ok)
-    return;
+    return std::nullopt;
 
   Control::Velocity2D current_vel;
-  auto result = controller->getTrackingCtrl(depth, detections, current_vel);
-  BOOST_TEST(result.isTrajFound,
-             fx.name << ": planner failed to find a control");
+  auto result = controller.getTrackingCtrl(source, detections, current_vel);
+  BOOST_TEST(result.isTrajFound, tag << ": planner failed to find a control");
   if (!result.isTrajFound)
-    return;
+    return std::nullopt;
 
   const float vx = result.trajectory.velocities.vx[0];
   const float omega = result.trajectory.velocities.omega[0];
@@ -210,12 +255,41 @@ void run_one_fixture(const FixtureCase &fx) {
   const float w_min = exp["omega_min"].get<float>();
   const float w_max = exp["omega_max"].get<float>();
 
-  BOOST_TEST(vx >= vx_min, fx.name << ": vx=" << vx << " < vx_min=" << vx_min);
-  BOOST_TEST(vx <= vx_max, fx.name << ": vx=" << vx << " > vx_max=" << vx_max);
+  BOOST_TEST(vx >= vx_min, tag << ": vx=" << vx << " < vx_min=" << vx_min);
+  BOOST_TEST(vx <= vx_max, tag << ": vx=" << vx << " > vx_max=" << vx_max);
   BOOST_TEST(omega >= w_min,
-             fx.name << ": omega=" << omega << " < omega_min=" << w_min);
+             tag << ": omega=" << omega << " < omega_min=" << w_min);
   BOOST_TEST(omega <= w_max,
-             fx.name << ": omega=" << omega << " > omega_max=" << w_max);
+             tag << ": omega=" << omega << " > omega_max=" << w_max);
+  return std::make_pair(vx, omega);
+}
+
+void run_one_fixture(const FixtureCase &fx) {
+  BOOST_TEST_MESSAGE("Running fixture: " << fx.name);
+  std::ifstream in((fx.dir / "case.json").string());
+  json case_json;
+  in >> case_json;
+
+  const cv::Mat depth_mat = load_depth_png(fx.dir / "depth.png");
+
+  auto depth_controller = build_controller(case_json);
+  const auto from_depth = run_one_source(
+      fx, "depth image", case_json, depth_view(depth_mat), *depth_controller);
+
+  const PackedCloud cloud = cloud_from_depth(depth_mat, case_json["camera"]);
+  auto cloud_controller = build_controller(case_json);
+  cloud_controller->setPointCloudSensor(camera_as_cloud_sensor());
+  const auto from_cloud = run_one_source(fx, "point cloud", case_json,
+                                         cloud.view(), *cloud_controller);
+
+  // Same scene through both sources must give the same command
+  BOOST_TEST(from_depth.has_value() == from_cloud.has_value(),
+             fx.name << ": depth-image and point-cloud paths disagree on "
+                        "finding a command");
+  if (from_depth && from_cloud) {
+    BOOST_CHECK_SMALL(from_depth->first - from_cloud->first, 1e-3f);
+    BOOST_CHECK_SMALL(from_depth->second - from_cloud->second, 1e-3f);
+  }
 }
 
 } // namespace

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -529,7 +529,7 @@ def test_dwa_creeps_onto_a_close_goal():
     """A goal closer than the smallest grid speed covers within the horizon:
     0.5 s steps, a 5 s rollout and a speed grid whose smallest speed (0.2 m/s)
     travels 0.9 m, twice the distance to the goal. Every straight grid sample
-    overshoots, so only the stop sample and the creep speed can end near the
+    overshoots, so only the creep speed can end near the
     goal. The controller must reach it with forward motion only: no reverse,
     no turning, no overshoot.
     """

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -530,8 +530,10 @@ def test_dwa_creeps_onto_a_close_goal():
     0.5 s steps, a 5 s rollout and a speed grid whose smallest speed (0.2 m/s)
     travels 0.9 m, twice the distance to the goal. Every straight grid sample
     overshoots, so only the stop sample and the creep speed can end near the
-    goal. The controller must reach it with forward motion only: no reverse,
-    no turning, no overshoot.
+    goal, and with the horizon capped at the goal the grid speeds can end on
+    it too. The controller must reach it with forward motion only: no reverse,
+    no turning, no overshoot, and within a few steps rather than by creeping
+    the whole way.
     """
     robot = Robot(
         robot_type=RobotType.DIFFERENTIAL_DRIVE,
@@ -600,6 +602,9 @@ def test_dwa_creeps_onto_a_close_goal():
         assert distance <= start_distance + 0.05, f"moved away at step {steps}"
 
     assert dwa.reached_end(), f"goal not reached in {steps} steps"
+    # Four steps with the goal-aware horizon; fifteen when creeping at the
+    # minimum speed the whole way
+    assert steps <= 6, f"took {steps} steps"
 
 
 def test_pure_pursuit(

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -530,10 +530,8 @@ def test_dwa_creeps_onto_a_close_goal():
     0.5 s steps, a 5 s rollout and a speed grid whose smallest speed (0.2 m/s)
     travels 0.9 m, twice the distance to the goal. Every straight grid sample
     overshoots, so only the stop sample and the creep speed can end near the
-    goal, and with the horizon capped at the goal the grid speeds can end on
-    it too. The controller must reach it with forward motion only: no reverse,
-    no turning, no overshoot, and within a few steps rather than by creeping
-    the whole way.
+    goal. The controller must reach it with forward motion only: no reverse,
+    no turning, no overshoot.
     """
     robot = Robot(
         robot_type=RobotType.DIFFERENTIAL_DRIVE,
@@ -602,9 +600,6 @@ def test_dwa_creeps_onto_a_close_goal():
         assert distance <= start_distance + 0.05, f"moved away at step {steps}"
 
     assert dwa.reached_end(), f"goal not reached in {steps} steps"
-    # Four steps with the goal-aware horizon; fifteen when creeping at the
-    # minimum speed the whole way
-    assert steps <= 6, f"took {steps} steps"
 
 
 def test_pure_pursuit(

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -510,6 +510,21 @@ def test_linear_ctrl_limits_min_vel():
     assert limits.min_vel == 0.2
 
 
+def test_angular_ctrl_limits_min_omega():
+    """The angular deadband of the controllers is the minimum angular velocity
+    of the angular control limits, 0.05 rad/s when not given."""
+    limits = AngularCtrlLimits(max_omega=1.0, max_acc=3.0, max_decel=3.0, max_ang=np.pi)
+    assert limits.min_omega == 0.05
+    assert (
+        AngularCtrlLimits(
+            max_omega=1.0, max_acc=3.0, max_decel=3.0, max_ang=np.pi, min_omega=0.2
+        ).min_omega
+        == 0.2
+    )
+    limits.min_omega = 0.3
+    assert limits.min_omega == 0.3
+
+
 def test_dwa_creeps_onto_a_close_goal():
     """A goal closer than the smallest grid speed covers within the horizon:
     0.5 s steps, a 5 s rollout and a speed grid whose smallest speed (0.2 m/s)

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -510,6 +510,54 @@ def test_linear_ctrl_limits_min_vel():
     assert limits.min_vel == 0.2
 
 
+def test_dwa_allow_reverse():
+    """Reversing samples are generated unless the DWA config turns them off,
+    in which case no command is ever negative."""
+    assert DWAConfig().allow_reverse is True
+
+    # The goal lies behind the robot: with reversing allowed the planner
+    # backs up, forward-only it must turn around instead
+    def first_command(allow_reverse: bool):
+        robot = Robot(
+            robot_type=RobotType.DIFFERENTIAL_DRIVE,
+            geometry_type=RobotGeometry.Type.CYLINDER,
+            geometry_params=np.array([0.2, 0.4]),
+        )
+        limits = RobotCtrlLimits(
+            vx_limits=LinearCtrlLimits(max_vel=0.8, max_acc=5.0, max_decel=10.0),
+            omega_limits=AngularCtrlLimits(
+                max_omega=1.5, max_acc=3.0, max_decel=3.0, max_ang=np.pi
+            ),
+        )
+        dwa = DWA(
+            robot=robot,
+            ctrl_limits=limits,
+            config=DWAConfig(
+                control_time_step=0.1,
+                prediction_horizon=10,
+                control_horizon=2,
+                max_linear_samples=9,
+                max_angular_samples=10,
+                max_num_threads=1,
+                allow_reverse=allow_reverse,
+            ),
+        )
+        poses = []
+        for x in (0.0, -1.5, -3.0):
+            pose = PoseStamped()
+            pose.pose.position.x = x
+            poses.append(pose)
+        dwa.set_path(Path(poses=poses))
+        robot.state.x, robot.state.y, robot.state.yaw = 0.0, 0.0, 0.0
+        angles = np.arange(0.0, 2 * np.pi, 0.1 * np.pi)
+        ranges = np.full(angles.size, 20.0)
+        assert dwa.loop_step(current_state=robot.state, ranges=ranges, angles=angles)
+        return dwa.linear_x_control[0]
+
+    assert first_command(True) < 0.0
+    assert first_command(False) >= 0.0
+
+
 def test_angular_ctrl_limits_min_omega():
     """The angular deadband of the controllers is the minimum angular velocity
     of the angular control limits, 0.05 rad/s when not given."""

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -497,6 +497,96 @@ def test_dwa_accepts_cartesian_points():
     assert dwa.loop_step(current_state=my_robot.state, points=points) is True
 
 
+def test_linear_ctrl_limits_min_vel():
+    """The creep speed is the minimum speed of the linear control limits,
+    with the sampler's former default when not given."""
+    limits = LinearCtrlLimits(max_vel=1.0, max_acc=5.0, max_decel=10.0)
+    assert limits.min_vel == 0.05
+    assert (
+        LinearCtrlLimits(max_vel=1.0, max_acc=5.0, max_decel=10.0, min_vel=0.1).min_vel
+        == 0.1
+    )
+    limits.min_vel = 0.2
+    assert limits.min_vel == 0.2
+
+
+def test_dwa_creeps_onto_a_close_goal():
+    """A goal closer than the smallest grid speed covers within the horizon:
+    0.5 s steps, a 5 s rollout and a speed grid whose smallest speed (0.2 m/s)
+    travels 0.9 m, twice the distance to the goal. Every straight grid sample
+    overshoots, so only the stop sample and the creep speed can end near the
+    goal. The controller must reach it with forward motion only: no reverse,
+    no turning, no overshoot.
+    """
+    robot = Robot(
+        robot_type=RobotType.DIFFERENTIAL_DRIVE,
+        geometry_type=RobotGeometry.Type.CYLINDER,
+        geometry_params=np.array([0.2, 0.4]),
+    )
+    # The creep speed is the minimum speed of the x-axis limits
+    limits = RobotCtrlLimits(
+        vx_limits=LinearCtrlLimits(
+            max_vel=0.8, max_acc=5.0, max_decel=10.0, min_vel=0.05
+        ),
+        omega_limits=AngularCtrlLimits(
+            max_omega=1.5, max_acc=3.0, max_decel=3.0, max_ang=np.pi
+        ),
+    )
+    config = DWAConfig(
+        control_time_step=0.5,
+        prediction_horizon=10,
+        control_horizon=5,
+        max_linear_samples=9,
+        max_angular_samples=10,
+        octree_resolution=0.1,
+        max_num_threads=1,
+        costs_weights=TrajectoryCostsWeights(
+            reference_path_distance_weight=1.0,
+            goal_distance_weight=1.0,
+            smoothness_weight=0.0,
+            jerk_weight=0.0,
+            obstacles_distance_weight=0.0,
+        ),
+    )
+    dwa = DWA(robot=robot, ctrl_limits=limits, config=config)
+
+    # A straight 3 m path along x
+    poses = []
+    for x in (0.0, 1.5, 3.0):
+        pose = PoseStamped()
+        pose.pose.position.x = x
+        poses.append(pose)
+    dwa.set_path(Path(poses=poses))
+
+    # 0.45 m short of the goal, facing it, at rest
+    robot.state.x = 2.55
+    robot.state.y = 0.0
+    robot.state.yaw = 0.0
+    start_distance = 0.45
+
+    angles = np.arange(0.0, 2 * np.pi, 0.1 * np.pi)
+    ranges = np.full(angles.size, 20.0)
+
+    steps = 0
+    while steps < 60:
+        steps += 1
+        if not dwa.loop_step(
+            current_state=robot.state, ranges=ranges, angles=angles
+        ):
+            # No command once the given state is at the goal
+            break
+        vx = dwa.linear_x_control[0]
+        omega = dwa.angular_control[0]
+        assert vx >= 0.0, f"reverse command {vx} at step {steps}"
+        assert abs(omega) < 0.3, f"turning command {omega} at step {steps}"
+        robot.set_control(velocity_x=vx, omega=omega)
+        robot.get_state(dt=config.control_time_step)
+        distance = np.hypot(3.0 - robot.state.x, robot.state.y)
+        assert distance <= start_distance + 0.05, f"moved away at step {steps}"
+
+    assert dwa.reached_end(), f"goal not reached in {steps} steps"
+
+
 def test_pure_pursuit(
     plot: bool = False,
     figure_name: str = "pure_pursuit",

--- a/tests/test_depth_detector.py
+++ b/tests/test_depth_detector.py
@@ -672,3 +672,78 @@ def test_point_cloud_accepts_bytes_and_readonly_buffers(
     broken = {k: v for k, v in cloud.items() if k != "z_offset"}
     with pytest.raises(TypeError):
         detector.compute_3d_detections(**broken, **args)
+
+
+# -----------------------------------------------------------------------------
+# Provenance of a lifted box: which input it came from, how much depth it rests on
+# -----------------------------------------------------------------------------
+
+
+def _box_over_the_void(center_bbox_2d):
+    """A box on pixels that carry no depth, which the detector drops."""
+    box = Bbox2D()
+    box.top_left_corner = np.array([0, 0], dtype=np.int32)
+    box.size = np.array([50, 50], dtype=np.int32)
+    box.img_size = center_bbox_2d.img_size
+    return box
+
+
+def test_boxes_keep_their_source_index_when_others_are_dropped(
+    detector, synthetic_depth_image, center_bbox_2d
+):
+    """The output is not positional, so a survivor must say which input it
+    was lifted from."""
+    results = detector.compute_3d_detections(
+        synthetic_depth_image,
+        [_box_over_the_void(center_bbox_2d), center_bbox_2d],
+        0.0, 0.0, 0.0, 0.0,
+    )
+    assert [box.source_index for box in results] == [1]
+
+
+def test_sample_count_is_the_usable_depth_inside_the_box(
+    detector, synthetic_depth_image, center_bbox_2d
+):
+    """The synthetic scene carries depth exactly inside the box, so every
+    pixel counts; a box half over the void counts half."""
+    (box,) = detector.compute_3d_detections(
+        synthetic_depth_image, [center_bbox_2d], 0.0, 0.0, 0.0, 0.0
+    )
+    w, h = center_bbox_2d.size
+    assert box.sample_count == w * h
+
+    half = Bbox2D()
+    half.top_left_corner = center_bbox_2d.top_left_corner - np.array(
+        [w // 2, 0], dtype=np.int32
+    )
+    half.size = center_bbox_2d.size
+    half.img_size = center_bbox_2d.img_size
+    (box,) = detector.compute_3d_detections(
+        synthetic_depth_image, [half], 0.0, 0.0, 0.0, 0.0
+    )
+    # the box limits are inclusive, which may add one column
+    assert box.sample_count == pytest.approx(w * h / 2, abs=h)
+
+
+def test_poi_boxes_carry_provenance(detector, synthetic_depth_image_poi, center_poi):
+    (box,) = detector.compute_3d_detections(
+        synthetic_depth_image_poi, center_poi, 0.0, 0.0, 0.0, 0.0
+    )
+    assert box.source_index == 0
+    assert box.sample_count > 1
+
+
+def test_point_cloud_boxes_carry_provenance(
+    detector, camera_params, camera_as_cloud_sensor, synthetic_depth_image, center_bbox_2d
+):
+    """Every back-projected point of the scene lands in the box, so the
+    count is the point count, and the index survives a dropped box."""
+    detector.set_point_cloud_sensor(camera_as_cloud_sensor)
+    points = _optical_points_from_depth(synthetic_depth_image, camera_params)
+    (box,) = detector.compute_3d_detections(
+        **_cloud_dict(points),
+        input=[_box_over_the_void(center_bbox_2d), center_bbox_2d],
+        robot_x=0.0, robot_y=0.0, robot_yaw=0.0, robot_speed=0.0,
+    )
+    assert box.source_index == 1
+    assert box.sample_count == len(points)

--- a/tests/test_depth_detector.py
+++ b/tests/test_depth_detector.py
@@ -2,6 +2,7 @@ import pytest
 import numpy as np
 from kompass_core.vision import CameraFrameConvention, DepthDetector
 from kompass_core.datatypes import Bbox2D, PointsOfInterest
+from kompass_cpp.types import SensorConfig
 
 # -----------------------------------------------------------------------------
 # Fixtures
@@ -222,8 +223,9 @@ def test_poi_multipoint_robot_frame(detector, camera_params):
     The MAD-based bounding box should encompass the spread and the 3D
     center should correspond to the median of the cluster.
     """
-    cx, cy = int(camera_params["principal_point"][0]), int(
-        camera_params["principal_point"][1]
+    cx, cy = (
+        int(camera_params["principal_point"][0]),
+        int(camera_params["principal_point"][1]),
     )
     img_h, img_w = camera_params["img_shape"]
 
@@ -294,9 +296,7 @@ def test_compute_3d_float32_nan_pixels_are_rejected(
     h, w = camera_params["img_shape"]
     img = np.full((h, w), np.nan, dtype=np.float32)
 
-    results = detector.compute_3d_detections(
-        img, [center_bbox_2d], 0.0, 0.0, 0.0, 0.0
-    )
+    results = detector.compute_3d_detections(img, [center_bbox_2d], 0.0, 0.0, 0.0, 0.0)
     assert len(results) == 0
 
 
@@ -397,3 +397,278 @@ def test_the_two_conventions_differ_by_the_rep103_turn(
     # Body-aligned: applied twice -> depth lands on -y, a clean 90 deg off
     doubled = centre(CameraFrameConvention.BODY_ALIGNED)
     assert doubled[1] == pytest.approx(-3.0, abs=0.05)
+
+
+# -----------------------------------------------------------------------------
+# Point cloud input
+# -----------------------------------------------------------------------------
+
+
+def _cloud_dict(points_xyz: np.ndarray) -> dict:
+    """Packs Nx3 float32 points as the PointCloud2 layout dict the mapper
+    takes: 16-byte records (x, y, z at offsets 0/4/8 plus 4 bytes of padding),
+    the way LiDAR drivers publish."""
+    n = len(points_xyz)
+    records = np.zeros((n, 4), dtype=np.float32)
+    records[:, :3] = points_xyz
+    return {
+        "data": records.reshape(-1).view(np.uint8),
+        "point_step": 16,
+        "row_step": 16 * n,
+        "height": 1,
+        "width": n,
+        "x_offset": 0,
+        "y_offset": 4,
+        "z_offset": 8,
+    }
+
+
+def _optical_points_from_depth(depth_mm: np.ndarray, camera_params: dict) -> np.ndarray:
+    """Every valid pixel back-projected at its centre into the camera's
+    optical frame (x right, y down, z forward), Nx3 float32."""
+    fx, fy = camera_params["focal_length"]
+    cx, cy = camera_params["principal_point"]
+    rows, cols = np.nonzero(depth_mm)
+    d = depth_mm[rows, cols].astype(np.float32) * 1e-3
+    return np.stack(
+        [(cols + 0.5 - cx) * d / fx, (rows + 0.5 - cy) * d / fy, d], axis=1
+    ).astype(np.float32)
+
+
+def _optical_to_body(points_opt: np.ndarray) -> np.ndarray:
+    """REP 103: optical (x right, y down, z forward) -> body (x forward,
+    y left, z up) for a camera at the body origin."""
+    return np.stack([points_opt[:, 2], -points_opt[:, 0], -points_opt[:, 1]], axis=1)
+
+
+@pytest.fixture
+def camera_as_cloud_sensor(forward_facing_camera):
+    """A cloud expressed in the camera's optical frame has the camera itself
+    as its sensor."""
+    return SensorConfig(
+        position=forward_facing_camera["translation"],
+        rotation=forward_facing_camera["rotation"],
+    )
+
+
+def _assert_same_boxes(from_depth, from_cloud, tol=1e-3):
+    assert len(from_depth) == len(from_cloud) == 1
+    assert np.allclose(from_depth[0].center, from_cloud[0].center, atol=tol)
+    assert np.allclose(from_depth[0].size, from_cloud[0].size, atol=tol)
+
+
+@pytest.mark.parametrize(
+    "robot_state", [(0.0, 0.0, 0.0, 0.0), (10.0, 5.0, 0.7, 0.0)], ids=["body", "world"]
+)
+def test_point_cloud_matches_depth_image(
+    detector,
+    camera_params,
+    synthetic_depth_image,
+    center_bbox_2d,
+    camera_as_cloud_sensor,
+    robot_state,
+):
+    """The same scene as a point cloud in the camera's optical frame lifts to
+    the same 3D box as the depth image."""
+    from_depth = detector.compute_3d_detections(
+        synthetic_depth_image, [center_bbox_2d], *robot_state
+    )
+    detector.set_point_cloud_sensor(camera_as_cloud_sensor)
+    cloud = _cloud_dict(
+        _optical_points_from_depth(synthetic_depth_image, camera_params)
+    )
+    from_cloud = detector.compute_3d_detections(
+        **cloud,
+        input=[center_bbox_2d],
+        robot_x=robot_state[0],
+        robot_y=robot_state[1],
+        robot_yaw=robot_state[2],
+        robot_speed=robot_state[3],
+    )
+    _assert_same_boxes(from_depth, from_cloud)
+
+
+def test_point_cloud_default_sensor_is_the_body_frame(
+    detector, camera_params, synthetic_depth_image, center_bbox_2d
+):
+    """Without set_point_cloud_sensor the cloud is taken in the robot body
+    frame: the optical cloud turned into body axes lifts to the same box."""
+    from_depth = detector.compute_3d_detections(
+        synthetic_depth_image, [center_bbox_2d], 0.0, 0.0, 0.0, 0.0
+    )
+    body_points = _optical_to_body(
+        _optical_points_from_depth(synthetic_depth_image, camera_params)
+    )
+    from_cloud = detector.compute_3d_detections(
+        **_cloud_dict(body_points),
+        input=[center_bbox_2d],
+        robot_x=0.0,
+        robot_y=0.0,
+        robot_yaw=0.0,
+        robot_speed=0.0,
+    )
+    _assert_same_boxes(from_depth, from_cloud)
+
+
+def test_point_cloud_ignores_invalid_points(
+    detector,
+    camera_params,
+    synthetic_depth_image,
+    center_bbox_2d,
+    camera_as_cloud_sensor,
+):
+    """Non-finite points, points behind the camera and points beyond the
+    depth range (a wall behind the target that projects into the same box)
+    do not change the result."""
+    detector.set_point_cloud_sensor(camera_as_cloud_sensor)
+    clean = _optical_points_from_depth(synthetic_depth_image, camera_params)
+    args = {
+        "input": [center_bbox_2d],
+        "robot_x": 0.0,
+        "robot_y": 0.0,
+        "robot_yaw": 0.0,
+        "robot_speed": 0.0,
+    }
+    from_clean = detector.compute_3d_detections(**_cloud_dict(clean), **args)
+
+    # A wall at 20 m (beyond the 10 m range) covering the whole box, more
+    # points than the target itself, plus a point behind the camera and NaNs
+    wall = clean.copy()
+    wall[:, 2] = 20.0
+    wall[:, :2] *= 20.0 / 3.0
+    behind = np.array([[0.0, 0.0, -3.0]], dtype=np.float32)
+    nans = np.full((10, 3), np.nan, dtype=np.float32)
+    polluted = np.concatenate([wall, behind, nans, clean, wall])
+    from_polluted = detector.compute_3d_detections(**_cloud_dict(polluted), **args)
+    _assert_same_boxes(from_clean, from_polluted)
+
+
+def test_point_cloud_pois_match_depth_image(
+    detector,
+    camera_params,
+    synthetic_depth_image_poi,
+    center_poi,
+    camera_as_cloud_sensor,
+):
+    from_depth = detector.compute_3d_detections(
+        synthetic_depth_image_poi, center_poi, 0.0, 0.0, 0.0, 0.0
+    )
+    detector.set_point_cloud_sensor(camera_as_cloud_sensor)
+    cloud = _cloud_dict(
+        _optical_points_from_depth(synthetic_depth_image_poi, camera_params)
+    )
+    from_cloud = detector.compute_3d_detections(
+        **cloud,
+        input=center_poi,
+        robot_x=0.0,
+        robot_y=0.0,
+        robot_yaw=0.0,
+        robot_speed=0.0,
+    )
+    _assert_same_boxes(from_depth, from_cloud)
+
+
+def test_point_cloud_lifts_through_lidar_mount_pose(detector, camera_params):
+    """A LiDAR mounted away from the camera, yawed, in its own body-aligned
+    frame: a cluster placed at a known body-frame location comes back there,
+    with a larger out-of-range wall behind it ignored."""
+    yaw = 0.2
+    lidar = SensorConfig(
+        position=np.array([-0.1, 0.0, 0.8], dtype=np.float32),
+        rotation=np.array(
+            [0.0, 0.0, np.sin(yaw / 2), np.cos(yaw / 2)], dtype=np.float32
+        ),
+    )
+    detector.set_point_cloud_sensor(lidar)
+    rot = np.array(
+        [
+            [np.cos(yaw), -np.sin(yaw), 0.0],
+            [np.sin(yaw), np.cos(yaw), 0.0],
+            [0.0, 0.0, 1.0],
+        ],
+        dtype=np.float32,
+    )
+
+    def in_lidar(points_body: np.ndarray) -> np.ndarray:
+        return (points_body - lidar.position) @ rot  # rot^T applied to each row
+
+    cluster_center = np.array([3.0, 0.5, 0.4], dtype=np.float32)
+    offsets = np.array(
+        [
+            [0.05 * k, 0.04 * i, 0.04 * j]
+            for i in range(-5, 6)
+            for j in range(-5, 6)
+            for k in (-1, 0, 1)
+        ],
+        dtype=np.float32,
+    )
+    cluster = cluster_center + offsets
+    wall = np.array(
+        [
+            [15.0, 0.5 + 0.05 * i, 0.4 + 0.05 * j]
+            for i in range(-10, 11)
+            for j in range(-10, 11)
+        ],
+        dtype=np.float32,
+    )
+    assert len(wall) > len(cluster)
+    points = in_lidar(np.concatenate([cluster, wall]))
+
+    # The cluster projects to u in [203, 270] and v in [140, 207] for this
+    # camera (fx = fy = 500 at the body origin)
+    box = Bbox2D(
+        top_left_corner=np.array([200, 137], dtype=np.int32),
+        size=np.array([74, 73], dtype=np.int32),
+    )
+    box.img_size = np.array([640, 480], dtype=np.int32)
+    boxes = detector.compute_3d_detections(
+        **_cloud_dict(points),
+        input=[box],
+        robot_x=0.0,
+        robot_y=0.0,
+        robot_yaw=0.0,
+        robot_speed=0.0,
+    )
+    assert len(boxes) == 1
+    assert np.allclose(boxes[0].center, cluster_center, atol=0.02)
+    assert 0.0 < boxes[0].size[0] < 0.2
+
+
+def test_point_cloud_accepts_bytes_and_readonly_buffers(
+    detector,
+    camera_params,
+    synthetic_depth_image,
+    center_bbox_2d,
+    camera_as_cloud_sensor,
+):
+    """The buffer crosses as delivered: a read-only np.frombuffer view (what a
+    ROS callback hands out) and plain bytes are both accepted; a dict missing
+    a layout field is rejected."""
+    detector.set_point_cloud_sensor(camera_as_cloud_sensor)
+    cloud = _cloud_dict(
+        _optical_points_from_depth(synthetic_depth_image, camera_params)
+    )
+    args = {
+        "input": [center_bbox_2d],
+        "robot_x": 0.0,
+        "robot_y": 0.0,
+        "robot_yaw": 0.0,
+        "robot_speed": 0.0,
+    }
+    reference = detector.compute_3d_detections(**cloud, **args)
+
+    raw = cloud["data"].tobytes()
+    readonly = np.frombuffer(raw, dtype=np.uint8)
+    assert not readonly.flags.writeable
+    _assert_same_boxes(
+        reference,
+        detector.compute_3d_detections(**{**cloud, "data": readonly}, **args),
+    )
+    _assert_same_boxes(
+        reference,
+        detector.compute_3d_detections(**{**cloud, "data": raw}, **args),
+    )
+
+    broken = {k: v for k, v in cloud.items() if k != "z_offset"}
+    with pytest.raises(TypeError):
+        detector.compute_3d_detections(**broken, **args)

--- a/tests/test_vision_follower.py
+++ b/tests/test_vision_follower.py
@@ -244,7 +244,7 @@ def test_rgbd_follower_exposes_rgb_follower_interface() -> None:
 _TILTED_MOUNT = (-0.5839669, 0.5936764, -0.38588133, 0.3970222)
 
 
-def _close_target_follower() -> VisionRGBDFollower:
+def _close_target_follower(**config_overrides) -> VisionRGBDFollower:
     robot = Robot(
         robot_type=RobotType.DIFFERENTIAL_DRIVE,
         # A real chassis: the circumradius is 0.357 m, so a target closer than
@@ -264,6 +264,7 @@ def _close_target_follower() -> VisionRGBDFollower:
         _use_local_coordinates=True,
         camera_position_to_robot=np.array([0.0, 0.0, 0.3], dtype=np.float32),
         camera_rotation_to_robot=np.array(_TILTED_MOUNT, dtype=np.float32),
+        **config_overrides,
     )
     return VisionRGBDFollower(
         robot=robot,
@@ -323,6 +324,53 @@ def test_close_target_does_not_saturate_omega() -> None:
     assert abs(omega) < 0.5 * max_omega, (
         f"omega={omega} on a close target: the feedforward is running away "
         f"(limit is {max_omega})"
+    )
+
+
+def test_missed_depth_ticks_run_the_wait_search_recovery() -> None:
+    """A tick without any depth source after tracking has started is an
+    observation gap: the follower holds position through its wait window
+    instead of failing outright, reports failure only when that recovery is
+    exhausted, and resumes following as soon as depth returns. Before
+    tracking has started a no-depth tick stays a plain no-op."""
+    follower = _close_target_follower(
+        enable_search=False,
+        target_wait_timeout=0.3,
+        control_horizon=2,
+    )
+    depth, box, (click_x, click_y) = _close_target_frame()
+    state = RobotState(x=0.0, y=0.0, yaw=0.0, speed=0.0)
+
+    # Without an initial target there is nothing to recover
+    assert not follower.loop_step(current_state=state, detections_2d=[box])
+
+    assert follower.set_initial_tracking_image(
+        current_state=state,
+        pose_x_img=click_x,
+        pose_y_img=click_y,
+        detected_boxes=[box],
+        depth_image=depth,
+    )
+    assert follower.loop_step(
+        current_state=state, detections_2d=[box], depth_image=depth
+    )
+
+    # Observation gap: held during the wait window, given up once it is
+    # exhausted. With control_horizon=2 each tick advances the recorded wait
+    # time by one control step (0.1 s), so a 0.3 s window gives up on the
+    # fourth tick. The give-up resets the recovery state, so later ticks hold
+    # again -- the consumer aborts on the first failure, which is the give-up.
+    gap = [
+        follower.loop_step(current_state=state, detections_2d=[]) for _ in range(6)
+    ]
+    assert False in gap, "recovery must eventually report failure"
+    give_up = gap.index(False)
+    assert give_up > 0, "first no-depth tick must hold, not abort"
+    assert all(gap[:give_up]), "every tick before the give-up must hold"
+
+    # Depth is back: the same target is picked up again
+    assert follower.loop_step(
+        current_state=state, detections_2d=[box], depth_image=depth
     )
 
 

--- a/tests/test_vision_follower.py
+++ b/tests/test_vision_follower.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import List
+from typing import List, Optional, Tuple
 
 import cv2
 import numpy as np
@@ -17,6 +17,7 @@ import pytest
 
 from kompass_core.control import VisionRGBDFollower, VisionRGBDFollowerConfig
 from kompass_core.datatypes import Bbox2D
+from kompass_cpp.types import SensorConfig
 from kompass_core.models import (
     AngularCtrlLimits,
     LinearCtrlLimits,
@@ -89,21 +90,57 @@ def _make_follower(case: dict) -> VisionRGBDFollower:
     )
 
 
-@pytest.mark.parametrize(
-    "case_dir", _discover_fixtures(), ids=lambda p: p.name
-)
-def test_vision_follower_fixture(case_dir: Path) -> None:
-    case = _load_case(case_dir)
-    depth = cv2.imread(str(case_dir / "depth.png"), cv2.IMREAD_UNCHANGED)
-    assert depth is not None and depth.dtype == np.uint16, (
-        f"Could not load 16-bit depth.png for {case_dir.name}"
+def _cloud_from_depth(depth_mm: np.ndarray, cam: dict) -> dict:
+    """The depth PNG as a point cloud in the camera's optical frame: every
+    valid pixel back-projected at its centre, packed as the PointCloud2
+    layout dict the mapper takes (16-byte float32 records, x/y/z at 0/4/8)."""
+    rows, cols = np.nonzero(depth_mm)
+    d = depth_mm[rows, cols].astype(np.float32) * float(cam["depth_conversion_factor"])
+    records = np.zeros((len(d), 4), dtype=np.float32)
+    records[:, 0] = (cols + 0.5 - float(cam["cx"])) * d / float(cam["fx"])
+    records[:, 1] = (rows + 0.5 - float(cam["cy"])) * d / float(cam["fy"])
+    records[:, 2] = d
+    n = len(d)
+    return {
+        "data": records.reshape(-1).view(np.uint8),
+        "point_step": 16,
+        "row_step": 16 * n,
+        "height": 1,
+        "width": n,
+        "x_offset": 0,
+        "y_offset": 4,
+        "z_offset": 8,
+    }
+
+
+def _camera_as_cloud_sensor(follower: VisionRGBDFollower) -> SensorConfig:
+    """A cloud in the camera's optical frame has the camera as its sensor."""
+    return SensorConfig(
+        position=follower._config.camera_position_to_robot,
+        rotation=follower._config.camera_rotation_to_robot,
     )
 
+
+def _run_fixture(
+    case_dir: Path,
+    case: dict,
+    *,
+    depth_image: Optional[np.ndarray] = None,
+    point_cloud: Optional[dict] = None,
+) -> Optional[Tuple[float, float]]:
+    """Runs one fixture through one depth source on a fresh follower and
+    checks the fixture's expected bounds. Returns (vx, omega) when a command
+    was found."""
+    source = "point cloud" if point_cloud is not None else "depth image"
     follower = _make_follower(case)
+    if point_cloud is not None:
+        follower.set_point_cloud_sensor(_camera_as_cloud_sensor(follower))
     detections = _build_detections(case)
     state = RobotState(
-        x=case["robot"]["x"], y=case["robot"]["y"],
-        yaw=case["robot"]["yaw"], speed=case["robot"]["speed"],
+        x=case["robot"]["x"],
+        y=case["robot"]["y"],
+        yaw=case["robot"]["yaw"],
+        speed=case["robot"]["speed"],
     )
 
     init_ok = follower.set_initial_tracking_image(
@@ -111,33 +148,68 @@ def test_vision_follower_fixture(case_dir: Path) -> None:
         pose_x_img=int(case["click"]["x"]),
         pose_y_img=int(case["click"]["y"]),
         detected_boxes=detections,
-        aligned_depth_image=depth,
+        aligned_depth_image=depth_image,
+        **(point_cloud or {}),
     )
     assert init_ok == case["expected"]["init_success"], (
-        f"{case_dir.name}: setInitialTracking returned {init_ok}, "
+        f"{case_dir.name} ({source}): setInitialTracking returned {init_ok}, "
         f"expected {case['expected']['init_success']}"
     )
     if not init_ok:
-        return
+        return None
 
     # Run one control step. Sensor data is an empty point cloud (no obstacles).
     found = follower.loop_step(
         current_state=state,
         detections_2d=detections,
-        depth_image=depth,
+        depth_image=depth_image,
+        **(point_cloud or {}),
     )
-    assert found, f"{case_dir.name}: planner failed to find a control"
+    assert found, f"{case_dir.name} ({source}): planner failed to find a control"
 
     vx = follower.linear_x_control[0]
     omega = follower.angular_control[0]
     exp = case["expected"]
     assert exp["vx_min"] <= vx <= exp["vx_max"], (
-        f"{case_dir.name}: vx={vx} outside [{exp['vx_min']}, {exp['vx_max']}]"
+        f"{case_dir.name} ({source}): vx={vx} outside [{exp['vx_min']}, {exp['vx_max']}]"
     )
     assert exp["omega_min"] <= omega <= exp["omega_max"], (
-        f"{case_dir.name}: omega={omega} outside "
+        f"{case_dir.name} ({source}): omega={omega} outside "
         f"[{exp['omega_min']}, {exp['omega_max']}]"
     )
+    return vx, omega
+
+
+def _load_depth(case_dir: Path) -> np.ndarray:
+    depth = cv2.imread(str(case_dir / "depth.png"), cv2.IMREAD_UNCHANGED)
+    assert depth is not None and depth.dtype == np.uint16, (
+        f"Could not load 16-bit depth.png for {case_dir.name}"
+    )
+    return depth
+
+
+@pytest.mark.parametrize("case_dir", _discover_fixtures(), ids=lambda p: p.name)
+def test_vision_follower_fixture(case_dir: Path) -> None:
+    case = _load_case(case_dir)
+    _run_fixture(case_dir, case, depth_image=_load_depth(case_dir))
+
+
+@pytest.mark.parametrize("case_dir", _discover_fixtures(), ids=lambda p: p.name)
+def test_vision_follower_fixture_point_cloud(case_dir: Path) -> None:
+    """The same fixture lifted from a point cloud instead of the depth image
+    must pass the same bounds and give the same command."""
+    case = _load_case(case_dir)
+    depth = _load_depth(case_dir)
+    from_depth = _run_fixture(case_dir, case, depth_image=depth)
+    from_cloud = _run_fixture(
+        case_dir, case, point_cloud=_cloud_from_depth(depth, case["camera"])
+    )
+    assert (from_depth is None) == (from_cloud is None), (
+        f"{case_dir.name}: depth-image and point-cloud paths disagree on finding a command"
+    )
+    if from_depth and from_cloud:
+        assert from_depth[0] == pytest.approx(from_cloud[0], abs=1e-3)
+        assert from_depth[1] == pytest.approx(from_cloud[1], abs=1e-3)
 
 
 def test_rgbd_follower_exposes_rgb_follower_interface() -> None:
@@ -252,3 +324,20 @@ def test_close_target_does_not_saturate_omega() -> None:
         f"omega={omega} on a close target: the feedforward is running away "
         f"(limit is {max_omega})"
     )
+
+
+def test_rgbd_follower_rejects_ambiguous_or_incomplete_depth_source(tmp_path):
+    """Two sources at once, or a cloud with layout fields missing, is a
+    programming error and raises instead of silently picking one."""
+    case = _load_case(_discover_fixtures()[0])
+    follower = _make_follower(case)
+    depth = np.zeros((480, 640), dtype=np.uint16)
+    cloud = _cloud_from_depth(depth + 3000, case["camera"])
+    state = RobotState(x=0.0, y=0.0, yaw=0.0, speed=0.0)
+    with pytest.raises(ValueError, match="not both"):
+        follower.loop_step(
+            current_state=state, detections_2d=[], depth_image=depth, **cloud
+        )
+    incomplete = {k: v for k, v in cloud.items() if k != "row_step"}
+    with pytest.raises(ValueError, match="row_step"):
+        follower.loop_step(current_state=state, detections_2d=[], **incomplete)

--- a/tests/test_vision_follower.py
+++ b/tests/test_vision_follower.py
@@ -244,7 +244,9 @@ def test_rgbd_follower_exposes_rgb_follower_interface() -> None:
 _TILTED_MOUNT = (-0.5839669, 0.5936764, -0.38588133, 0.3970222)
 
 
-def _close_target_follower(**config_overrides) -> VisionRGBDFollower:
+def _close_target_follower(
+    ctrl_limits: Optional[RobotCtrlLimits] = None, **config_overrides
+) -> VisionRGBDFollower:
     robot = Robot(
         robot_type=RobotType.DIFFERENTIAL_DRIVE,
         # A real chassis: the circumradius is 0.357 m, so a target closer than
@@ -252,7 +254,7 @@ def _close_target_follower(**config_overrides) -> VisionRGBDFollower:
         geometry_type=RobotGeometry.Type.BOX,
         geometry_params=np.array([0.61, 0.37, 0.4]),
     )
-    ctrl_limits = RobotCtrlLimits(
+    ctrl_limits = ctrl_limits or RobotCtrlLimits(
         vx_limits=LinearCtrlLimits(max_vel=1.5, max_acc=3.0, max_decel=3.0),
         omega_limits=AngularCtrlLimits(
             max_omega=2.5, max_acc=2.5, max_decel=2.5, max_ang=np.pi / 2
@@ -325,6 +327,55 @@ def test_close_target_does_not_saturate_omega() -> None:
         f"omega={omega} on a close target: the feedforward is running away "
         f"(limit is {max_omega})"
     )
+
+
+def test_commands_below_the_robot_minimums_are_zeroed() -> None:
+    """The follower zeroes linear and angular commands below the minimum
+    velocities of the control limits instead of sending them to the robot.
+    The thresholds come from the limits, not from a follower parameter."""
+    depth, box, (click_x, click_y) = _close_target_frame()
+    state = RobotState(x=0.0, y=0.0, yaw=0.0, speed=0.0)
+
+    def commands(min_vel: float, min_omega: float):
+        limits = RobotCtrlLimits(
+            vx_limits=LinearCtrlLimits(
+                max_vel=1.5, max_acc=3.0, max_decel=3.0, min_vel=min_vel
+            ),
+            omega_limits=AngularCtrlLimits(
+                max_omega=2.5,
+                max_acc=2.5,
+                max_decel=2.5,
+                max_ang=np.pi / 2,
+                min_omega=min_omega,
+            ),
+        )
+        follower = _close_target_follower(ctrl_limits=limits)
+        assert follower.set_initial_tracking_image(
+            current_state=state,
+            pose_x_img=click_x,
+            pose_y_img=click_y,
+            detected_boxes=[box],
+            depth_image=depth,
+        )
+        assert follower.loop_step(
+            current_state=state, detections_2d=[box], depth_image=depth
+        )
+        return follower.linear_x_control[0], follower.angular_control[0]
+
+    # No deadband: both commands are live
+    v, omega = commands(0.0, 0.0)
+    assert v != 0.0 and omega != 0.0
+
+    # A linear minimum just above the live command zeroes only the linear one
+    v_cut, omega_kept = commands(abs(v) * 1.01, 0.0)
+    assert v_cut == 0.0
+    assert omega_kept != 0.0
+
+    # An angular minimum just above the live command zeroes only the angular
+    # one; the linear command does not depend on it
+    v_kept, omega_cut = commands(0.0, abs(omega) * 1.01)
+    assert omega_cut == 0.0
+    assert v_kept == v
 
 
 def test_rgbd_follower_rejects_ambiguous_or_incomplete_depth_source(tmp_path):

--- a/tests/test_vision_follower.py
+++ b/tests/test_vision_follower.py
@@ -148,7 +148,7 @@ def _run_fixture(
         pose_x_img=int(case["click"]["x"]),
         pose_y_img=int(case["click"]["y"]),
         detected_boxes=detections,
-        aligned_depth_image=depth_image,
+        depth_image=depth_image,
         **(point_cloud or {}),
     )
     assert init_ok == case["expected"]["init_success"], (
@@ -312,7 +312,7 @@ def test_close_target_does_not_saturate_omega() -> None:
         pose_x_img=click_x,
         pose_y_img=click_y,
         detected_boxes=[box],
-        aligned_depth_image=depth,
+        depth_image=depth,
     )
     assert follower.loop_step(
         current_state=state, detections_2d=[box], depth_image=depth

--- a/tests/test_vision_follower.py
+++ b/tests/test_vision_follower.py
@@ -327,53 +327,6 @@ def test_close_target_does_not_saturate_omega() -> None:
     )
 
 
-def test_missed_depth_ticks_run_the_wait_search_recovery() -> None:
-    """A tick without any depth source after tracking has started is an
-    observation gap: the follower holds position through its wait window
-    instead of failing outright, reports failure only when that recovery is
-    exhausted, and resumes following as soon as depth returns. Before
-    tracking has started a no-depth tick stays a plain no-op."""
-    follower = _close_target_follower(
-        enable_search=False,
-        target_wait_timeout=0.3,
-        control_horizon=2,
-    )
-    depth, box, (click_x, click_y) = _close_target_frame()
-    state = RobotState(x=0.0, y=0.0, yaw=0.0, speed=0.0)
-
-    # Without an initial target there is nothing to recover
-    assert not follower.loop_step(current_state=state, detections_2d=[box])
-
-    assert follower.set_initial_tracking_image(
-        current_state=state,
-        pose_x_img=click_x,
-        pose_y_img=click_y,
-        detected_boxes=[box],
-        depth_image=depth,
-    )
-    assert follower.loop_step(
-        current_state=state, detections_2d=[box], depth_image=depth
-    )
-
-    # Observation gap: held during the wait window, given up once it is
-    # exhausted. With control_horizon=2 each tick advances the recorded wait
-    # time by one control step (0.1 s), so a 0.3 s window gives up on the
-    # fourth tick. The give-up resets the recovery state, so later ticks hold
-    # again -- the consumer aborts on the first failure, which is the give-up.
-    gap = [
-        follower.loop_step(current_state=state, detections_2d=[]) for _ in range(6)
-    ]
-    assert False in gap, "recovery must eventually report failure"
-    give_up = gap.index(False)
-    assert give_up > 0, "first no-depth tick must hold, not abort"
-    assert all(gap[:give_up]), "every tick before the give-up must hold"
-
-    # Depth is back: the same target is picked up again
-    assert follower.loop_step(
-        current_state=state, detections_2d=[box], depth_image=depth
-    )
-
-
 def test_rgbd_follower_rejects_ambiguous_or_incomplete_depth_source(tmp_path):
     """Two sources at once, or a cloud with layout fields missing, is a
     programming error and raises instead of silently picking one."""

--- a/tests/test_zero_copy_boundary.py
+++ b/tests/test_zero_copy_boundary.py
@@ -21,6 +21,7 @@ import itertools
 import time
 
 import numpy as np
+import pytest
 
 from kompass_cpp.mapping import LocalMapper as LocalMapperCpp
 from kompass_cpp.types import RobotGeometry, SensorConfig, SensorInputType
@@ -351,3 +352,45 @@ def test_rgbd_follower_point_cloud_accepts_readonly_buffer():
     )
     box.timestamp = 0.1
     assert follower.loop_step(current_state=state, detections_2d=[box], **cloud)
+
+
+def test_depth_image_dtype_binds_its_own_overload_and_is_never_cast():
+    """The uint16 and float32 depth-image overloads differ only by dtype, so
+    the depth argument is bound noconvert. Without it, any call that needs an
+    implicit conversion elsewhere (an int for a float argument, say) drops to
+    nanobind's converting pass, where the uint16 overload -- registered first
+    -- accepts a float32 image by casting it: metres truncated to integers,
+    then read as millimetres. So a float32 image must lift the same whatever
+    the other arguments look like, and a dtype or layout matching neither
+    overload must be refused rather than silently copied."""
+    detector = DepthDetector(
+        np.array([0.1, 10.0], dtype=np.float32),  # depth range
+        np.array([0.0, 0.0, 0.0], dtype=np.float32),  # camera translation
+        np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32),  # camera rotation
+        np.array([500.0, 500.0], dtype=np.float32),  # focal length
+        np.array([320.0, 240.0], dtype=np.float32),  # principal point
+        1e-3,  # mm -> m, applies to the uint16 path only
+    )
+    box = _target_box(640, 480)
+    metres = np.zeros((480, 640), dtype=np.float32)
+    x0, y0 = _BOX_CORNER
+    metres[y0 : y0 + _BOX_SIZE, x0 : x0 + _BOX_SIZE] = 2.5
+
+    exact = detector.compute_3d_detections(metres, [box], 0.0, 0.0, 0.0, 0.0)
+    # robot_x as an int forces the converting pass. A cast to uint16 would
+    # read the box as 2 mm, below the depth range, and lift nothing at all.
+    converted_elsewhere = detector.compute_3d_detections(
+        metres, [box], 0, 0.0, 0.0, 0.0
+    )
+    assert exact and converted_elsewhere, "the float32 image was not lifted"
+    np.testing.assert_allclose(converted_elsewhere[0].center, exact[0].center)
+    assert np.linalg.norm(exact[0].center) == pytest.approx(2.5, abs=0.05)
+
+    # Neither overload matches: refuse instead of copying into one of them
+    for unsupported in (
+        metres.astype(np.float64),
+        metres.astype(np.int32),
+        np.repeat(metres, 2, axis=1)[:, ::2],  # right shape, not contiguous
+    ):
+        with pytest.raises(TypeError):
+            detector.compute_3d_detections(unsupported, [box], 0.0, 0.0, 0.0, 0.0)

--- a/tests/test_zero_copy_boundary.py
+++ b/tests/test_zero_copy_boundary.py
@@ -259,7 +259,7 @@ def test_rgbd_follower_boundary_does_not_scale_with_image_size():
         pose_x_img=x0 + _BOX_SIZE // 2,
         pose_y_img=y0 + _BOX_SIZE // 2,
         detected_boxes=[_target_box(640, 480)],
-        aligned_depth_image=small,
+        depth_image=small,
     )
 
     clock = itertools.count(1)

--- a/tests/test_zero_copy_boundary.py
+++ b/tests/test_zero_copy_boundary.py
@@ -201,9 +201,7 @@ def test_depth_detector_boundary_does_not_scale_with_image_size():
 
     small_box, big_box = _target_box(640, 480), _target_box(1280, 960)
     ratio = _median_ratio(
-        lambda: detector.compute_3d_detections(
-            small, [small_box], 0.0, 0.0, 0.0, 0.0
-        ),
+        lambda: detector.compute_3d_detections(small, [small_box], 0.0, 0.0, 0.0, 0.0),
         lambda: detector.compute_3d_detections(big, [big_box], 0.0, 0.0, 0.0, 0.0),
     )
     assert ratio < _MAX_RATIO, (
@@ -288,3 +286,68 @@ def test_rgbd_follower_boundary_does_not_scale_with_image_size():
         f"loop_step with a 4x-pixel depth image costs {ratio:.2f}x the VGA "
         "call: the depth boundary is doing per-pixel (full image) work"
     )
+
+
+def test_rgbd_follower_point_cloud_accepts_readonly_buffer():
+    # NOTE: there is deliberately no timing-ratio guard for the point-cloud
+    # path. Its cost is O(points) by design (every point is projected into
+    # the image), so a copy of the buffer is not separable from the work
+    # itself by scaling the input the way the depth-image guards do. What the
+    # boundary must guarantee is that the sensor's buffer crosses as
+    # delivered: a ROS callback hands out a read-only np.frombuffer view.
+    follower = VisionRGBDFollower(
+        robot=Robot(
+            robot_type=RobotType.DIFFERENTIAL_DRIVE,
+            geometry_type=CoreRobotGeometry.Type.CYLINDER,
+            geometry_params=np.array([0.1, 0.4]),
+        ),
+        ctrl_limits=RobotCtrlLimits(
+            vx_limits=LinearCtrlLimits(max_vel=1.5, max_acc=3.0, max_decel=3.0),
+            omega_limits=AngularCtrlLimits(
+                max_omega=2.5, max_acc=2.5, max_decel=2.5, max_ang=np.pi / 2
+            ),
+        ),
+        config=VisionRGBDFollowerConfig(
+            control_time_step=0.1,
+            _use_local_coordinates=True,
+            min_depth=0.1,
+            max_depth=10.0,
+        ),
+        camera_focal_length=[500.0, 500.0],
+        camera_principal_point=[320.0, 240.0],
+    )
+    # The default sensor (identity mount) takes the cloud in the body frame:
+    # a 3 m target, 1 m wide and tall, dense enough to fill its box
+    ys, zs = np.meshgrid(np.linspace(-0.5, 0.5, 60), np.linspace(-0.5, 0.5, 60))
+    target = np.zeros((ys.size, 4), dtype=np.float32)
+    target[:, 0] = 3.0
+    target[:, 1] = ys.ravel()
+    target[:, 2] = zs.ravel()
+    readonly = np.frombuffer(target.tobytes(), dtype=np.uint8)
+    assert not readonly.flags.writeable
+    cloud = {
+        "data": readonly,
+        "point_step": _PC_STRIDE,
+        "row_step": _PC_STRIDE * len(target),
+        "height": 1,
+        "width": len(target),
+        "x_offset": 0,
+        "y_offset": 4,
+        "z_offset": 8,
+    }
+    # The target projects to a ~167 px square around the principal point
+    box = Bbox2D(
+        top_left_corner=np.array([230, 150], dtype=np.int32),
+        size=np.array([180, 180], dtype=np.int32),
+    )
+    box.set_img_size(np.array([640, 480], dtype=np.int32))
+    state = RobotState(x=0.0, y=0.0, yaw=0.0, speed=0.0)
+    assert follower.set_initial_tracking_image(
+        current_state=state,
+        pose_x_img=320,
+        pose_y_img=240,
+        detected_boxes=[box],
+        **cloud,
+    )
+    box.timestamp = 0.1
+    assert follower.loop_step(current_state=state, detections_2d=[box], **cloud)


### PR DESCRIPTION
## Why

Lifting 2D detections to 3D only worked through an aligned depth image, and in kompass that image had to travel *inside* the embodied-agents detections message — which embodied-agents only fills for RealSense `RGBD` inputs, and which puts a full depth map on the wire with every detection. A robot with a 3D LiDAR and a plain camera could not lift detections at all, and a robot with a separate depth topic could not use it. This PR makes a point cloud a first-class depth source for the depth detector and the RGBD follower, with the same contract the mapper and critical-zone checker already use for clouds.

## What changed

- **Point-cloud lifting in `DepthDetector`**: `updateBoxes` / `updatePOIs` overloads taking a `PointCloudView`. Every point is transformed into the camera and projected through the intrinsics; the points landing inside a 2D box contribute their depth along the camera axis, and the box is then reduced by the existing median/MAD path — `convert2Dboxto3Dbox` was split into `gatherDepthSamples` (depth image) and the shared `boxFromDepthSamples`, so the depth-image path is a pure refactor (fixture parity unchanged). The cloud pass is single, with one reused sample bucket per box, a union-rectangle early reject, a layout check done once instead of per point, and a range gate that also drops non-finite points and anything at or behind the camera plane. Points behind the target that project into its box play the role background pixels play in a depth image: the median/MAD majority vote clips them. The sensor is described with the mapper's `SensorConfig` (`setPointCloudSensor`: mount pose in the body frame + `cloud_field_type`), identity/FLOAT32 until set. Organized clouds take the same projection path; `TODO` markers sit where a pixel-indexed path would go.
- **`RGBDFollower` cloud entries**: `getTrackingCtrl` and both `setInitialTracking` variants gain `PointCloudView` overloads, plus `setPointCloudSensor` (forwarded to the detector whether it is built before or after `setCameraIntrinsics`). The tracker state machine is no longer duplicated per source: private templates `liftDetections` / `trackDetections` / `initTracking` / `initTrackingAtPixel` over the depth source type carry both the depth-image and cloud entries, the header holds declarations only, `findBoxAtPixel` replaces the by-value box copy, and the implementation file is grouped into sections.
- **Bindings and Python**: a cloud crosses exactly like the mapper's single-cloud entry — `data, point_step, row_step, height, width, x_offset, y_offset, z_offset` as keyword arguments (the `ByteArray` handle lives on the call frame, no keepalive), the encoding riding on the `SensorConfig`. `set_point_cloud_sensor(SensorConfig)` on `DepthDetector` and `RGBDFollower`; `compute_3d_detections`, `get_tracking_ctrl` and `set_initial_tracking` cloud overloads. The `VisionRGBDFollower` wrapper's `loop_step`, `set_initial_tracking_2d_target` and `set_initial_tracking_image` take either `depth_image=` or the layout keywords (`**_` accepted so a whole cloud container can be splatted in); passing both, or an incomplete layout, raises `ValueError` instead of silently picking one.
- **One keyword for the depth image**: `depth_image` everywhere — the binding's `depth_img` and the follower entries'/wrapper's `aligned_depth_image` are renamed (pre-1.0; embodied-agents calls the detector positionally and is unaffected).
- **Fixture test fix**: `vision_follower_fixture_test.cpp` built the follower with an identity mount pose, which the follower has read in the optical convention since 055bf35, so 4 of its 5 cases had been failing on `main` (every target 90° off). It now passes the REP 103 optical→body turn, matching the Python wrapper's default.
- **Tests**: new `depth_detector_test` (C++): projection parity against the depth image on the same scene (two boxes, world frame), an organized cloud with padded rows, a yawed LiDAR mounted away from the camera lifting a cluster to its known body position while a larger out-of-range wall projecting into the same box, a behind-camera point and NaNs are ignored, empty results, POI parity. The fixture test now runs every case through both sources with a `(vx, omega)` parity check. Python: cloud ≡ depth image in body and world frame, the default sensor as the body frame, invalid-point rejection, POI, LiDAR mount, read-only `np.frombuffer` and `bytes` buffers accepted, wrapper contract errors; every follower fixture also runs through the cloud path.
